### PR TITLE
feat(vite): visualize chunk/assets size in nanovis

### DIFF
--- a/packages/vite/src/app/components/chunks/Flamegraph.vue
+++ b/packages/vite/src/app/components/chunks/Flamegraph.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { GraphBase, GraphBaseOptions } from 'nanovis'
+import type { ChunkChartInfo } from '~/types/chart'
+import { useTemplateRef, watchEffect } from 'vue'
+
+const props = defineProps<{
+  graph: GraphBase<ChunkChartInfo | undefined, GraphBaseOptions<ChunkChartInfo | undefined>>
+}>()
+
+const el = useTemplateRef<HTMLDivElement>('el')
+
+watchEffect(() => el.value?.append(props.graph.el))
+</script>
+
+<template>
+  <div ref="el" />
+</template>

--- a/packages/vite/src/app/components/chunks/Sunburst.vue
+++ b/packages/vite/src/app/components/chunks/Sunburst.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import type { GraphBase, GraphBaseOptions } from 'nanovis'
+import type { ChunkChartInfo, ChunkChartNode } from '~/types/chart'
+import { colorToCssBackground } from 'nanovis'
+import { useTemplateRef, watchEffect } from 'vue'
+
+const props = defineProps<{
+  graph: GraphBase<ChunkChartInfo | undefined, GraphBaseOptions<ChunkChartInfo | undefined>>
+  selected?: ChunkChartNode | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', node: ChunkChartNode | null): void
+}>()
+
+const el = useTemplateRef<HTMLDivElement>('el')
+watchEffect(() => el.value?.append(props.graph.el))
+</script>
+
+<template>
+  <div grid="~ cols-[max-content_1fr] gap-2" p4>
+    <div ref="el" w-500px />
+    <div flex="~ col gap-4">
+      <ChartNavBreadcrumb
+        border="b base" py2
+        :selected="selected"
+        :options="graph.options"
+        @select="emit('select', $event)"
+      />
+      <div v-if="selected" grid="~ cols-[250px_1fr] gap-1">
+        <template v-for="child of selected.children" :key="child.id">
+          <button
+            ws-nowrap text-nowrap text-left overflow-hidden text-ellipsis text-sm
+            hover="bg-active" rounded px2
+            @click="emit('select', child)"
+          >
+            <span v-if="child.meta && child.meta === selected?.meta" text-primary>(self)</span>
+            <span v-else>{{ child.meta?.name || child.id }}</span>
+          </button>
+
+          <button
+            relative flex="~ gap-1 items-center"
+            hover="bg-active" rounded
+            @click="emit('select', child)"
+          >
+            <div
+              h-5 rounded shadow border="~ base"
+              :style="{
+                background: colorToCssBackground(graph.options.getColor?.(child) || '#000'),
+                width: `${child.size / selected.size * 100}%`,
+              }"
+            />
+            <DisplayFileSizeBadge text-xs :bytes="child.size" :total="selected.size" :percent-ratio="3" />
+            <div
+              v-if="child.children.length > 0"
+              v-tooltip="`${child.children.length} modules`"
+              :title="`${child.children.length} modules`"
+              text-xs op-fade
+            >
+              ({{ child.children.length }})
+            </div>
+          </button>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/vite/src/app/pages/session/[session]/chunks.vue
+++ b/packages/vite/src/app/pages/session/[session]/chunks.vue
@@ -1,16 +1,22 @@
 <script setup lang="ts">
 import type { RolldownChunkInfo, SessionContext } from '~~/shared/types/data'
 import type { ClientSettings } from '~/state/settings'
+import type { ChunkChartInfo, ChunkChartNode } from '~/types/chart'
 import { useRpc } from '#imports'
-import { computedWithControl, useAsyncState } from '@vueuse/core'
+import { computedWithControl, useAsyncState, useMouse } from '@vueuse/core'
 import Fuse from 'fuse.js'
-import { computed, ref } from 'vue'
+import { Flamegraph, Sunburst, Treemap } from 'nanovis'
+import { computed, reactive, ref, watch } from 'vue'
+import ChartTreemap from '~/components/chart/Treemap.vue'
+import { useChartGraph } from '~/composables/chart'
 import { useGraphPathManager } from '~/composables/graph-path-selector'
 import { settings } from '~/state/settings'
 
 const props = defineProps<{
   session: SessionContext
 }>()
+
+const mouse = reactive(useMouse())
 
 const chunkViewTypes = [
   {
@@ -27,6 +33,21 @@ const chunkViewTypes = [
     label: 'Graph',
     value: 'graph',
     icon: 'i-ph-graph-duotone',
+  },
+  {
+    label: 'Treemap',
+    value: 'treemap',
+    icon: 'i-ph-checkerboard-duotone',
+  },
+  {
+    label: 'Sunburst',
+    value: 'sunburst',
+    icon: 'i-ph-chart-donut-duotone',
+  },
+  {
+    label: 'Flamegraph',
+    value: 'flamegraph',
+    icon: 'i-ph-chart-bar-horizontal-duotone',
   },
 ] as const
 
@@ -89,6 +110,95 @@ const { pathSelectorVisible, pathNodes, selectPathNodes, togglePathSelector, nor
 function toggleDisplay(type: ClientSettings['chunkViewType']) {
   settings.value.chunkViewType = type
 }
+
+// Calculate chunk size from modules
+const modulesMap = computed(() => {
+  const map = new Map()
+  for (const module of props.session.modulesList) {
+    map.set(module.id, module)
+  }
+  return map
+})
+
+function getChunkSize(chunk: RolldownChunkInfo): number {
+  // First try to use asset size if available
+  if (chunk.asset?.size) {
+    return chunk.asset.size
+  }
+
+  // Otherwise, calculate from module transforms
+  return chunk.modules.reduce((total, id) => {
+    const moduleInfo = modulesMap.value.get(id)
+    if (!moduleInfo || !moduleInfo.buildMetrics?.transforms?.length)
+      return total
+
+    const transforms = moduleInfo.buildMetrics.transforms
+    return total + transforms[transforms.length - 1]!.transformed_code_size
+  }, 0)
+}
+
+// Normalize chunks with size for chart visualization
+const chunksWithSize = computed(() => {
+  return searched.value.map(chunk => ({
+    ...chunk,
+    filename: chunk.name || `chunk-${chunk.chunk_id}`,
+    size: getChunkSize(chunk),
+  }))
+})
+
+// Chart graph setup for nanovis visualizations
+const { tree, chartOptions, graph, nodeHover, nodeSelected, selectedNode, selectNode, buildGraph } = useChartGraph<
+  RolldownChunkInfo & { id: string, filename: string, size: number },
+  ChunkChartInfo,
+  ChunkChartNode
+>({
+  data: chunksWithSize,
+  nameKey: 'filename',
+  sizeKey: 'size',
+  rootText: 'Chunks',
+  nodeType: 'chunk',
+  graphOptions: {
+    onClick(node) {
+      if (node)
+        nodeHover.value = node
+    },
+    onHover(node) {
+      if (node)
+        nodeHover.value = node
+      if (node === null)
+        nodeHover.value = undefined
+    },
+    onLeave() {
+      nodeHover.value = undefined
+    },
+    onSelect(node) {
+      nodeSelected.value = node || tree.value.root
+      selectedNode.value = node?.meta
+    },
+  },
+  onUpdate() {
+    switch (settings.value.chunkViewType) {
+      case 'sunburst':
+        graph.value = new Sunburst(tree.value.root, chartOptions.value)
+        break
+      case 'treemap':
+        graph.value = new Treemap(tree.value.root, {
+          ...chartOptions.value,
+          selectedPaddingRatio: 0,
+        })
+        break
+      case 'flamegraph':
+        graph.value = new Flamegraph(tree.value.root, chartOptions.value)
+        break
+    }
+  },
+})
+
+watch(() => settings.value.chunkViewType, () => {
+  if (['treemap', 'sunburst', 'flamegraph'].includes(settings.value.chunkViewType)) {
+    buildGraph()
+  }
+})
 </script>
 
 <template>
@@ -166,5 +276,64 @@ function toggleDisplay(type: ClientSettings['chunkViewType']) {
         :entry-id="pathNodes.start"
       />
     </template>
+    <template v-else-if="settings.chunkViewType === 'treemap'">
+      <div of-auto h-screen flex="~ col gap-2" pt32>
+        <ChartTreemap
+          v-if="graph" :graph="graph"
+          :selected="nodeSelected"
+          @select="x => selectNode(x)"
+        >
+          <template #default="{ selected, options, onSelect }">
+            <ChartNavBreadcrumb
+              border="b base" py2 min-h-10
+              :selected="selected"
+              :options="options"
+              @select="onSelect"
+            />
+          </template>
+        </ChartTreemap>
+      </div>
+    </template>
+    <template v-else-if="settings.chunkViewType === 'sunburst'">
+      <div of-auto h-screen flex="~ col gap-2" pt32>
+        <ChunksSunburst
+          v-if="graph" :graph="graph"
+          :selected="nodeSelected"
+          @select="x => selectNode(x)"
+        />
+      </div>
+    </template>
+    <template v-else-if="settings.chunkViewType === 'flamegraph'">
+      <div of-auto h-screen flex="~ col gap-2" pt32>
+        <ChunksFlamegraph
+          v-if="graph" :graph="graph"
+        />
+      </div>
+    </template>
+    <DisplayGraphHoverView :hover-x="mouse.x" :hover-y="mouse.y">
+      <div
+        v-if="nodeHover?.meta"
+        border="~ base rounded-lg" bg-base p2
+        flex="~ col gap-2"
+        min-w-50
+        shadow-lg
+      >
+        <div flex="~ gap-2 items-center">
+          <i i-ph-shapes-duotone flex-none />
+          <span truncate>{{ nodeHover.meta.name || '[unnamed]' }}</span>
+        </div>
+        <div flex="~ gap-2 items-center">
+          <span op50 text-xs>Size:</span>
+          <DisplayFileSizeBadge :bytes="nodeHover.meta.size" text-xs />
+        </div>
+        <div v-if="nodeHover.meta.modules?.length" flex="~ gap-2 items-center">
+          <span op50 text-xs>Modules:</span>
+          <span text-xs>{{ nodeHover.meta.modules?.length }}</span>
+        </div>
+        <div v-if="nodeHover.meta.is_initial" flex="~ gap-2 items-center">
+          <DisplayBadge text="initial" />
+        </div>
+      </div>
+    </DisplayGraphHoverView>
   </div>
 </template>

--- a/packages/vite/src/app/state/settings.ts
+++ b/packages/vite/src/app/state/settings.ts
@@ -22,7 +22,7 @@ export interface ClientSettings {
   pluginDetailsModuleTypes: string[] | null
   pluginDetailsDurationSortType: string
   pluginDetailSelectedHook: string
-  chunkViewType: 'list' | 'detailed-list' | 'graph'
+  chunkViewType: 'list' | 'detailed-list' | 'graph' | 'treemap' | 'sunburst' | 'flamegraph'
   pluginDetailsShowType: 'changed' | 'unchanged' | 'all'
   packageViewType: 'table' | 'treemap' | 'duplicate-packages'
   packageSizeSortType: string

--- a/packages/vite/src/app/types/chart.ts
+++ b/packages/vite/src/app/types/chart.ts
@@ -1,5 +1,5 @@
 import type { TreeNode } from 'nanovis'
-import type { PackageInfo, PluginBuildInfo, RolldownAssetInfo } from '~~/shared/types'
+import type { PackageInfo, PluginBuildInfo, RolldownAssetInfo, RolldownChunkInfo } from '~~/shared/types'
 
 export type AssetChartInfo = Omit<RolldownAssetInfo, 'type'> & {
   path: string
@@ -7,6 +7,14 @@ export type AssetChartInfo = Omit<RolldownAssetInfo, 'type'> & {
 }
 
 export type AssetChartNode = TreeNode<AssetChartInfo | undefined>
+
+export type ChunkChartInfo = Omit<RolldownChunkInfo, 'type'> & {
+  path: string
+  type: 'folder' | 'chunk'
+  size: number
+}
+
+export type ChunkChartNode = TreeNode<ChunkChartInfo | undefined>
 
 export type PackageChartInfo = PackageInfo & {
   path: string


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR implements the "Visualize chunk/assets size in nanovis" feature from #9.

### Changes

Adds three new visualization options for chunks in the session view:

- **Treemap** - Nested rectangles showing chunk sizes proportionally
- **Sunburst** - Radial donut chart with drill-down navigation  
- **Flamegraph** - Horizontal bar chart hierarchy

### Implementation

- Extended `chunkViewType` settings to include `'treemap' | 'sunburst' | 'flamegraph'`
- Added `ChunkChartInfo` and `ChunkChartNode` types for chart data
- Created Sunburst.vue and Flamegraph.vue components in `components/chunks/`
- Updated chunks.vue page with:
  - View type selector buttons for the new visualizations
  - Chunk size calculation (from asset size or module transforms)
  - `useChartGraph` composable integration
  - Hover tooltip showing chunk details (name, size, modules, initial badge)

### Linked Issues

#9 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
