### PR TITLE
feat: adjust layout and add virtual scroll for plugin detail table

### DIFF
--- a/packages/devtools-vite/src/app/components/data/PluginDetailsTable.vue
+++ b/packages/devtools-vite/src/app/components/data/PluginDetailsTable.vue
@@ -71,11 +71,6 @@ function toggleDurationSortType() {
 </script>
 
 <template>
-  <!--
-    FIXME:
-    when none selected column, the table virtual list will render many empty rows.
-    next time select some columns, the virtual list will have some render issues
-  -->
   <div role="table" w-full>
     <div role="row" class="sticky top-0 z10 border-b border-base" flex="~ row">
       <div v-if="selectedFields.includes('hookName')" role="columnheader" bg-base flex-none w32 ws-nowrap p1 text-center font-600>
@@ -130,7 +125,7 @@ function toggleDurationSortType() {
     </div>
 
     <DataVirtualList
-      v-if="filtered.length"
+      v-if="filtered.length && selectedFields.length"
       role="rowgroup"
       :items="filtered"
       key-prop="id"
@@ -170,7 +165,12 @@ function toggleDurationSortType() {
     <div v-else>
       <div p4>
         <div w-full h-48 flex="~ items-center justify-center" op50 italic>
-          No data
+          <p v-if="!selectedFields.length">
+            No columns selected
+          </p>
+          <p v-else>
+            No data
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://github.com/vitejs/devtools/pull/80#issuecomment-3190485063

After this pr merged, many list add virtual scroll to optimize render effect with large data. But the plugin detail table do not be handle because it use `<table>` tag. 

@webfansplz said need to refactor the table into a flex layout to support it, and now I try to refactor this table by current pr.

### Screenshot


### PR Content
- refactor the plugin details table into a div base flex
- add aria role to simulate table with flex div layout
- add virtual scroll for plugin detail table
- add none column selected tip
  <img width="1399" height="609" alt="image" src="https://github.com/user-attachments/assets/346273ef-422e-460b-87ba-6095bf8797cf" />

If have any question and optimize suggestion, please comment and tell me anytime!