### PR TITLE
 fix: make dropdown scrollable

### DIFF
--- a/packages/devtools-vite/src/app/styles/global.css
+++ b/packages/devtools-vite/src/app/styles/global.css
@@ -63,7 +63,7 @@ summary::-webkit-details-marker {
   --at-apply: text-sm;
 }
 
-.v-popper--theme-dropdown {
+.v-popper--theme-dropdown .v-popper__inner {
   max-width: 50vw;
   max-height: 50vh;
   overflow: auto;


### PR DESCRIPTION
## Problem

Before:
When one module have huge import item, the dropdown menu cannot be scroll and scroll behavior will effect the outer layer.

![20250822183515_rec_](https://github.com/user-attachments/assets/5cd471d1-292e-4118-896d-d9aafbfdd051)

After:
Inner wrapper scroll normally

![img_v3_02pd_6402ae44-c919-4380-9971-f4be53e93a7g](https://github.com/user-attachments/assets/88673e8b-8013-4dac-9e18-1ac561bbb172)

https://github.com/vitejs/devtools/blob/d8e4282e823f843ad8eac3297edf59b79da6903f/packages/devtools-vite/src/app/styles/global.css#L66-L70
Because this style code already existed, I think this is only a tiny error and I fixed it by this pr.