### PR TITLE
feat: add click event on FlowmapNode to toggle

### DIFF
--- a/packages/devtools/src/app/components/flowmap/Expandable.vue
+++ b/packages/devtools/src/app/components/flowmap/Expandable.vue
@@ -14,6 +14,7 @@ const expanded = defineModel<boolean>('expanded', { required: false, default: tr
 
 <template>
   <FlowmapNode
+    v-model:expanded="expanded"
     :lines="{ top: true, bottom: !expandable || !expanded }" pl6 pt4
     :class-node-outer="classRootNode"
     :active="activeStart"
@@ -24,7 +25,7 @@ const expanded = defineModel<boolean>('expanded', { required: false, default: tr
 
     <template v-if="expandable" #inline-before>
       <button
-        w-6 h-6 mr1 ml--7 mya rounded-full hover="bg-active" flex="~ items-center justify-center"
+        w-6 h-6 mr1 ml--7 mya rounded-full hover="bg-active" flex="~ items-center justify-center" cursor-pointer
         @click="expanded = !expanded"
       >
         <div i-ph-caret-right text-sm op50 transition duration-300 :class="{ 'rotate-90': expanded }" />

--- a/packages/devtools/src/app/components/flowmap/Node.vue
+++ b/packages/devtools/src/app/components/flowmap/Node.vue
@@ -9,6 +9,8 @@ const props = defineProps<{
   classNodeInner?: string
   active?: boolean
 }>()
+
+const expanded = defineModel<boolean>('expanded', { required: false, default: true })
 </script>
 
 <template>
@@ -31,7 +33,8 @@ const props = defineProps<{
           props.classNodeOuter,
           active ? 'border-flow-active' : 'border-flow',
         ]"
-        border="~ rounded-2xl" bg-base of-hidden
+        border="~ rounded-2xl" bg-base of-hidden cursor-pointer
+        @click="expanded = !expanded"
       >
         <slot name="inner">
           <div px3 py1 :class="props.classNodeInner" flex="~ inline gap-2 items-center">


### PR DESCRIPTION
I think in regular use, there should be stretch events on FlowmapNode, not just the arrow


https://github.com/user-attachments/assets/90c9c0de-8048-498c-9f41-c95e3497261a

