### PR TITLE
fix: prevent focusOn error when rootModules is empty in Graph component

### DIFF
--- a/packages/devtools/src/app/components/modules/Graph.vue
+++ b/packages/devtools/src/app/components/modules/Graph.vue
@@ -162,7 +162,9 @@ function calculateGraph() {
   nextTick(() => {
     width.value = (container.value!.scrollWidth / scale.value + SPACING.margin)
     height.value = (container.value!.scrollHeight / scale.value + SPACING.margin)
-    focusOn(rootModules.value[0].id, false)
+    if (rootModules.value.length > 0) {
+      focusOn(rootModules.value[0].id, false)
+    }
   })
 }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/fe90050e-87d6-4d25-aca1-4e6b62b29502

