### PR TITLE
fix: refactor docks grouping logic in ViewBuiltinSettings

### DIFF
--- a/packages/core/src/client/webcomponents/components/views-builtin/ViewBuiltinSettings.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/ViewBuiltinSettings.vue
@@ -125,7 +125,6 @@ function moveOrder(category: string, id: string, delta: number) {
     throw new Error(`Invalid new index ${newIndex} for category ${category}`)
 
   array.splice(newIndex, 0, array.splice(index, 1)[0]!)
-  items[1] = array
 
   settingsStore.mutate((state) => {
     array.forEach((item, index) => {


### PR DESCRIPTION
I think Settings should not be added, because if the user selects it and then closes the panel, they will permanently lose access to Settings.

I think Settings should be separated out.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
