### PR TITLE
fix(core): correct dock separator orientation in edge mode

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockEntriesWithCategories.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntriesWithCategories.vue
@@ -22,7 +22,7 @@ const emit = defineEmits<{
 <template>
   <template v-for="[category, entries], idx of groups" :key="category">
     <slot v-if="idx > 0" name="separator" :category="category" :index="idx" :is-vertical="isVertical">
-      <div class="border-base m1 h-20px w-px border-r-1.5" />
+      <div class="border-base m1" :class="isVertical && !rotate ? 'w-20px h-px border-b-1.5' : 'h-20px w-px border-r-1.5'" />
     </slot>
     <DockEntries
       :context="context"


### PR DESCRIPTION
### Description

When without rotating (edge mode) and in vertical position, the separator should be horizontal.

| Before | After |
|--------|--------|
| <img width="1288" height="1450" alt="屏幕截图 2026-03-20 182210" src="https://github.com/user-attachments/assets/acc0edf8-68d5-4b20-a28f-63125bbca669" />| <img width="1315" height="1454" alt="屏幕截图 2026-03-20 182243" src="https://github.com/user-attachments/assets/c8306fcb-92c0-421f-8a07-242e26e579fe" />|


