### PR TITLE
fix: keep the current view when switching modules

### DIFF
--- a/packages/devtools/src/app/components/data/ModuleDetailsLoader.vue
+++ b/packages/devtools/src/app/components/data/ModuleDetailsLoader.vue
@@ -8,6 +8,7 @@ import { getContentByteSize } from '~~/app/utils/format'
 const props = defineProps<{
   session: SessionContext
   module: string
+  view: 'flow' | 'charts' | 'imports'
 }>()
 
 const emit = defineEmits<{
@@ -18,7 +19,6 @@ const rpc = useRpc()
 const transforms = ref<RolldownModuleTransformInfo[]>([])
 const transformsLoading = ref(false)
 const flowNodeSelected = ref(false)
-const view = ref<'flow' | 'charts' | 'imports'>('flow')
 
 watchEffect(async () => {
   const arg = {
@@ -137,7 +137,7 @@ function selectFlowNode(v: boolean) {
           px2 py1 w-40
           border="~ base rounded-lg"
           hover="bg-active"
-          @click="view = 'flow'"
+          @click="$router.replace({ query: { ...$route.query, moduleView: 'flow' } })"
         >
           <div i-ph-git-branch-duotone rotate-180 />
           Build Flow
@@ -148,7 +148,7 @@ function selectFlowNode(v: boolean) {
           px2 py1 w-40
           border="~ base rounded-lg"
           hover="bg-active"
-          @click="view = 'charts'"
+          @click="$router.replace({ query: { ...$route.query, moduleView: 'charts' } })"
         >
           <div i-ph-chart-donut-duotone />
           Charts
@@ -159,7 +159,7 @@ function selectFlowNode(v: boolean) {
           px2 py1 w-40
           border="~ base rounded-lg"
           hover="bg-active"
-          @click="view = 'imports'"
+          @click="$router.replace({ query: { ...$route.query, moduleView: 'imports' } })"
         >
           <div i-ph-graph-duotone />
           Imports

--- a/packages/devtools/src/app/components/data/ModuleDetailsLoader.vue
+++ b/packages/devtools/src/app/components/data/ModuleDetailsLoader.vue
@@ -3,12 +3,12 @@ import type { ModuleInfo, RolldownModuleTransformInfo, SessionContext } from '~~
 import { useRpc } from '#imports'
 import { computedAsync } from '@vueuse/core'
 import { computed, nextTick, ref, watchEffect } from 'vue'
+import { settings } from '~~/app/state/settings'
 import { getContentByteSize } from '~~/app/utils/format'
 
 const props = defineProps<{
   session: SessionContext
   module: string
-  view: 'flow' | 'charts' | 'imports'
 }>()
 
 const emit = defineEmits<{
@@ -132,34 +132,34 @@ function selectFlowNode(v: boolean) {
       </div>
       <div flex="~ gap-2">
         <button
-          :class="view === 'flow' ? 'text-primary' : ''"
+          :class="settings.moduleDetailsViewType === 'flow' ? 'text-primary' : ''"
           flex="~ gap-2 items-center justify-center"
           px2 py1 w-40
           border="~ base rounded-lg"
           hover="bg-active"
-          @click="$router.replace({ query: { ...$route.query, moduleView: 'flow' } })"
+          @click="settings.moduleDetailsViewType = 'flow'"
         >
           <div i-ph-git-branch-duotone rotate-180 />
           Build Flow
         </button>
         <button
-          :class="view === 'charts' ? 'text-primary' : ''"
+          :class="settings.moduleDetailsViewType === 'charts' ? 'text-primary' : ''"
           flex="~ gap-2 items-center justify-center"
           px2 py1 w-40
           border="~ base rounded-lg"
           hover="bg-active"
-          @click="$router.replace({ query: { ...$route.query, moduleView: 'charts' } })"
+          @click="settings.moduleDetailsViewType = 'charts'"
         >
           <div i-ph-chart-donut-duotone />
           Charts
         </button>
         <button
-          :class="view === 'imports' ? 'text-primary' : ''"
+          :class="settings.moduleDetailsViewType === 'imports' ? 'text-primary' : ''"
           flex="~ gap-2 items-center justify-center"
           px2 py1 w-40
           border="~ base rounded-lg"
           hover="bg-active"
-          @click="$router.replace({ query: { ...$route.query, moduleView: 'imports' } })"
+          @click="settings.moduleDetailsViewType = 'imports'"
         >
           <div i-ph-graph-duotone />
           Imports
@@ -168,7 +168,7 @@ function selectFlowNode(v: boolean) {
     </div>
     <div of-auto h-full pt-30>
       <FlowmapModuleFlow
-        v-if="view === 'flow'"
+        v-if="settings.moduleDetailsViewType === 'flow'"
         p4
         :info
         :session
@@ -176,13 +176,13 @@ function selectFlowNode(v: boolean) {
         @select="selectFlowNode"
       />
       <ChartModuleFlamegraph
-        v-if="view === 'charts'"
+        v-if="settings.moduleDetailsViewType === 'charts'"
         :info
         :session="session"
         :flow-node-selected="flowNodeSelected"
       />
       <DataModuleImportRelationships
-        v-if="view === 'imports'"
+        v-if="settings.moduleDetailsViewType === 'imports'"
         :module="info"
         :session="session"
       />

--- a/packages/devtools/src/app/pages/session/[session].vue
+++ b/packages/devtools/src/app/pages/session/[session].vue
@@ -116,6 +116,7 @@ onMounted(async () => {
       >
         <DataModuleDetailsLoader
           :module="(route.query.module as string)"
+          :view="(route.query.moduleView as 'flow' | 'charts' | 'imports') || 'flow'"
           :session="session"
           @close="closeFlowPanel"
         />

--- a/packages/devtools/src/app/pages/session/[session].vue
+++ b/packages/devtools/src/app/pages/session/[session].vue
@@ -116,7 +116,6 @@ onMounted(async () => {
       >
         <DataModuleDetailsLoader
           :module="(route.query.module as string)"
-          :view="(route.query.moduleView as 'flow' | 'charts' | 'imports') || 'flow'"
           :session="session"
           @close="closeFlowPanel"
         />

--- a/packages/devtools/src/app/state/settings.ts
+++ b/packages/devtools/src/app/state/settings.ts
@@ -15,6 +15,7 @@ export interface ClientSettings {
   flowShowAllLoads: boolean
   assetViewType: 'list' | 'folder' | 'treemap'
   chartAnimation: boolean
+  moduleDetailsViewType: 'flow' | 'charts' | 'imports'
 }
 
 export const settings = useLocalStorage<ClientSettings>(
@@ -32,6 +33,7 @@ export const settings = useLocalStorage<ClientSettings>(
     flowShowAllLoads: false,
     assetViewType: 'list',
     chartAnimation: true,
+    moduleDetailsViewType: 'flow',
   },
   {
     mergeDefaults: true,


### PR DESCRIPTION
When exploring the Imports view, clicking on an entry will return the view to the Build Flow view was really bothering me. In this PR, I tried to fix it.