### PR TITLE
fix: breaking of border flow line

### DIFF
--- a/packages/devtools/src/app/components/flowmap/ModuleFlow.vue
+++ b/packages/devtools/src/app/components/flowmap/ModuleFlow.vue
@@ -266,7 +266,7 @@ const codeDisplay = computed(() => {
                 :item="item"
                 :session="session"
                 :active="isSelectedAncestor(item)"
-                :class="index > 0 ? 'pt-2' : ''"
+                :class="index > 0 && item.type !== 'no_changes_hide' ? 'pt-2' : ''"
                 @select="e => selected = e"
                 @toggle-show-all="flowShowAllLoads = !flowShowAllLoads"
               />
@@ -294,7 +294,7 @@ const codeDisplay = computed(() => {
                 :item="item"
                 :session="session"
                 :active="isSelectedAncestor(item)"
-                :class="index > 0 ? 'pt-2' : ''"
+                :class="index > 0 && item.type !== 'no_changes_hide' ? 'pt-2' : ''"
                 @select="e => selected = e"
                 @toggle-show-all="flowShowAllTransforms = !flowShowAllTransforms"
               />


### PR DESCRIPTION
Hi, 

### Before changes:

`border flow line` is breaking if expends items, see below screenshot:
￼￼
<img width="951" height="1047" alt="image" src="https://github.com/user-attachments/assets/2a6f3ebc-37ca-4450-ba6c-500fe03e9340" />

---

### After changes:

<img width="915" height="1068" alt="image" src="https://github.com/user-attachments/assets/1d6fcc89-450f-4e84-bb51-cda0ce7eba2d" />

And also work fine on collapsing
<img width="819" height="418" alt="image" src="https://github.com/user-attachments/assets/ad7ab0bf-4f33-4811-b4e8-0bfa86ffa201" />

---

### Brief

only `loads` and `transforms` have `no_changes_hide` item.

---
Please help to review
Thx
