### PR TITLE
feat: move auth storage to global user directory

### DIFF
--- a/packages/core/src/node/context-internal.ts
+++ b/packages/core/src/node/context-internal.ts
@@ -1,5 +1,6 @@
 import type { DevToolsNodeContext } from '@vitejs/devtools-kit'
 import type { SharedState } from '@vitejs/devtools-kit/utils/shared-state'
+import { homedir } from 'node:os'
 import { join } from 'pathe'
 import { createStorage } from './storage'
 
@@ -25,7 +26,7 @@ export function getInternalContext(context: DevToolsNodeContext): DevToolsIntern
     const internalContext: DevToolsInternalContext = {
       storage: {
         auth: createStorage<InternalAnonymousAuthStorage>({
-          filepath: join(context.workspaceRoot, 'node_modules/.vite/devtools/auth.json'),
+          filepath: join(homedir(), '.vite/devtools/auth.json'),
           initialValue: {
             trusted: {},
           },


### PR DESCRIPTION
### Description

Move trusted client authentication storage from per-project (`node_modules/.vite/devtools/auth.json`) to global user directory (`~/.vite/devtools/auth.json`). This allows clients to remain trusted across multiple projects without needing to re-authenticate for each one.

### Linked Issues

None

### Additional context

The change affects only the auth storage path in `packages/core/src/node/context-internal.ts`. The storage mechanism and all other authentication logic remain unchanged.