### PR TITLE
fix: defineProps macro compiler  warning

### DIFF
--- a/packages/devtools/src/app/components/chart/ModuleFlamegraph.vue
+++ b/packages/devtools/src/app/components/chart/ModuleFlamegraph.vue
@@ -2,7 +2,7 @@
 import type { TreeNodeInput } from 'nanovis'
 import type { ModuleInfo, SessionContext } from '~~/shared/types'
 import { Flamegraph, normalizeTreeNode } from 'nanovis'
-import { computed, defineProps, nextTick, onMounted, onUnmounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
 
 const props = defineProps<{
   info: ModuleInfo

--- a/packages/devtools/src/app/components/data/RawEventsTable.vue
+++ b/packages/devtools/src/app/components/data/RawEventsTable.vue
@@ -2,7 +2,7 @@
 import type { RolldownEvent } from '~~/node/rolldown/events-manager'
 import type { SessionContext } from '~~/shared/types'
 import { Dropdown as VDropdown } from 'floating-vue'
-import { defineProps, withDefaults } from 'vue'
+import { withDefaults } from 'vue'
 
 type FIELDS = 'module_id' | 'action' | 'content' | 'timestamp' | 'event_id' | 'plugin_name' | '*'
 


### PR DESCRIPTION
Hi,

Please check the warning in console below.

![20250715145024](https://github.com/user-attachments/assets/70b63ef3-5e55-49d6-ac3c-430a9e20cedc)


This PR just removed `defineProps` in `import statement`.
Please help to review.
Thx