### PR TITLE
refactor: use descriptive namespace for json-render state key

### DIFF
--- a/packages/core/src/node/context.ts
+++ b/packages/core/src/node/context.ts
@@ -60,7 +60,7 @@ export async function createDevToolsContext(
   // json-render factory
   let jrCounter = 0
   context.createJsonRenderer = (initialSpec: JsonRenderSpec): JsonRenderer => {
-    const stateKey = `__jr:${jrCounter++}`
+    const stateKey = `devtoolskit:internal:json-render:${jrCounter++}`
     const statePromise = rpcHost.sharedState.get(stateKey as any, {
       initialValue: initialSpec as any,
     })


### PR DESCRIPTION
### Description

Rename the internal shared state key for json-render from the cryptic `__jr:<id>` to a more descriptive and properly namespaced `devtoolskit:internal:json-render:<id>`. This improves code clarity and reduces the risk of accidental namespace collisions with other internal state keys.

### Linked Issues

None

### Additional context

No breaking changes — the key is only constructed in one place and dynamically read by clients via `_stateKey`.