### PR TITLE
fix(core): hide elements out of dock panel

### DIFF
--- a/packages/core/src/client/webcomponents/components/DockPanel.vue
+++ b/packages/core/src/client/webcomponents/components/DockPanel.vue
@@ -163,7 +163,7 @@ onMounted(() => {
   <div
     v-show="context.docks.selected && context.docks.selected.type !== 'action'"
     ref="dockPanel"
-    class="bg-glass:75 rounded-lg border border-base shadow"
+    class="bg-glass:75 rounded-lg border border-base shadow overflow-hidden"
     :style="panelStyle"
   >
     <DockPanelResizer :panel="context.panel" />


### PR DESCRIPTION
Before: 
<img width="1012" height="305" alt="Before" src="https://github.com/user-attachments/assets/ec4a058c-9b8e-4fea-bac4-2f2be8474b8c" />
