### PR TITLE
fix(ui): prevent diff highlight from affecting line number gutter in CodeMirror

### DIFF
--- a/packages/devtools/src/app/components/code/DiffEditor.vue
+++ b/packages/devtools/src/app/components/code/DiffEditor.vue
@@ -152,6 +152,6 @@ function _onUpdate(size: number) {
   --at-apply: bg-red-400/30;
 }
 .CodeMirror-linenumber{
-    --at-apply: bg-white;
+    --at-apply: bg-[var(--cn-line-number-background)];
 }
 </style>

--- a/packages/devtools/src/app/components/code/DiffEditor.vue
+++ b/packages/devtools/src/app/components/code/DiffEditor.vue
@@ -151,7 +151,4 @@ function _onUpdate(size: number) {
 .diff-removed-inline {
   --at-apply: bg-red-400/30;
 }
-.CodeMirror-linenumber{
-    --at-apply: bg-[var(--cn-line-number-background)];
-}
 </style>

--- a/packages/devtools/src/app/components/code/DiffEditor.vue
+++ b/packages/devtools/src/app/components/code/DiffEditor.vue
@@ -151,4 +151,7 @@ function _onUpdate(size: number) {
 .diff-removed-inline {
   --at-apply: bg-red-400/30;
 }
+.CodeMirror-linenumber{
+    --at-apply: bg-white;
+}
 </style>

--- a/packages/devtools/src/app/styles/cm.css
+++ b/packages/devtools/src/app/styles/cm.css
@@ -27,6 +27,7 @@ html:not(.dark) {
   --cm-json-property: #698c96;
   --cm-selection-background: #44444410;
   --cm-line-number-gutter: #fafafa50;
+  --cn-line-number-background: #fafafa;
 }
 
 html.dark {
@@ -53,6 +54,7 @@ html.dark {
   --cm-line-highlight-background: #444444;
   --cm-selection-background: #44444450;
   --cm-line-number-gutter: #1a1a1a50;
+  --cn-line-number-background: #141414;
 }
 
 

--- a/packages/devtools/src/app/styles/cm.css
+++ b/packages/devtools/src/app/styles/cm.css
@@ -26,8 +26,7 @@ html:not(.dark) {
   --cm-regex: #ab5e3f;
   --cm-json-property: #698c96;
   --cm-selection-background: #44444410;
-  --cm-line-number-gutter: #fafafa50;
-  --cn-line-number-background: #fafafa;
+  --cm-line-number-gutter: #fafafa;
 }
 
 html.dark {
@@ -53,8 +52,7 @@ html.dark {
   --cm-line-number: #888888;
   --cm-line-highlight-background: #444444;
   --cm-selection-background: #44444450;
-  --cm-line-number-gutter: #1a1a1a50;
-  --cn-line-number-background: #141414;
+  --cm-line-number-gutter: #1a1a1a;
 }
 
 


### PR DESCRIPTION
CodeMirror line numbers without a background color can interfere with reading when looking at the difference between the two.
<img width="1798" height="937" alt="image" src="https://github.com/user-attachments/assets/e9205c91-457c-4538-af16-79a2f92f6ffc" />
<img width="1799" height="937" alt="image" src="https://github.com/user-attachments/assets/8b08eb1d-59be-4365-807a-9487e602afe2" />
