### PR TITLE
fix(vite): truncate text in homepage

### DIFF
--- a/packages/vite/src/app/pages/home.vue
+++ b/packages/vite/src/app/pages/home.vue
@@ -140,7 +140,7 @@ const metadata = computed(() => [
             <div>
               {{ row.label }}
             </div>
-            <div font-mono>
+            <div font-mono truncate>
               {{ row.value }}
             </div>
           </div>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

small PR to truncate text in vite's homepage so it's responsive

### Linked Issues

### Additional context

| Before | After |
|--------|--------|
| <img width="618" height="936" alt="Screenshot 2026-03-19 at 6 56 14 PM" src="https://github.com/user-attachments/assets/282d634a-b521-4c2e-b8b3-2695e505dbc1" /> | <img width="618" height="936" alt="Screenshot 2026-03-19 at 6 55 41 PM" src="https://github.com/user-attachments/assets/93329755-15f2-43a0-8d4a-719d5ea1956f" /> | 
