### PR TITLE
chore(devtools-vite): adjust ui

### DIFF
--- a/packages/devtools-vite/src/app/pages/session/[session].vue
+++ b/packages/devtools-vite/src/app/pages/session/[session].vue
@@ -23,20 +23,11 @@ const rpc = useRpc()
 const router = useRouter()
 const route = useRoute()
 
-function closeFlowPanel() {
-  router.replace({ query: { ...route.query, module: undefined } })
-}
-
-function closeAssetPanel() {
-  router.replace({ query: { ...route.query, asset: undefined } })
-}
-
-function closePluginPanel() {
-  router.replace({ query: { ...route.query, plugin: undefined } })
-}
-
-function closeChunkPanel() {
-  router.replace({ query: { ...route.query, chunk: undefined } })
+const currentPanelType = computed(() => ['module', 'asset', 'plugin', 'chunk'].find(key => typeof route.query[key] !== 'undefined'))
+function closeCurrentPanel() {
+  if (currentPanelType.value) {
+    router.replace({ query: { ...route.query, [currentPanelType.value]: undefined } })
+  }
 }
 
 onKeyDown('Escape', (e) => {
@@ -45,19 +36,7 @@ onKeyDown('Escape', (e) => {
   if (!e.isTrusted || e.repeat)
     return
 
-  const { module, asset, plugin, chunk } = route.query
-
-  if (module)
-    closeFlowPanel()
-
-  if (asset)
-    closeAssetPanel()
-
-  if (plugin)
-    closePluginPanel()
-
-  if (chunk)
-    closeChunkPanel()
+  closeCurrentPanel()
 })
 
 useSideNav(() => {
@@ -128,11 +107,12 @@ onMounted(async () => {
     </div>
 
     <div
-      v-if="route.query.module" fixed inset-0
+      v-if="currentPanelType" fixed inset-0
       backdrop-blur-8 backdrop-brightness-95 z-panel-content
-      @click.self="closeFlowPanel"
+      @click.self="closeCurrentPanel"
     >
       <div
+        v-if="currentPanelType === 'module'"
         :key="(route.query.module as string)"
         fixed right-0 bottom-0 top-20 left-20 z-panel-content
         bg-glass border="l t base rounded-tl-xl"
@@ -140,18 +120,11 @@ onMounted(async () => {
         <DataModuleDetailsLoader
           :module="(route.query.module as string)"
           :session="session"
-          @close="closeFlowPanel"
+          @close="closeCurrentPanel"
         />
       </div>
-    </div>
-
-    <!-- for assets -->
-    <div
-      v-if="route.query.asset" fixed inset-0
-      backdrop-blur-8 backdrop-brightness-95 z-panel-content
-      @click.self="closeAssetPanel"
-    >
       <div
+        v-if="currentPanelType === 'asset'"
         :key="(route.query.asset as string)"
         fixed right-0 bottom-0 top-30 z-panel-content of-hidden
         bg-glass border="l t base rounded-tl-xl"
@@ -160,16 +133,11 @@ onMounted(async () => {
         <DataAssetDetailsLoader
           :asset="(route.query.asset as string)"
           :session="session"
-          @close="closeAssetPanel"
+          @close="closeCurrentPanel"
         />
       </div>
-    </div>
-    <div
-      v-if="route.query.plugin" fixed inset-0
-      backdrop-blur-8 backdrop-brightness-95 z-panel-content
-      @click.self="closePluginPanel"
-    >
       <div
+        v-if="currentPanelType === 'plugin'"
         :key="(route.query.plugin as string)"
         fixed right-0 bottom-0 top-20 left-20 z-panel-content
         bg-glass border="l t base rounded-tl-xl"
@@ -177,18 +145,11 @@ onMounted(async () => {
         <DataPluginDetailsLoader
           :plugin="(route.query.plugin as string)"
           :session="session"
-          @close="closePluginPanel"
+          @close="closeCurrentPanel"
         />
       </div>
-    </div>
-
-    <!-- for chunks -->
-    <div
-      v-if="route.query.chunk" fixed inset-0
-      backdrop-blur-8 backdrop-brightness-95 z-panel-content
-      @click.self="closeChunkPanel"
-    >
       <div
+        v-if="currentPanelType === 'chunk'"
         :key="(route.query.chunk as string)"
         fixed right-0 bottom-0 top-20 z-panel-content
         bg-glass border="l t base rounded-tl-xl"
@@ -197,7 +158,7 @@ onMounted(async () => {
         <DataChunkDetailsLoader
           :chunk="(Number(route.query.chunk))"
           :session="session"
-          @close="closeChunkPanel"
+          @close="closeCurrentPanel"
         />
       </div>
     </div>

--- a/packages/devtools-vite/src/app/pages/session/[session].vue
+++ b/packages/devtools-vite/src/app/pages/session/[session].vue
@@ -90,13 +90,13 @@ useSideNav(() => {
     {
       title: 'Assets',
       to: `/session/${session.id}/assets`,
-      icon: 'i-ph-package-duotone',
+      icon: 'i-ph-files-duotone',
       category: 'session',
     },
     {
       title: 'Packages',
       to: `/session/${session.id}/packages`,
-      icon: 'i-catppuccin-npm',
+      icon: 'i-ph-package-duotone',
       category: 'session',
     },
   ]


### PR DESCRIPTION
This PR includes the change in these following aspect:

- Use more unified and more intuitive icons at side nav (`i-ph-files-duotone` for `assets` page, `i-ph-package-duotone` for `package` page instead of colored `i-catppuccin-npm`)
- Refactored panel logic to reduce repeat codes and avoid panel overlapping

<img width="305" height="358" alt="Current" src="https://github.com/user-attachments/assets/df515e30-ac04-4baf-956e-dd950244264f" />

<img width="234" height="345" alt="Changed" src="https://github.com/user-attachments/assets/6c2e943d-f55f-449a-8e0f-264ded06ed53" />
