### PR TITLE
feat: add `authId` option to `DevToolsOptions`

### DIFF
--- a/packages/core/playground/vite.config.ts
+++ b/packages/core/playground/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     // For local playground only. As a user you don't install this plugin directly.
     DevTools({
       builtinDevTools: false,
+      authId: 'test-fixed-auth-id',
     }),
     DevToolsRolldownUI(),
     UnoCSS(),

--- a/packages/core/src/node/plugins/index.ts
+++ b/packages/core/src/node/plugins/index.ts
@@ -9,16 +9,21 @@ export interface DevToolsOptions {
    * @default true
    */
   builtinDevTools?: boolean
+  /**
+   * Use a fixed auth id for all clients connecting to the devtools.
+   */
+  authId?: string
 }
 
 export async function DevTools(options: DevToolsOptions = {}): Promise<Plugin[]> {
   const {
     builtinDevTools = true,
+    authId,
   } = options
 
   const plugins = [
     DevToolsInjection(),
-    DevToolsServer(),
+    DevToolsServer({ authId }),
   ]
 
   if (builtinDevTools) {

--- a/packages/core/src/node/plugins/server.ts
+++ b/packages/core/src/node/plugins/server.ts
@@ -34,7 +34,11 @@ export function renderDockImportsMap(docks: Iterable<DevToolsDockEntry>): string
   ].join('\n')
 }
 
-export function DevToolsServer(): Plugin {
+export interface DevToolsServerOptions {
+  authId?: string
+}
+
+export function DevToolsServer(options: DevToolsServerOptions = {}): Plugin {
   let context: DevToolsNodeContext
   return {
     name: 'vite:devtools:server',
@@ -51,6 +55,7 @@ export function DevToolsServer(): Plugin {
         cwd: viteDevServer.config.root,
         hostWebSocket: host,
         context,
+        authId: options.authId,
       })
       viteDevServer.middlewares.use(DEVTOOLS_MOUNT_PATH, middleware)
     },

--- a/packages/core/src/node/ws.ts
+++ b/packages/core/src/node/ws.ts
@@ -20,6 +20,7 @@ export interface CreateWsServerOptions {
   hostWebSocket: string
   base?: string
   context: DevToolsNodeContext
+  authId?: string
 }
 
 const ANONYMOUS_SCOPE = 'vite:anonymous:'
@@ -117,6 +118,7 @@ export async function createWsServer(options: CreateWsServerOptions) {
     return {
       backend: 'websocket',
       websocket: port,
+      ...(options.authId ? { authId: options.authId } : {}),
     }
   }
 

--- a/packages/kit/src/client/rpc.ts
+++ b/packages/kit/src/client/rpc.ts
@@ -184,7 +184,7 @@ export async function getDevToolsRpcClient(
   const context: DevToolsClientContext = {
     rpc: undefined!,
   }
-  const authId = getConnectionAuthIdFromWindows(options.authId)
+  const authId = getConnectionAuthIdFromWindows(options.authId ?? connectionMeta.authId)
   const clientRpc: DevToolsClientRpcHost = new RpcFunctionsCollectorBase<DevToolsRpcClientFunctions, DevToolsClientContext>(context)
 
   async function fetchJsonFromBases(path: string): Promise<any> {

--- a/packages/kit/src/types/vite-plugin.ts
+++ b/packages/kit/src/types/vite-plugin.ts
@@ -86,4 +86,5 @@ export interface DevToolsNodeUtils {
 export interface ConnectionMeta {
   backend: 'websocket' | 'static'
   websocket?: number | string
+  authId?: string
 }


### PR DESCRIPTION
### Description

Allow pre-configuring a `authId` for websocket RPC client

### Why need?

I am attempting to connect to the DevTools WebSocket from a third-party server, which requires a specific `authId`. 
So that I can send servers(BFF, Backend) logs to the DevTools.