### PR TITLE
fix: plugin details table width

### DIFF
--- a/packages/devtools-vite/src/app/components/data/PluginDetailsTable.vue
+++ b/packages/devtools-vite/src/app/components/data/PluginDetailsTable.vue
@@ -71,7 +71,7 @@ function toggleDurationSortType() {
 </script>
 
 <template>
-  <div role="table" w-full>
+  <div role="table" min-w-max>
     <div role="row" class="sticky top-0 z10 border-b border-base" flex="~ row">
       <div v-if="selectedFields.includes('hookName')" role="columnheader" bg-base flex-none w32 ws-nowrap p1 text-center font-600>
         Hook name


### PR DESCRIPTION
### Problem

The content in PluginDetailsPage gets clipped when the user's screen isn't wide, just like it:

<img width="848" height="598" alt="with bug" src="https://github.com/user-attachments/assets/23a5e478-90c8-47f5-9959-f0ab8040f96f" />

The refactor of table in #83 caused this issue

### Fixes

Correct the size of table div

<img width="763" height="632" alt="FIxes" src="https://github.com/user-attachments/assets/3c649799-17e8-4707-b65e-2bec23a30f57" />

*Hope this helps!*

