### PR TITLE
chore: fix moduleId block style

### DIFF
--- a/packages/devtools/src/app/components/display/ModuleId.vue
+++ b/packages/devtools/src/app/components/display/ModuleId.vue
@@ -63,7 +63,7 @@ const containerClass = computed(() => {
         :class="containerClass"
       >
         <DisplayFileIcon v-if="icon" :filename="id" mr1.5 />
-        <span>
+        <span overflow-hidden text-ellipsis break-all line-clamp-2>
           <DisplayHighlightedPath :path="relativePath" :minimal="minimal" />
         </span>
         <slot />


### PR DESCRIPTION
before:
<img width="492" height="293" alt="image" src="https://github.com/user-attachments/assets/eb029ac6-cc33-43dc-b05c-a8a0e9549e8a" />
after:
<img width="511" height="293" alt="image" src="https://github.com/user-attachments/assets/ea7b4330-f258-4d43-8324-1b0904564b43" />
