### PR TITLE
perf: fixed editor height to trigger `codemirror` virtual scroll

### DIFF
--- a/packages/devtools/src/app/components/code/DiffEditor.vue
+++ b/packages/devtools/src/app/components/code/DiffEditor.vue
@@ -132,9 +132,9 @@ function _onUpdate(size: number) {
 </script>
 
 <template>
-  <div h-full w-full :class="oneColumn ? 'flex' : 'grid grid-cols-2'">
-    <div v-show="!oneColumn" ref="fromEl" class="h-inherit" />
-    <div ref="toEl" class="h-inherit" />
+  <div h-full w-full max-h-100vh :class="oneColumn ? 'flex' : 'grid grid-cols-2'">
+    <div v-show="!oneColumn" ref="fromEl" class="h-full max-h-100vh" />
+    <div ref="toEl" class="h-full max-h-100vh" />
   </div>
 </template>
 

--- a/packages/devtools/src/app/components/flowmap/ModuleFlow.vue
+++ b/packages/devtools/src/app/components/flowmap/ModuleFlow.vue
@@ -287,9 +287,9 @@ const codeDisplay = computed(() => {
         v-if="codeDisplay"
         w-200 m4
         border="~ base rounded-lg" bg-glass of-hidden
-        grid="~ rows-[max-content_1fr]"
+        grid="~ rows-[max-content_1fr]" max-h-120vh
       >
-        <div pl4 p2 font-mono border="b base" flex="~ items-center gap-2">
+        <div pl4 p2 font-mono border="b base" flex="~ items-center gap-2" h-max-100vh>
           <PluginName :name="codeDisplay.plugin_name" />
           <span op50 text-xs>
             {{ codeDisplay.type === 'load' ? 'Load' : 'Transform' }}


### PR DESCRIPTION
Not sure if there's a better way, but this workaround helps us avoid performance issues for now.

## Before

![iShot_2025-06-09_23 38 39](https://github.com/user-attachments/assets/90df070b-8bee-409e-9114-9edb357bd1d3)


## After


![iShot_2025-06-09_23 42 28](https://github.com/user-attachments/assets/f5639ed9-d5b1-450a-8914-8f7b0495b60b)
