### PR TITLE
feat: control module flow panel size

### DIFF
--- a/packages/devtools/src/app/components/code/DiffEditor.vue
+++ b/packages/devtools/src/app/components/code/DiffEditor.vue
@@ -132,9 +132,9 @@ function _onUpdate(size: number) {
 </script>
 
 <template>
-  <div h-full w-full max-h-100vh :class="oneColumn ? 'flex' : 'grid grid-cols-2'">
-    <div v-show="!oneColumn" ref="fromEl" h-full max-h-100vh />
-    <div ref="toEl" h-full max-h-100vh :class="oneColumn ? 'w-full' : ''" />
+  <div h-full w-full of-auto :class="oneColumn ? 'flex' : 'grid grid-cols-2'" style="overscroll-behavior: contain">
+    <div v-show="!oneColumn" ref="fromEl" h-inherit />
+    <div ref="toEl" h-inherit :class="oneColumn ? 'w-full' : ''" />
   </div>
 </template>
 

--- a/packages/devtools/src/app/components/flowmap/ModuleFlow.vue
+++ b/packages/devtools/src/app/components/flowmap/ModuleFlow.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { ModuleInfo, RolldownChunkInfo, RolldownModuleFlowNode, RolldownModuleNoChanges, RolldownModuleNoChangesHide, RolldownModuleTransformInfo, SessionContext } from '~~/shared/types'
-import { Menu as VMenu } from 'floating-vue'
-import { computed, shallowRef, toRefs, watch } from 'vue'
-import { settingsRefs } from '~/state/settings'
-import PluginName from '../display/PluginName.vue'
+import type { ModuleInfo, RolldownChunkInfo, RolldownModuleFlowNode, SessionContext } from '~~/shared/types'
+import { Pane, Splitpanes } from 'splitpanes'
+import { shallowRef, toRefs, watch } from 'vue'
+import ModuleFlowDetails from './ModuleFlowDetails.vue'
+import ModuleFlowTimeline from './ModuleFlowTimeline.vue'
 
 const props = defineProps<{
   info: ModuleInfo
@@ -15,394 +15,51 @@ const emit = defineEmits<{
 }>()
 const { info } = toRefs(props)
 
-const {
-  flowShowAllTransforms,
-  flowShowAllLoads,
-  flowExpandTransforms,
-  flowExpandLoads,
-  flowExpandResolveId,
-  flowExpandChunks,
-  flowExpandAssets,
-} = settingsRefs
-
 const selected = shallowRef<RolldownChunkInfo | RolldownModuleFlowNode | null>(null)
-
-const resolveIds = computed(() => info?.value?.resolve_ids ?? [])
-
-const transforms = computed((): (RolldownModuleNoChanges | RolldownModuleNoChangesHide | RolldownModuleTransformInfo)[] => {
-  const unchanged = info?.value?.transforms?.filter(t => t.content_from === t.content_to)
-  const changed = info?.value?.transforms?.filter(t => t.content_from !== t.content_to)
-
-  if (flowShowAllTransforms.value && !unchanged?.length)
-    return info?.value?.transforms ?? []
-
-  if (flowShowAllTransforms.value && unchanged?.length) {
-    return [
-      ...(info.value.transforms ?? []),
-      ({
-        type: 'no_changes_hide',
-        id: 'no_changes_hide',
-        count: unchanged?.length ?? 0,
-        duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
-      } satisfies RolldownModuleNoChangesHide),
-    ]
-  }
-
-  if (!unchanged?.length)
-    return changed ?? []
-
-  return [
-    ({
-      type: 'no_changes_collapsed',
-      id: 'no_changes_collapsed',
-      count: unchanged?.length ?? 0,
-      duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
-    } satisfies RolldownModuleNoChanges),
-    ...(changed ?? []),
-  ]
-})
-
-const loads = computed(() => {
-  const unchanged = info?.value?.loads?.filter(l => !l.content)
-  const changed = info?.value?.loads?.filter(l => l.content)
-
-  if (flowShowAllLoads.value && !unchanged?.length)
-    return info?.value?.loads ?? []
-
-  if (flowShowAllLoads.value && unchanged?.length) {
-    return [
-      ...(info.value.loads ?? []),
-      ({
-        type: 'no_changes_hide',
-        id: 'no_changes_hide',
-        count: unchanged?.length ?? 0,
-        duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
-      } satisfies RolldownModuleNoChangesHide),
-    ]
-  }
-
-  if (!unchanged?.length)
-    return changed ?? []
-
-  return [
-    ({
-      type: 'no_changes_collapsed',
-      id: 'no_changes_collapsed',
-      count: unchanged?.length ?? 0,
-      duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
-    } satisfies RolldownModuleNoChanges),
-    ...(changed ?? []),
-  ]
-})
-
-const nodes = computed<RolldownModuleFlowNode[]>(() => [
-  ...resolveIds.value,
-  ...loads.value,
-  ...transforms.value,
-  ...info.value.chunks,
-  ...info.value.assets,
-])
-
-function isSelectedAncestor(node?: RolldownModuleFlowNode) {
-  if (!selected.value || !node)
-    return false
-  const indexSelected = nodes.value.indexOf(selected.value)
-  const indexNode = nodes.value.indexOf(node)
-  if (indexSelected >= indexNode)
-    return true
-  return false
-}
 
 watch(selected, (v) => {
   emit('select', !!v)
 })
 
-const codeDisplay = computed(() => {
-  if (!selected.value)
-    return null
-  if (!('type' in selected.value))
-    return null
-  if (selected.value.type === 'transform') {
-    return {
-      type: 'transform',
-      plugin_name: selected.value.plugin_name,
-      from: selected.value.content_from,
-      to: selected.value.content_to,
-    }
-  }
-  else if (selected.value.type === 'load') {
-    return {
-      type: 'load',
-      from: '',
-      plugin_name: selected.value.plugin_name,
-      to: selected.value.content,
-    }
-  }
-  return null
-})
+function handleSelect(value: RolldownModuleFlowNode | null) {
+  selected.value = value
+}
+
+function handleClose() {
+  selected.value = null
+}
 </script>
 
 <template>
-  <div pt4 ws-nowrap>
-    <div v-if="info.importers?.length" text-sm>
-      <div flex>
-        <VMenu>
-          <FlowmapNode class-node-outer="border-dashed">
-            <template #inner>
-              <div flex="~ items-center gap-1" text-sm text-blue px3 py1>
-                <div i-ph-arrows-merge-duotone rotate-270 />
-                {{ info.importers?.length }} importers
-              </div>
-            </template>
-          </FlowmapNode>
-          <template #popper="{ hide }">
-            <div p2 flex="~ col gap-1">
-              <DisplayModuleId
-                v-for="importer of info.importers"
-                :id="importer"
-                :key="importer"
-                :session="session"
-                :link="true"
-                class="hover:bg-active"
-                px2 py1 rounded
-                @click="hide"
-              />
-            </div>
-          </template>
-        </VMenu>
-      </div>
-      <div
-        pl-10 border="r" h-4 w-1px z-flowmap-line
-        class="border-flow-line border-dashed"
+  <Splitpanes class="!h-auto !of-visible p4 module-flow-splitter">
+    <Pane size="45" min-size="10" max-size="90" class="!h-auto !of-visible">
+      <ModuleFlowTimeline
+        :info="info"
+        :session="session"
+        :transforms-loading="transformsLoading"
+        :selected="selected"
+        @select="handleSelect"
       />
-    </div>
-    <div flex="~">
-      <FlowmapNode
-        :lines="{ bottom: true }"
-        :active="selected != null"
-      >
-        <template #content>
-          <div p2>
-            <DisplayModuleId
-              :id="info.id"
-              :session="session"
-            />
-          </div>
-        </template>
-      </FlowmapNode>
-      <template v-if="info.imports?.length">
-        <div w-10 border="t base dashed" mya />
-        <VMenu mya>
-          <FlowmapNode class-node-outer="border-dashed">
-            <template #inner>
-              <div flex="~ items-center gap-1" text-sm text-orange px3 py1>
-                <div i-ph-arrows-split-duotone rotate-270 />
-                {{ info.imports?.length }} imports
-              </div>
-            </template>
-          </FlowmapNode>
-          <template #popper="{ hide }">
-            <div p2 flex="~ col gap-1">
-              <DisplayModuleId
-                v-for="imp of info.imports"
-                :id="imp.module_id"
-                :key="imp.module_id"
-                :kind="imp.kind"
-                :session="session"
-                :link="true"
-                class="hover:bg-active"
-                px2 py1 rounded
-                @click="hide"
-              />
-            </div>
-          </template>
-        </VMenu>
-      </template>
-    </div>
-    <div flex="~ gap-10" min-w-300>
-      <div select-none w-max>
-        <FlowmapExpandable
-          v-model:expanded="flowExpandResolveId"
-          :expandable="resolveIds.length > 0"
-          :class-root-node="resolveIds.length === 0 ? 'border-dashed' : ''"
-          :active-start="isSelectedAncestor(resolveIds[0] || loads[0])"
-          :active-end="isSelectedAncestor(loads[0])"
-        >
-          <template #node>
-            <div i-ph-magnifying-glass-duotone /> Resolve Id
-            <span op50 text-xs>({{ info.resolve_ids.length }})</span>
-          </template>
-          <template #container>
-            <div>
-              <FlowmapNodeModuleInfo
-                v-for="(item, index) of resolveIds"
-                :key="item.id"
-                :item="item"
-                :session="session"
-                :active="isSelectedAncestor(item)"
-                :class="index > 0 ? 'pt-2' : ''"
-                @select="e => selected = e"
-              />
-            </div>
-          </template>
-        </FlowmapExpandable>
+    </Pane>
 
-        <FlowmapExpandable
-          v-model:expanded="flowExpandLoads"
-          :expandable="loads.length > 0"
-          :class-root-node="loads.length === 0 ? 'border-dashed' : ''"
-          :active-start="isSelectedAncestor(loads[0])"
-          :active-end="isSelectedAncestor(transforms[0])"
-        >
-          <template #node>
-            <div i-ph-upload-simple-duotone /> Load
-            <span op50 text-xs>({{ info.loads.length }})</span>
-          </template>
-          <template #container>
-            <div>
-              <FlowmapNodeModuleInfo
-                v-for="(item, index) of loads"
-                :key="item.id"
-                :item="item"
-                :session="session"
-                :active="isSelectedAncestor(item)"
-                :class="index > 0 && item.type !== 'no_changes_hide' ? 'pt-2' : ''"
-                @select="e => selected = e"
-                @toggle-show-all="flowShowAllLoads = !flowShowAllLoads"
-              />
-            </div>
-          </template>
-        </FlowmapExpandable>
-
-        <FlowmapExpandable
-          v-model:expanded="flowExpandTransforms"
-          :expandable="transforms.length > 0"
-          :class-root-node="transforms.length === 0 ? 'border-dashed' : ''"
-          :active-start="isSelectedAncestor(transforms[0])"
-          :active-end="isSelectedAncestor(info.chunks[0] || transforms.at(-1))"
-        >
-          <template #node>
-            <div i-ph-magic-wand-duotone /> Transform
-            <span v-if="transformsLoading" i-ph-spinner animate-spin />
-            <span v-else op50 text-xs>({{ info.transforms.length }})</span>
-          </template>
-          <template #container>
-            <div>
-              <FlowmapNodeModuleInfo
-                v-for="(item, index) of transforms"
-                :key="item.id"
-                :item="item"
-                :session="session"
-                :active="isSelectedAncestor(item)"
-                :class="index > 0 && item.type !== 'no_changes_hide' ? 'pt-2' : ''"
-                @select="e => selected = e"
-                @toggle-show-all="flowShowAllTransforms = !flowShowAllTransforms"
-              />
-            </div>
-          </template>
-        </FlowmapExpandable>
-
-        <FlowmapExpandable
-          v-model:expanded="flowExpandChunks"
-          :lines="{ top: true }"
-          :expandable="info.chunks.length > 0"
-          :class-root-node="info.chunks.length === 0 ? 'border-dashed' : ''"
-          :active-start="isSelectedAncestor(info.chunks[0])"
-          :active-end="isSelectedAncestor(info.chunks.at(-1))"
-          pl6 pt4
-        >
-          <template #node>
-            <div i-ph-shapes-duotone /> Chunk
-            <span op50 text-xs>({{ info.chunks.length }})</span>
-          </template>
-          <template #container>
-            <FlowmapNodeChunkInfo
-              v-for="chunk of info.chunks"
-              :key="chunk.chunk_id"
-              :item="chunk"
-              :active="isSelectedAncestor(chunk)"
-              :session="session"
-              @select="e => selected = e"
-            />
-          </template>
-        </FlowmapExpandable>
-
-        <!-- <FlowmapNode :lines="{ top: true, bottom: true }" pl6 pt4>
-          <template #content>
-            <div i-ph-tree-duotone /> Tree shake
-          </template>
-        </FlowmapNode> -->
-
-        <FlowmapExpandable
-          v-model:expanded="flowExpandAssets"
-          :lines="{ top: true }"
-          :expandable="info.assets.length > 0"
-          :class-root-node="info.assets.length === 0 ? 'border-dashed' : ''"
-          :active-start="isSelectedAncestor(info.assets[0])"
-          :active-end="isSelectedAncestor(info.assets.at(-1))"
-          :show-tail="false"
-          pl6 pt4
-        >
-          <template #node>
-            <div i-ph-package-duotone /> Assets
-            <span op50 text-xs>({{ info.assets.length }})</span>
-          </template>
-          <template #container>
-            <FlowmapNodeAssetInfo
-              v-for="asset of info.assets"
-              :key="asset.filename"
-              :item="asset"
-              :active="isSelectedAncestor(asset)"
-              :session="session"
-              @select="e => selected = e"
-            />
-          </template>
-        </FlowmapExpandable>
+    <Pane v-if="selected" size="55" min-size="10" max-size="90" class="!h-auto !of-visible">
+      <!-- the origin of the height: -->
+      <!-- DialogTopMargin (20) + HandleHeight (30) + padding (4*2) = 58 -->
+      <div w-full h="[calc(100vh-(var(--spacing)*58))]" sticky top-4>
+        <div absolute left-0 top="1/2" translate-x="-1/2" translate-y="-1/2" bg="#DFDFDF dark:#313131" h-10 w-2 rounded-full z-10 cursor-col-resize />
+        <ModuleFlowDetails
+          :selected="selected"
+          :session="session"
+          :chunks="info.chunks"
+          @close="handleClose"
+        />
       </div>
-
-      <div
-        w-259
-        :class="codeDisplay?.from && codeDisplay?.to ? '' : 'border-dashed'"
-        border="~ base rounded-lg" of-hidden max-h-120vh m4 flex="~ col"
-      >
-        <template v-if="selected?.type === 'chunk'">
-          <div p4 h-full of-auto>
-            <DataChunkDetails
-              :chunk="selected"
-              :session="session"
-            />
-          </div>
-        </template>
-        <template v-else-if="selected?.type === 'asset'">
-          <div p4>
-            <DataAssetDetails
-              :asset="selected"
-              :session="session"
-              :chunks="info.chunks"
-            />
-          </div>
-        </template>
-        <template v-else-if="codeDisplay?.from && codeDisplay?.to">
-          <div pl4 p2 font-mono border="b base" flex="~ items-center gap-2" h-max-100vh>
-            <PluginName :name="codeDisplay?.plugin_name ?? ''" />
-            <span v-if="codeDisplay?.type" op50 text-xs>
-              {{ codeDisplay?.type === 'load' ? 'Load' : 'Transform' }}
-            </span>
-            <div flex-auto />
-            <DisplayCloseButton @click="selected = null" />
-          </div>
-          <CodeDiffEditor
-            :from="codeDisplay?.from ?? ''"
-            :to="codeDisplay?.to ?? ''"
-            :diff="true"
-            :one-column="false"
-          />
-        </template>
-        <!-- TODO: show more info with selected node -->
-        <span v-else op50 italic ma>
-          Select a node to view
-        </span>
-      </div>
-    </div>
-  </div>
+    </Pane>
+  </Splitpanes>
 </template>
+
+<style>
+.module-flow-splitter>.splitpanes__splitter:before {
+  background-color: transparent;
+}
+</style>

--- a/packages/devtools/src/app/components/flowmap/ModuleFlowDetails.vue
+++ b/packages/devtools/src/app/components/flowmap/ModuleFlowDetails.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { RolldownChunkInfo, RolldownModuleFlowNode, SessionContext } from '~~/shared/types'
+import { computed } from 'vue'
+import PluginName from '../display/PluginName.vue'
+
+const props = defineProps<{
+  selected: RolldownChunkInfo | RolldownModuleFlowNode | null
+  session: SessionContext
+  chunks: RolldownChunkInfo[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const codeDisplay = computed(() => {
+  if (!props.selected)
+    return null
+  if (!('type' in props.selected))
+    return null
+  if (props.selected.type === 'transform') {
+    return {
+      type: 'transform',
+      plugin_name: props.selected.plugin_name,
+      from: props.selected.content_from,
+      to: props.selected.content_to,
+    }
+  }
+  else if (props.selected.type === 'load') {
+    return {
+      type: 'load',
+      from: '',
+      plugin_name: props.selected.plugin_name,
+      to: props.selected.content,
+    }
+  }
+  return null
+})
+
+function handleClose() {
+  emit('close')
+}
+</script>
+
+<template>
+  <div
+    bg-glass w-full h-full
+    :class="codeDisplay?.from && codeDisplay?.to ? '' : 'border-dashed'"
+    border="~ base rounded-lg" of-hidden flex="~ col"
+  >
+    <template v-if="selected?.type === 'chunk'">
+      <div p4 h-full of-auto style="overscroll-behavior: contain">
+        <DataChunkDetails
+          :chunk="selected"
+          :session="session"
+        />
+      </div>
+    </template>
+    <template v-else-if="selected?.type === 'asset'">
+      <div p4 h-full of-auto style="overscroll-behavior: contain">
+        <DataAssetDetails
+          :asset="selected"
+          :session="session"
+          :chunks="chunks"
+        />
+      </div>
+    </template>
+    <template v-else-if="codeDisplay?.from && codeDisplay?.to">
+      <div pl4 p2 font-mono border="b base" flex="~ items-center gap-2">
+        <PluginName :name="codeDisplay?.plugin_name ?? ''" />
+        <span v-if="codeDisplay?.type" op50 text-xs>
+          {{ codeDisplay?.type === 'load' ? 'Load' : 'Transform' }}
+        </span>
+        <div flex-auto />
+        <DisplayCloseButton @click="handleClose" />
+      </div>
+      <CodeDiffEditor
+        :from="codeDisplay?.from ?? ''"
+        :to="codeDisplay?.to ?? ''"
+        :diff="true"
+        :one-column="false"
+      />
+    </template>
+    <!-- TODO: show more info with selected node -->
+    <span v-else op50 italic ma>
+      Select a node to view
+    </span>
+  </div>
+</template>

--- a/packages/devtools/src/app/components/flowmap/ModuleFlowTimeline.vue
+++ b/packages/devtools/src/app/components/flowmap/ModuleFlowTimeline.vue
@@ -1,0 +1,341 @@
+<script setup lang="ts">
+import type { ModuleInfo, RolldownModuleFlowNode, RolldownModuleNoChanges, RolldownModuleNoChangesHide, RolldownModuleTransformInfo, SessionContext } from '~~/shared/types'
+import { Menu as VMenu } from 'floating-vue'
+import { computed, toRefs } from 'vue'
+import { settingsRefs } from '~/state/settings'
+
+const props = defineProps<{
+  info: ModuleInfo
+  session: SessionContext
+  transformsLoading: boolean
+  selected: RolldownModuleFlowNode | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', value: RolldownModuleFlowNode | null): void
+}>()
+
+const { info } = toRefs(props)
+
+const {
+  flowShowAllTransforms,
+  flowShowAllLoads,
+  flowExpandTransforms,
+  flowExpandLoads,
+  flowExpandResolveId,
+  flowExpandChunks,
+  flowExpandAssets,
+} = settingsRefs
+
+const resolveIds = computed(() => info?.value?.resolve_ids ?? [])
+
+const transforms = computed((): (RolldownModuleNoChanges | RolldownModuleNoChangesHide | RolldownModuleTransformInfo)[] => {
+  const unchanged = info?.value?.transforms?.filter(t => t.content_from === t.content_to)
+  const changed = info?.value?.transforms?.filter(t => t.content_from !== t.content_to)
+
+  if (flowShowAllTransforms.value && !unchanged?.length)
+    return info?.value?.transforms ?? []
+
+  if (flowShowAllTransforms.value && unchanged?.length) {
+    return [
+      ...(info.value.transforms ?? []),
+      ({
+        type: 'no_changes_hide',
+        id: 'no_changes_hide',
+        count: unchanged?.length ?? 0,
+        duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
+      } satisfies RolldownModuleNoChangesHide),
+    ]
+  }
+
+  if (!unchanged?.length)
+    return changed ?? []
+
+  return [
+    ({
+      type: 'no_changes_collapsed',
+      id: 'no_changes_collapsed',
+      count: unchanged?.length ?? 0,
+      duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
+    } satisfies RolldownModuleNoChanges),
+    ...(changed ?? []),
+  ]
+})
+
+const loads = computed(() => {
+  const unchanged = info?.value?.loads?.filter(l => !l.content)
+  const changed = info?.value?.loads?.filter(l => l.content)
+
+  if (flowShowAllLoads.value && !unchanged?.length)
+    return info?.value?.loads ?? []
+
+  if (flowShowAllLoads.value && unchanged?.length) {
+    return [
+      ...(info.value.loads ?? []),
+      ({
+        type: 'no_changes_hide',
+        id: 'no_changes_hide',
+        count: unchanged?.length ?? 0,
+        duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
+      } satisfies RolldownModuleNoChangesHide),
+    ]
+  }
+
+  if (!unchanged?.length)
+    return changed ?? []
+
+  return [
+    ({
+      type: 'no_changes_collapsed',
+      id: 'no_changes_collapsed',
+      count: unchanged?.length ?? 0,
+      duration: unchanged?.reduce((acc, t) => acc + t.duration, 0) ?? 0,
+    } satisfies RolldownModuleNoChanges),
+    ...(changed ?? []),
+  ]
+})
+
+const nodes = computed<RolldownModuleFlowNode[]>(() => [
+  ...resolveIds.value,
+  ...loads.value,
+  ...transforms.value,
+  ...info.value.chunks,
+  ...info.value.assets,
+])
+
+function isSelectedAncestor(node?: RolldownModuleFlowNode) {
+  if (!props.selected || !node)
+    return false
+  const indexSelected = nodes.value.indexOf(props.selected)
+  const indexNode = nodes.value.indexOf(node)
+  if (indexSelected >= indexNode)
+    return true
+  return false
+}
+
+function handleSelect(value: RolldownModuleFlowNode | null) {
+  emit('select', value)
+}
+</script>
+
+<template>
+  <div select-none h-full of-auto ws-nowrap w-100vh of-visible>
+    <!-- Importers section -->
+    <div v-if="info.importers?.length" text-sm>
+      <div flex>
+        <VMenu>
+          <FlowmapNode class-node-outer="border-dashed">
+            <template #inner>
+              <div flex="~ items-center gap-1" text-sm text-blue px3 py1>
+                <div i-ph-arrows-merge-duotone rotate-270 />
+                {{ info.importers?.length }} importers
+              </div>
+            </template>
+          </FlowmapNode>
+          <template #popper="{ hide }">
+            <div p2 flex="~ col gap-1">
+              <DisplayModuleId
+                v-for="importer of info.importers"
+                :id="importer"
+                :key="importer"
+                :session="session"
+                :link="true"
+                class="hover:bg-active"
+                px2 py1 rounded
+                @click="hide"
+              />
+            </div>
+          </template>
+        </VMenu>
+      </div>
+      <div
+        pl-10 border="r" h-4 w-1px z-flowmap-line
+        class="border-flow-line border-dashed"
+      />
+    </div>
+
+    <!-- Main module node -->
+    <div flex="~">
+      <FlowmapNode
+        :lines="{ bottom: true }"
+        :active="selected != null"
+      >
+        <template #content>
+          <div p2>
+            <DisplayModuleId
+              :id="info.id"
+              :session="session"
+            />
+          </div>
+        </template>
+      </FlowmapNode>
+      <template v-if="info.imports?.length">
+        <div w-10 border="t base dashed" mya />
+        <VMenu mya>
+          <FlowmapNode class-node-outer="border-dashed">
+            <template #inner>
+              <div flex="~ items-center gap-1" text-sm text-orange px3 py1>
+                <div i-ph-arrows-split-duotone rotate-270 />
+                {{ info.imports?.length }} imports
+              </div>
+            </template>
+          </FlowmapNode>
+          <template #popper="{ hide }">
+            <div p2 flex="~ col gap-1">
+              <DisplayModuleId
+                v-for="imp of info.imports"
+                :id="imp.module_id"
+                :key="imp.module_id"
+                :kind="imp.kind"
+                :session="session"
+                :link="true"
+                class="hover:bg-active"
+                px2 py1 rounded
+                @click="hide"
+              />
+            </div>
+          </template>
+        </VMenu>
+      </template>
+    </div>
+
+    <!-- Flow timeline content -->
+    <FlowmapExpandable
+      v-model:expanded="flowExpandResolveId"
+      :expandable="resolveIds.length > 0"
+      :class-root-node="resolveIds.length === 0 ? 'border-dashed' : ''"
+      :active-start="isSelectedAncestor(resolveIds[0] || loads[0])"
+      :active-end="isSelectedAncestor(loads[0])"
+    >
+      <template #node>
+        <div i-ph-magnifying-glass-duotone /> Resolve Id
+        <span op50 text-xs>({{ info.resolve_ids.length }})</span>
+      </template>
+      <template #container>
+        <div>
+          <FlowmapNodeModuleInfo
+            v-for="(item, index) of resolveIds"
+            :key="item.id"
+            :item="item"
+            :session="session"
+            :active="isSelectedAncestor(item)"
+            :class="index > 0 ? 'pt-2' : ''"
+            @select="handleSelect"
+          />
+        </div>
+      </template>
+    </FlowmapExpandable>
+
+    <FlowmapExpandable
+      v-model:expanded="flowExpandLoads"
+      :expandable="loads.length > 0"
+      :class-root-node="loads.length === 0 ? 'border-dashed' : ''"
+      :active-start="isSelectedAncestor(loads[0])"
+      :active-end="isSelectedAncestor(transforms[0])"
+    >
+      <template #node>
+        <div i-ph-upload-simple-duotone /> Load
+        <span op50 text-xs>({{ info.loads.length }})</span>
+      </template>
+      <template #container>
+        <div>
+          <FlowmapNodeModuleInfo
+            v-for="(item, index) of loads"
+            :key="item.id"
+            :item="item"
+            :session="session"
+            :active="isSelectedAncestor(item)"
+            :class="index > 0 && item.type !== 'no_changes_hide' ? 'pt-2' : ''"
+            @select="handleSelect"
+            @toggle-show-all="flowShowAllLoads = !flowShowAllLoads"
+          />
+        </div>
+      </template>
+    </FlowmapExpandable>
+
+    <FlowmapExpandable
+      v-model:expanded="flowExpandTransforms"
+      :expandable="transforms.length > 0"
+      :class-root-node="transforms.length === 0 ? 'border-dashed' : ''"
+      :active-start="isSelectedAncestor(transforms[0])"
+      :active-end="isSelectedAncestor(info.chunks[0] || transforms.at(-1))"
+    >
+      <template #node>
+        <div i-ph-magic-wand-duotone /> Transform
+        <span v-if="transformsLoading" i-ph-spinner animate-spin />
+        <span v-else op50 text-xs>({{ info.transforms.length }})</span>
+      </template>
+      <template #container>
+        <div>
+          <FlowmapNodeModuleInfo
+            v-for="(item, index) of transforms"
+            :key="item.id"
+            :item="item"
+            :session="session"
+            :active="isSelectedAncestor(item)"
+            :class="index > 0 && item.type !== 'no_changes_hide' ? 'pt-2' : ''"
+            @select="handleSelect"
+            @toggle-show-all="flowShowAllTransforms = !flowShowAllTransforms"
+          />
+        </div>
+      </template>
+    </FlowmapExpandable>
+
+    <FlowmapExpandable
+      v-model:expanded="flowExpandChunks"
+      :lines="{ top: true }"
+      :expandable="info.chunks.length > 0"
+      :class-root-node="info.chunks.length === 0 ? 'border-dashed' : ''"
+      :active-start="isSelectedAncestor(info.chunks[0])"
+      :active-end="isSelectedAncestor(info.chunks.at(-1))"
+      pl6 pt4
+    >
+      <template #node>
+        <div i-ph-shapes-duotone /> Chunk
+        <span op50 text-xs>({{ info.chunks.length }})</span>
+      </template>
+      <template #container>
+        <FlowmapNodeChunkInfo
+          v-for="chunk of info.chunks"
+          :key="chunk.chunk_id"
+          :item="chunk"
+          :active="isSelectedAncestor(chunk)"
+          :session="session"
+          @select="handleSelect"
+        />
+      </template>
+    </FlowmapExpandable>
+
+    <!-- <FlowmapNode :lines="{ top: true, bottom: true }" pl6 pt4>
+      <template #content>
+        <div i-ph-tree-duotone /> Tree shake
+      </template>
+    </FlowmapNode> -->
+
+    <FlowmapExpandable
+      v-model:expanded="flowExpandAssets"
+      :lines="{ top: true }"
+      :expandable="info.assets.length > 0"
+      :class-root-node="info.assets.length === 0 ? 'border-dashed' : ''"
+      :active-start="isSelectedAncestor(info.assets[0])"
+      :active-end="isSelectedAncestor(info.assets.at(-1))"
+      :show-tail="false"
+      pl6 pt4
+    >
+      <template #node>
+        <div i-ph-package-duotone /> Assets
+        <span op50 text-xs>({{ info.assets.length }})</span>
+      </template>
+      <template #container>
+        <FlowmapNodeAssetInfo
+          v-for="asset of info.assets"
+          :key="asset.filename"
+          :item="asset"
+          :active="isSelectedAncestor(asset)"
+          :session="session"
+          @select="handleSelect"
+        />
+      </template>
+    </FlowmapExpandable>
+  </div>
+</template>


### PR DESCRIPTION
this diff view looks very crowded on my screen. I tried to add a resizing feature.

Since the `ModuleFlow.vue` was getting quite large, I split the code into `ModuleFlowDetails.vue` and `ModuleFlowTimeline.vue` based on the left and right panel layout. This makes it easier for me to work on the styles and helps with future maintainability.

The diff may look big, but there are no actual UI changes — sorry for the noise, and thanks for your understanding!


## Demo:


https://github.com/user-attachments/assets/e9ea3107-4605-45de-b22c-bf65ebc96cd5


