### PR TITLE
feat: Add listening to `Escape` button to close `PluginDetailLoader`

### DIFF
--- a/packages/devtools-vite/src/app/pages/session/[session].vue
+++ b/packages/devtools-vite/src/app/pages/session/[session].vue
@@ -42,13 +42,16 @@ onKeyDown('Escape', (e) => {
   if (!e.isTrusted || e.repeat)
     return
 
-  const { module, asset } = route.query
+  const { module, asset, plugin } = route.query
 
   if (module)
     closeFlowPanel()
 
   if (asset)
     closeAssetPanel()
+
+  if (plugin)
+    closePluginPanel()
 })
 
 useSideNav(() => {


### PR DESCRIPTION
Just like https://github.com/vitejs/devtools/pull/44

Now we add plugin detail dialog, and it can not able to close use `Escape`, this pr supply it.