### PR TITLE
fix: correct the return value of `parseReadablePath` on Windows

### DIFF
--- a/packages/devtools-vite/src/app/utils/filepath.ts
+++ b/packages/devtools-vite/src/app/utils/filepath.ts
@@ -44,7 +44,9 @@ export const parseReadablePath = makeCachedFunction((path: string, root: string)
     }
   }
 
-  if (parsedPath.match(/^\w+:/) && !(/^[a-z]:\\/i.test(path))) {
+  if (parsedPath.match(/^\w+:/)
+    && !(path.match(/^[a-z]:\\/i)) // in order to check if it is Windows' path
+  ) {
     return {
       moduleName: parsedPath,
       path: parsedPath,


### PR DESCRIPTION
### Problem

`parseReadablePath` function in `app/utils/filepath.ts` will check if the path match regex `/^\w+:/` in order to match the path like `rolldown:*`

However, the Windows' path will also match the regex, *I think it may be unexpected*. The node_modules filters(in TODO #12 ) feat won't work with it in the future because of the wrong module name

### Fixes

Added a regex for Windows' path

One more thing: If it really is a bug, I will make a test file for it