### PR TITLE
Prevent space key from scrolling the page in Graph view

### DIFF
--- a/packages/devtools/src/app/components/modules/Graph.vue
+++ b/packages/devtools/src/app/components/modules/Graph.vue
@@ -62,6 +62,11 @@ onKeyPressed(['=', '+'], (e) => {
     zoomIn()
 })
 
+// Prevent space from scrolling the page
+onKeyPressed([' '], (e) => {
+  e.preventDefault()
+})
+
 const modulesMap = computed(() => {
   const map = new Map<string, ModuleListItem>()
   for (const module of props.modules) {


### PR DESCRIPTION
Hi, I often use Figma and am used to holding the space key to zoom. On this page, holding space scrolls the whole window, which feels a bit off. This PR prevents the space key from scrolling the page in the Graph view.
Is everyone okay with this change, or does anyone prefer the original behavior? 



https://github.com/user-attachments/assets/3c94302e-8ae8-4d61-862c-027bbe51e230



