### PR TITLE
chore: improve assets and chunk details display

### DIFF
--- a/packages/devtools-vite/src/app/components/data/AssetDetails.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetails.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Asset as AssetInfo } from '@rolldown/debug'
 import type { RolldownAssetInfo, RolldownChunkInfo, SessionContext } from '~~/shared/types'
+import { useRoute } from '#app/composables/router'
 import { useRpc } from '#imports'
 import { useAsyncState } from '@vueuse/core'
 import { computed, ref } from 'vue'
@@ -18,6 +19,7 @@ const props = withDefaults(defineProps<{
 })
 
 const rpc = useRpc()
+const route = useRoute()
 const showSource = ref(false)
 const { state } = useAsyncState(
   async () => {
@@ -111,14 +113,17 @@ function openInEditor() {
         <div op50>
           Chunks
         </div>
-        <div v-for="chunk of assetChunks" :key="chunk.chunk_id" border="~ base rounded-lg" px2 py1>
+        <NuxtLink
+          v-for="chunk of assetChunks" :key="chunk.chunk_id" border="~ base rounded-lg" px2 py1
+          :to="{ path: route.path, query: { chunk: chunk.chunk_id } }"
+        >
           <DataChunkDetails
             :chunk="chunk"
             :session="session"
             :show-modules="false"
             :show-imports="false"
           />
-        </div>
+        </NuxtLink>
       </div>
       <template v-if="_importers?.length || _imports?.length">
         <div flex="~ col gap-2">

--- a/packages/devtools-vite/src/app/components/data/AssetDetails.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetails.vue
@@ -81,6 +81,7 @@ function openInEditor() {
           <div i-ph-file-text />
           View source
         </button>
+        <slot />
       </div>
     </div>
 

--- a/packages/devtools-vite/src/app/components/data/AssetDetailsLoader.vue
+++ b/packages/devtools-vite/src/app/components/data/AssetDetailsLoader.vue
@@ -52,11 +52,11 @@ const { state } = useAsyncState(
 </script>
 
 <template>
-  <div v-if="state?.asset" p4 relative h-full w-full of-auto pt12 bg-glass z-panel-content>
-    <DisplayCloseButton
-      absolute right-2 top-1.5
-      @click="emit('close')"
-    />
-    <DataAssetDetails :asset="state.asset" :session="session" :chunks="state?.chunks" :importers="state?.importers" :imports="state?.imports" />
+  <div v-if="state?.asset" p4 relative h-full w-full of-auto bg-glass z-panel-content>
+    <DataAssetDetails :asset="state.asset" :session="session" :chunks="state?.chunks" :importers="state?.importers" :imports="state?.imports">
+      <DisplayCloseButton
+        @click="emit('close')"
+      />
+    </DataAssetDetails>
   </div>
 </template>

--- a/packages/devtools-vite/src/app/components/data/ChunkDetails.vue
+++ b/packages/devtools-vite/src/app/components/data/ChunkDetails.vue
@@ -33,6 +33,7 @@ withDefaults(defineProps<{
         <div i-ph-package-duotone />
         {{ chunk.modules.length }}
       </div>
+      <slot />
     </div>
 
     <template v-if="showImports && chunk.imports.length > 0">

--- a/packages/devtools-vite/src/app/components/data/ChunkDetailsLoader.vue
+++ b/packages/devtools-vite/src/app/components/data/ChunkDetailsLoader.vue
@@ -27,11 +27,11 @@ const { state, isLoading } = useAsyncState(
 <template>
   <VisualLoading v-if="isLoading" />
 
-  <div v-if="state" p4 pt-12 relative h-full w-full of-auto z-panel-content>
-    <DisplayCloseButton
-      absolute right-2 top-1.5
-      @click="emit('close')"
-    />
-    <DataChunkDetails :session="session" :chunk="state" />
+  <div v-if="state" p4 relative h-full w-full of-auto z-panel-content>
+    <DataChunkDetails :session="session" :chunk="state">
+      <DisplayCloseButton
+        @click="emit('close')"
+      />
+    </DataChunkDetails>
   </div>
 </template>

--- a/packages/devtools-vite/src/app/components/display/ModuleId.vue
+++ b/packages/devtools-vite/src/app/components/display/ModuleId.vue
@@ -49,7 +49,7 @@ const containerClass = computed(() => {
 <template>
   <component
     :is="link ? NuxtLink : 'div'"
-    :to="link ? (typeof link === 'string' ? link : { path: route.path, query: { ...route.query, module: id }, hash: location.hash }) : undefined"
+    :to="link ? (typeof link === 'string' ? link : { path: route.path, query: { ...route.query, module: id, chunk: undefined }, hash: location.hash }) : undefined"
   >
     <Tooltip
       my-auto text-sm font-mono block w-full


### PR DESCRIPTION
This PR includes the change in these following aspect

1. Fixed `chunk` in `route.query` to avoid details panel overlapping 
2. Improve the position of the close button in `ChunkDetails` and `AssetsDetails` to make it more reasonable
3. Added link in `AssetsDetails` that navigates to `ChunkDetails` panel

Screenshot:

<img width="1047" height="534" alt="Assets Details" src="https://github.com/user-attachments/assets/84f276b8-3877-4ad2-9211-3f07cfb37249" />
<img width="1136" height="398" alt="Chunk Details" src="https://github.com/user-attachments/assets/e2639830-8c9e-4769-b82b-3c71eb6654b3" />
