### PR TITLE
fix: treemap view hover blinking

### DIFF
--- a/packages/vite/src/app/components/display/GraphHoverView.vue
+++ b/packages/vite/src/app/components/display/GraphHoverView.vue
@@ -46,7 +46,7 @@ watch([hoverX, hoverY], ([x, y]) => {
 
 <template>
   <Teleport to="body">
-    <div ref="hoverElement" fixed z-panel-content :style="{ left: `${left}px`, top: `${top}px` }">
+    <div ref="hoverElement" fixed z-panel-content pointer-events-none :style="{ left: `${left}px`, top: `${top}px` }">
       <slot />
     </div>
   </Teleport>


### PR DESCRIPTION
Add 'pointer-events-none' to Tooltip to prevent it from interfering with Treemap hover events, eliminating flickering when mouse moves quickly." 
Close #109 