### PR TITLE
chore(vscode): hide `docs` and `examples` in npm scripts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,7 @@
     "json",
     "jsonc",
     "yaml"
-  ]
+  ],
+
+  "npm.exclude": "**/{docs,examples/**}"
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Since VSCode displays npm scripts from all packages in a monorepo, this makes for a bit of a messy developer experience. This PR hides the scripts under `docs` and `examples`:
- The scripts in `docs` are already mapped in the root `package.json`
- The `examples` aren’t frequently used

Feel free to close this if you don't think it's necessary.

Now:
<img width="323" height="232" alt="image" src="https://github.com/user-attachments/assets/51c1a066-f48b-46f9-837f-e9a1eeeb5f74" />


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
