### PR TITLE
feat: add expandable module details in FlatList

### DIFF
--- a/packages/devtools/src/app/components/modules/FlatList.vue
+++ b/packages/devtools/src/app/components/modules/FlatList.vue
@@ -1,23 +1,46 @@
 <script setup lang="ts">
 import type { ModuleListItem, SessionContext } from '~~/shared/types'
+import { ref } from 'vue'
+import ModuleDetailsLoader from '~/components/data/ModuleDetailsLoader.vue'
 
 defineProps<{
   session: SessionContext
   modules: ModuleListItem[]
 }>()
+
+const expandedId = ref<string | null>(null)
+
+function toggleExpandModule(id: string) {
+  if (expandedId.value === id)
+    expandedId.value = null
+  else
+    expandedId.value = id
+}
 </script>
 
 <template>
   <div flex="~ col gap-2" p4>
-    <template v-for="mod of modules" :key="mod">
-      <!-- TODO: toggle to show detailed list like plugins and time cost -->
-      <DisplayModuleId
-        :id="mod.id"
-        :session
-        hover="bg-active" block px2 p1
+    <template v-for="mod of modules" :key="mod.id">
+      <div
         border="~ base rounded"
-        :link="true"
-      />
+        block
+        :class="expandedId === mod.id ? 'bg-active' : ''"
+      >
+        <DisplayModuleId
+          :id="mod.id"
+          :session
+          px2 p1 block
+          cursor-pointer
+          @click="toggleExpandModule(mod.id)"
+        />
+        <div v-if="expandedId === mod.id" border="t base" p2>
+          <ModuleDetailsLoader
+            :session="session"
+            :module="mod.id"
+            @close="expandedId = null"
+          />
+        </div>
+      </div>
     </template>
   </div>
 </template>


### PR DESCRIPTION
Add the component `ModuleDetailsLoader` in the `FlatList` to display details when clicking on an item.

Screenshot:
<img width="1710" height="1070" alt="image" src="https://github.com/user-attachments/assets/c2f690d0-4e61-4b22-9222-9cbb0ce81b3c" />