### PR TITLE
docs: replace `rolldown-vite` with `Vite 8+`

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -5,8 +5,8 @@ outline: deep
 # Getting Started
 
 > [!WARNING]
-> Vite DevTools currently only supports Vite-Rolldown's build mode.
-> Dev mode and normal Vite are not supported yet.
+> Vite DevTools currently only supports build mode of Vite 8+.
+> Dev mode and Vite versions under 8 are not supported yet.
 
 ## What is Vite DevTools?
 
@@ -113,7 +113,7 @@ Now that you have Vite DevTools set up, you can:
 
 - **Build mode only**: Currently works with Vite-Rolldown's build mode
 - **Dev mode**: Not yet supported (planned for future releases)
-- **Standard Vite**: Requires Rolldown Vite for now
+- **Vite Version**: Requires Vite 8 or higher versions for now
 
 ## Architecture Overview
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Just replace some words like `Rolldown Vite` `Standard Vite` to `Vite 8+` and `Vite versions under 8` since Vite 8 is [offically released](https://github.com/vitejs/vite/releases/tag/v8.0.0).