### PR TITLE
fix: prevent hiding settings entry in DockContextMenu

### DIFF
--- a/packages/core/src/client/webcomponents/components/DockContextMenu.ts
+++ b/packages/core/src/client/webcomponents/components/DockContextMenu.ts
@@ -48,6 +48,8 @@ function refreshDock(context: DocksContext, entry: DevToolsDockEntry) {
 }
 
 function canHide(context: DocksContext, entry: DevToolsDockEntry) {
+  if (entry.id === '~settings')
+    return false
   return context.docks.entries.some(item => item.id === entry.id)
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

If Settings gets accidentally hidden, there’s no way to show it again.

- Fix a bug where the Settings dock entry (`~settings`) could be hidden via the right-click context menu, with no way to 
  show it again
- The Settings view is the only UI for managing dock entry visibility, so hiding it creates a dead-end
- Updated `canHide()` in `DockContextMenu.ts` to return `false` for the `~settings` entry

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
