### PR TITLE
fix(graph): fixed scrollbar and content clipping issues when zooming

### DIFF
--- a/packages/devtools/src/app/components/modules/Graph.vue
+++ b/packages/devtools/src/app/components/modules/Graph.vue
@@ -242,30 +242,37 @@ onMounted(() => {
     :class="isGrabbing ? 'cursor-grabbing' : ''"
   >
     <div
-      flex="~ items-center justify-center"
-      :style="{ transform: `scale(${scale})`, transformOrigin: '0 0' }"
+      :style="{
+        width: `${width * scale}px`,
+        height: `${height * scale}px`,
+      }"
     >
+      <!-- Make this <div> in order to expand the scroll bar -->
       <div
-        absolute left-0 top-0
-        :style="{
-          width: `${width * scale}px`,
-          height: `${height * scale}px`,
-        }"
-        class="bg-dots"
-      />
-      <svg pointer-events-none absolute left-0 top-0 z-graph-link :width="width" :height="height">
-        <g>
-          <path
-            v-for="link of links"
-            :key="link.id"
-            :d="generateLink(link)!"
-            :class="getLinkColor(link)"
-            :stroke-dasharray="link.import?.kind === 'dynamic-import' ? '3 6' : undefined"
-            fill="none"
-          />
-        </g>
-      </svg>
-      <!-- <svg pointer-events-none absolute left-0 top-0 z-graph-link-active :width="width" :height="height">
+        flex="~ items-center justify-center"
+        :style="{ transform: `scale(${scale})`, transformOrigin: '0 0' }"
+      >
+        <div
+          absolute left-0 top-0
+          :style="{
+            width: `${width}px`,
+            height: `${height}px`,
+          }"
+          class="bg-dots"
+        />
+        <svg pointer-events-none absolute left-0 top-0 z-graph-link :width="width" :height="height">
+          <g>
+            <path
+              v-for="link of links"
+              :key="link.id"
+              :d="generateLink(link)!"
+              :class="getLinkColor(link)"
+              :stroke-dasharray="link.import?.kind === 'dynamic-import' ? '3 6' : undefined"
+              fill="none"
+            />
+          </g>
+        </svg>
+        <!-- <svg pointer-events-none absolute left-0 top-0 z-graph-link-active :width="width" :height="height">
       <g>
         <path
           v-for="link of links"
@@ -276,31 +283,32 @@ onMounted(() => {
         />
       </g>
     </svg> -->
-      <template
-        v-for="node of nodes"
-        :key="node.data.module.id"
-      >
-        <template v-if="node.data.module.id !== '~root'">
-          <DisplayModuleId
-            :id="node.data.module.id"
-            :ref="(el: any) => nodesRefMap.set(node.data.module.id, el?.$el)"
-            absolute hover="bg-active" block px2 p1 bg-glass z-graph-node
-            border="~ base rounded"
-            :link="true"
-            :session="session"
-            :minimal="true"
-            :style="{
-              left: `${node.x}px`,
-              top: `${node.y}px`,
-              minWidth: graphRender === 'normal' ? `${SPACING.width}px` : undefined,
-              transform: 'translate(-50%, -50%)',
-              maxWidth: '400px',
-              maxHeight: '50px',
-              overflow: 'hidden',
-            }"
-          />
+        <template
+          v-for="node of nodes"
+          :key="node.data.module.id"
+        >
+          <template v-if="node.data.module.id !== '~root'">
+            <DisplayModuleId
+              :id="node.data.module.id"
+              :ref="(el: any) => nodesRefMap.set(node.data.module.id, el?.$el)"
+              absolute hover="bg-active" block px2 p1 bg-glass z-graph-node
+              border="~ base rounded"
+              :link="true"
+              :session="session"
+              :minimal="true"
+              :style="{
+                left: `${node.x}px`,
+                top: `${node.y}px`,
+                minWidth: graphRender === 'normal' ? `${SPACING.width}px` : undefined,
+                transform: 'translate(-50%, -50%)',
+                maxWidth: '400px',
+                maxHeight: '50px',
+                overflow: 'hidden',
+              }"
+            />
+          </template>
         </template>
-      </template>
+      </div>
     </div>
     <div
       fixed right-6 bottom-6 z-panel-nav flex="~ col gap-2 items-center"

--- a/packages/devtools/src/app/components/modules/Graph.vue
+++ b/packages/devtools/src/app/components/modules/Graph.vue
@@ -248,8 +248,8 @@ onMounted(() => {
       <div
         absolute left-0 top-0
         :style="{
-          width: `${width}px`,
-          height: `${height}px`,
+          width: `${width * scale}px`,
+          height: `${height * scale}px`,
         }"
         class="bg-dots"
       />

--- a/packages/devtools/src/app/components/modules/Graph.vue
+++ b/packages/devtools/src/app/components/modules/Graph.vue
@@ -195,7 +195,7 @@ function getLinkColor(_link: Link) {
   return 'stroke-#8882'
 }
 
-function handleDragingScroll() {
+function handleDraggingScroll() {
   let x = 0
   let y = 0
   const SCROLLBAR_THICKNESS = 20
@@ -225,7 +225,7 @@ function handleDragingScroll() {
 }
 
 onMounted(() => {
-  handleDragingScroll()
+  handleDraggingScroll()
 
   watch(
     () => [props.modules, graphRender.value],


### PR DESCRIPTION
### Problem

I noticed the nodes may get clipped when I zoom in the graph, and the slot of the scroll bar won't change its size after zooming.

`transform: scale()`' only provides visual scaling without any layout space changes, so it caused the bug

### Fixes

I added a box in container with the `width` and `height` multiplied by `scale`, it will provide a space for layout and the scroll displays normally and the content won't be clipped

### Impact

**Breaking Changes**: none

The content can be displayed normally even if it's small, and the scroll slot's size will change with user's zoom

*The scroll bar may get longer than before, though it's expected*
*I also fixed a really really small typo issue by renaming `handleDragingScroll` to `handleDraggingScroll`*


[Comparing](https://github.com/user-attachments/assets/d5c7a2af-e596-427a-b76c-56f849502417)

