### PR TITLE
fix: correct hover position

### DIFF
--- a/packages/devtools-vite/src/app/components/display/GraphHoverView.vue
+++ b/packages/devtools-vite/src/app/components/display/GraphHoverView.vue
@@ -31,7 +31,7 @@ watch([hoverX, hoverY], ([x, y]) => {
   }
 
   computePosition(virtualEl, hoverElement.value!, {
-    placement: 'bottom-start',
+    placement: 'right-start',
     middleware: [flip(), shift(), offset({
       mainAxis: 8,
       alignmentAxis: 8,


### PR DESCRIPTION
### Problen

#89 used `@floating-ui/dom` to flip and use `left + 10` and `top + 10` to set the hover menu's position. It caused some problems, especially in the `TreeMap` graph and `assets` page, the hover menu will disappear when the mouse in the page's corner

### Fixes

Fixed this bug by using `offset` middleware instead of the number added to the style

The video can show this process


https://github.com/user-attachments/assets/cf1d613d-09af-48da-aef5-b050ad4479b7

