### PR TITLE
chore: use `projects` instead of `workspace` in `vitest`

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    workspace: ['packages/*'],
+    projects: ['packages/*'],
   },
 })


### PR DESCRIPTION
`workspace` is deprecated in `vitest` 3.2
https://vitest.dev/blog/vitest-3-2.html#workspace-is-deprecated