### PR TITLE
fix(assets): proper asset details displaying for .map or other non-module assets

### DIFF
--- a/packages/devtools-vite/src/app/components/data/AssetDetails.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetails.vue
@@ -23,18 +23,21 @@ const { state } = useAsyncState(
   async () => {
     if (!props.lazy)
       return
+
     const res = await rpc.value!['vite:rolldown:get-asset-details']?.({
       session: props.session.id,
       id: props.asset.filename,
     })
-    return {
-      chunks: [{ ...res?.chunk, type: 'chunk' }],
-      importers: res?.importers,
-      imports: res?.imports,
-    } satisfies {
-      chunks: RolldownChunkInfo[]
-      importers: AssetInfo[]
-      imports: AssetInfo[]
+    if ('chunk' in res) {
+      return {
+        chunks: [{ ...res?.chunk, type: 'chunk' }],
+        importers: res?.importers,
+        imports: res?.imports,
+      } as {
+        chunks: RolldownChunkInfo[]
+        importers: AssetInfo[]
+        imports: AssetInfo[]
+      }
     }
   },
   null,

--- a/packages/devtools-vite/src/app/components/data/AssetDetails.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetails.vue
@@ -39,6 +39,17 @@ const { state } = useAsyncState(
         imports: AssetInfo[]
       }
     }
+    else {
+      return {
+        chunks: [],
+        importers: [],
+        imports: [],
+      } as {
+        chunks: RolldownChunkInfo[]
+        importers: AssetInfo[]
+        imports: AssetInfo[]
+      }
+    }
   },
   null,
 )
@@ -97,7 +108,7 @@ function openInEditor() {
       </div>
     </template>
 
-    <div flex="~ col gap-4">
+    <div v-if="assetChunks && assetChunks.length > 0" flex="~ col gap-4">
       <div flex="~ col gap-2">
         <div op50>
           Chunks

--- a/packages/devtools-vite/src/app/components/data/AssetDetails.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetails.vue
@@ -133,5 +133,14 @@ function openInEditor() {
         </div>
       </template>
     </div>
+    <div v-else flex="~ col gap-1">
+      <!-- For other situation -->
+      <div op50>
+        [Non-Module Asset]
+      </div>
+      <div v-if="asset.filename.endsWith('.map')" flex="~ items-center gap-2">
+        <span op50>Source Map for</span> <DisplayBadge :text="JSON.parse(asset.content!).file" />
+      </div>
+    </div>
   </div>
 </template>

--- a/packages/devtools-vite/src/app/components/data/AssetDetailsLoader.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetailsLoader.vue
@@ -36,8 +36,14 @@ const { state } = useAsyncState(
     else {
       return {
         asset: { ...res?.asset, type: 'asset' },
+        chunks: [],
+        importers: [],
+        imports: [],
       } satisfies {
         asset: RolldownAssetInfo
+        chunks: RolldownChunkInfo[]
+        importers: AssetInfo[]
+        imports: AssetInfo[]
       }
     }
   },
@@ -51,6 +57,6 @@ const { state } = useAsyncState(
       absolute right-2 top-1.5
       @click="emit('close')"
     />
-    <DataAssetDetails :asset="state.asset" :session="session" />
+    <DataAssetDetails :asset="state.asset" :session="session" :chunks="state?.chunks" :importers="state?.importers" :imports="state?.imports" />
   </div>
 </template>

--- a/packages/devtools-vite/src/app/components/data/AssetDetailsLoader.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetailsLoader.vue
@@ -20,16 +20,25 @@ const { state } = useAsyncState(
       session: props.session.id,
       id: props.asset,
     })
-    return {
-      asset: { ...res?.asset, type: 'asset' },
-      chunks: [{ ...res?.chunk, type: 'chunk' }],
-      importers: res?.importers,
-      imports: res?.imports,
-    } satisfies {
-      asset: RolldownAssetInfo
-      chunks: RolldownChunkInfo[]
-      importers: AssetInfo[]
-      imports: AssetInfo[]
+    if ('chunk' in res) {
+      return {
+        asset: { ...res?.asset, type: 'asset' },
+        chunks: [{ ...res?.chunk, type: 'chunk' }],
+        importers: res?.importers,
+        imports: res?.imports,
+      } as {
+        asset: RolldownAssetInfo
+        chunks: RolldownChunkInfo[]
+        importers: AssetInfo[]
+        imports: AssetInfo[]
+      }
+    }
+    else {
+      return {
+        asset: { ...res?.asset, type: 'asset' },
+      } satisfies {
+        asset: RolldownAssetInfo
+      }
     }
   },
   null,
@@ -42,6 +51,6 @@ const { state } = useAsyncState(
       absolute right-2 top-1.5
       @click="emit('close')"
     />
-    <DataAssetDetails :asset="state.asset" :session="session" :chunks="state?.chunks" :importers="state?.importers" :imports="state?.imports" />
+    <DataAssetDetails :asset="state.asset" :session="session" />
   </div>
 </template>

--- a/packages/devtools-vite/src/node/rpc/functions/rolldown-get-asset-details.ts
+++ b/packages/devtools-vite/src/node/rpc/functions/rolldown-get-asset-details.ts
@@ -14,6 +14,14 @@ export const rolldownGetAssetDetails = defineRpcFunction({
         const asset = assets.get(id)!
         const assetList = Array.from(assets.values())
         const chunkList = Array.from(chunks.values())
+
+        if (asset.chunk_id === null) {
+          // sourceMap or other
+          return {
+            asset,
+          }
+        }
+
         const assetChunkId = asset.chunk_id!
         const chunk = chunks.get(assetChunkId)!
         const importers = chunkList.filter(mod => mod.imports.some(i => i.chunk_id === assetChunkId)).map(c => assetList.find(a => a.chunk_id === c.chunk_id)!)

--- a/packages/devtools-vite/src/node/rpc/functions/rolldown-get-asset-details.ts
+++ b/packages/devtools-vite/src/node/rpc/functions/rolldown-get-asset-details.ts
@@ -9,8 +9,8 @@ export const rolldownGetAssetDetails = defineRpcFunction({
     return {
       handler: async ({ session, id }: { session: string, id: string }) => {
         const reader = await manager.loadSession(session)
-        const assets = await reader.manager.assets
-        const chunks = await reader.manager.chunks
+        const assets = reader.manager.assets
+        const chunks = reader.manager.chunks
         const asset = assets.get(id)!
         const assetList = Array.from(assets.values())
         const chunkList = Array.from(chunks.values())


### PR DESCRIPTION
### Problem

Assets page will display the `.map` and other assets not created from a chunk, and It can be click but nothing in it  like this.

<img width="1582" height="1031" alt="A blank for the asset" src="https://github.com/user-attachments/assets/22a2bea9-a058-43aa-92d1-9d349ce43c66" />

And there is also some error in console (sever-side)
```
 ERROR  ⬢ RPC error on executing "vite:rolldown:get-asset-details":                                                                        16:56:48
 ERROR  Cannot read properties of undefined (reading 'imports')        
```

We can't assert `assetChunkId` is not `null` and it caused the problem

### Fixes

Added some `if(..){}` to judge if `assetChunkId` is `null`, and render differently on the client-side

Now it displays normally especially to Source Map

<img width="812" height="211" alt="After" src="https://github.com/user-attachments/assets/0d6f8dea-2220-4d46-9dbf-e15340a7085b" />

And there won't be error anymore in the console
