### PR TITLE
feat: add prettier custom scrollbar

### DIFF
--- a/packages/devtools-vite/src/app/styles/global.css
+++ b/packages/devtools-vite/src/app/styles/global.css
@@ -91,10 +91,29 @@ summary::-webkit-details-marker {
 
 /* For Scrollbar */
 ::-webkit-scrollbar {
-  width: 9px;
+  width: 11px;
 } 
 
+::-webkit-scrollbar:horizontal {
+  height: 11px;
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 ::-webkit-scrollbar-thumb {
-  background: #555555;
+  background-color: #8884;
   border-radius: 100px; 
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: #8885;
+}
+
+::-webkit-scrollbar-track {
+  border-radius: 1px;
+  background: transparent;
 }

--- a/packages/devtools-vite/src/app/styles/global.css
+++ b/packages/devtools-vite/src/app/styles/global.css
@@ -88,3 +88,13 @@ summary::-webkit-details-marker {
 .v-popper__popper--shown {
   overflow: visible !important;
 }
+
+/* For Scrollbar */
+::-webkit-scrollbar {
+  width: 9px;
+} 
+
+::-webkit-scrollbar-thumb {
+  background: #555555;
+  border-radius: 100px; 
+}


### PR DESCRIPTION
As the discussion in #71

<img width="163" height="699" alt="Light Mode" src="https://github.com/user-attachments/assets/06ebe7ea-1b3f-42da-882e-b2b77f6db9ab" />
<img width="544" height="505" alt="Dark Mode" src="https://github.com/user-attachments/assets/d150dc85-b0df-4eb7-9bd2-fd7ce9562998" />


As a devtools, the scrollbar become lighter and thiner, and it also looks well in dark mode.

And the background color will change when hover, although we aren't able to use `transition` to make some fading animation (There are some discussions: [Stack Flow](https://stackoverflow.com/questions/4576853/does-webkit-scrollbar-work-with-webkit-transition))
