### PR TITLE
fix: defer logs RPC call until client is authorized

### DIFF
--- a/packages/core/src/client/webcomponents/state/logs.ts
+++ b/packages/core/src/client/webcomponents/state/logs.ts
@@ -62,10 +62,13 @@ export function useLogs(context: DocksContext): Reactive<LogsState> {
   context.rpc.client.register({
     name: 'devtoolskit:internal:logs:updated' satisfies keyof DevToolsRpcClientFunctions,
     type: 'action',
-    handler: () => updateLogs(),
+    handler: () => {
+      if (context.rpc.isTrusted)
+        updateLogs()
+    },
   })
 
-  updateLogs()
+  context.rpc.ensureTrusted().then(() => updateLogs())
   return state
 }
 


### PR DESCRIPTION
## Description

Prevents unauthorized RPC errors when connecting to DevTools. The client trust request fires asynchronously in the background, but `useLogs()` was calling `devtoolskit:internal:logs:list` synchronously on component mount, before trust was established. This caused "Unauthorized access" errors.

Now guards the initial logs query with `ensureTrusted()`, matching the pattern used by shared state. Also guards the server-push handler to prevent logs:updated events from triggering unauthorized calls.

## Changes

- Defer initial `updateLogs()` call until `ensureTrusted()` resolves
- Guard the `logs:updated` RPC handler to skip updates while untrusted

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)