### PR TITLE
fix(color): fixed branch error when calling getPluginColor('error')

### DIFF
--- a/packages/devtools-vite/src/app/utils/color.ts
+++ b/packages/devtools-vite/src/app/utils/color.ts
@@ -49,7 +49,7 @@ const predefinedColorMap = {
 
 export function getPluginColor(name: string, opacity = 1): string {
   name = name.replace(/[^a-z]+/gi, '').toLowerCase()
-  if (predefinedColorMap[name]) {
+  if (name in predefinedColorMap) {
     const color = predefinedColorMap[name]!
     if (typeof color === 'number') {
       return getHsla(color, opacity)


### PR DESCRIPTION
### Problem

We expect to get the return value from `getHsla` when calling `getPluginColor` with the any keys in `predefinedColorMap`

It works most of the time, but it will use `getHashColorFromString` when calling `getPluginColor('error')` although `error` is a key of `predefinedColorMap`

### Fixes

Fixed the above issue by correcting filtering undefined method