### PR TITLE
fix(graph): provide proper touchpad zoom action

### DIFF
--- a/packages/devtools/src/app/composables/zoomElement.ts
+++ b/packages/devtools/src/app/composables/zoomElement.ts
@@ -42,13 +42,20 @@ export function useZoomElement(
   }
 
   function handleWheel(event: WheelEvent) {
-    if (!toValue(wheel))
-      return
+    if (toValue(wheel)) {
+      // Use control + wheel
+      event.preventDefault()
 
-    event.preventDefault()
+      const zoomFactor = 0.2
+      zoom(event.deltaY < 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
+    }
+    else if (event.ctrlKey) {
+      // Use touchpad zoom
+      event.preventDefault()
 
-    const zoomFactor = 0.2
-    zoom(event.deltaY < 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
+      const zoomFactor = 0.03
+      zoom(event.deltaY < 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
+    }
   }
 
   function zoomIn(factor = 0.2) {

--- a/packages/devtools/src/app/composables/zoomElement.ts
+++ b/packages/devtools/src/app/composables/zoomElement.ts
@@ -53,8 +53,8 @@ export function useZoomElement(
       // Use touchpad zoom
       event.preventDefault()
 
-      const zoomFactor = 0.03
-      zoom(event.deltaY < 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
+      const zoomFactor = 0.004
+      zoom(event.deltaY * zoomFactor * -1, event.clientX, event.clientY)
     }
   }
 


### PR DESCRIPTION
### Problem

1. The whole webpage will be zoom if you try zoom graph with touchpad
2. In the existing ctrl + mouse wheel zoom, the touchpad is not considered (super fast zoom speed, just process it like normal mouse)

### Fixes

The touchpad sends zoom actions by `wheel` DOM event and `event.ctrl` is `true` but `{control} = useMagicKey()` is false

So we can use it to know when user use touchpad to zoom, and process the zoom request with true `deltaY`

### Impact

No Breaking Changes

The users with a touchpad will feel better (Btw, I only test on the macbook's touchpad, although the touchpad in Windows should have the same actions, [see more there](https://learn.microsoft.com/en-us/answers/questions/3938899/why-pinch-to-zoom-with-touchpad-generates-ctrl-key?forum=windows-all)


[A video to show it](https://github.com/user-attachments/assets/f22e659d-8edc-4619-b4aa-909fd615fb95)

