### PR TITLE
docs: add commands and when clauses agent skills

### DIFF
--- a/skills/vite-devtools-kit/SKILL.md
+++ b/skills/vite-devtools-kit/SKILL.md
@@ -25,6 +25,7 @@ A DevTools plugin extends a Vite plugin with a `devtools.setup(ctx)` hook. The c
 | `ctx.logs` | Emit structured log entries and toast notifications |
 | `ctx.terminals` | Spawn and manage child processes with streaming terminal output |
 | `ctx.createJsonRenderer` | Create server-side JSON render specs for zero-client-code UIs |
+| `ctx.commands` | Register executable commands with keyboard shortcuts and palette visibility |
 | `ctx.viteConfig` | Resolved Vite configuration |
 | `ctx.viteServer` | Dev server instance (dev mode only) |
 | `ctx.mode` | `'dev'` or `'build'` |
@@ -107,12 +108,13 @@ export default function myAnalyzer(): Plugin {
 
 ## Namespacing Convention
 
-**CRITICAL**: Always prefix RPC functions, shared state keys, and dock IDs with your plugin name:
+**CRITICAL**: Always prefix RPC functions, shared state keys, dock IDs, and command IDs with your plugin name:
 
 ```ts
 // Good - namespaced
 'my-plugin:get-modules'
 'my-plugin:state'
+'my-plugin:clear-cache'  // command ID
 
 // Bad - may conflict
 'get-modules'
@@ -253,6 +255,27 @@ await session.restart()
 ```
 
 A common pattern is combining with launcher docks — see [Terminals Patterns](./references/terminals-patterns.md).
+
+## Commands & Command Palette
+
+Register executable commands discoverable via `Mod+K` palette:
+
+```ts
+import { defineCommand } from '@vitejs/devtools-kit'
+
+ctx.commands.register(defineCommand({
+  id: 'my-plugin:clear-cache',
+  title: 'Clear Build Cache',
+  icon: 'ph:trash-duotone',
+  keybindings: [{ key: 'Mod+Shift+C' }],
+  when: 'clientType == embedded',
+  handler: async () => { /* ... */ },
+}))
+```
+
+Commands support sub-commands (two-level hierarchy), conditional visibility via `when` clauses, and user-customizable keyboard shortcuts.
+
+See [Commands Patterns](./references/commands-patterns.md) and [When Clauses](./references/when-clauses.md) for full details.
 
 ## Logs & Notifications
 
@@ -498,6 +521,8 @@ export default defineConfig({
 6. **Use Iconify icons** - Prefer `ph:*` (Phosphor) icons: `icon: 'ph:chart-bar-duotone'`
 7. **Deduplicate logs** - Use explicit `id` for logs representing ongoing operations
 8. **Use Self-Inspect** - Add `@vitejs/devtools-self-inspect` during development to debug your plugin
+9. **Namespace command IDs** - Use `my-plugin:action` pattern for command IDs, same as RPC and state
+10. **Use `when` clauses** - Conditionally show commands/docks with `when` expressions instead of programmatic show/hide
 
 ## Example Plugins
 
@@ -516,3 +541,5 @@ Real-world example plugins in the repo — reference their code structure and pa
 - [JSON Render Patterns](./references/json-render-patterns.md) - Server-side JSON specs, components, state binding
 - [Terminals Patterns](./references/terminals-patterns.md) - Child processes, custom streams, session lifecycle
 - [Logs Patterns](./references/logs-patterns.md) - Log entries, toast notifications, and handle patterns
+- [Commands Patterns](./references/commands-patterns.md) - Command registration, sub-commands, keybindings, palette integration
+- [When Clauses](./references/when-clauses.md) - Conditional expression syntax, context variables, API reference

--- a/skills/vite-devtools-kit/references/commands-patterns.md
+++ b/skills/vite-devtools-kit/references/commands-patterns.md
@@ -1,0 +1,241 @@
+# Commands & Command Palette
+
+Register executable commands discoverable through a built-in palette with keyboard shortcuts.
+
+## Defining Commands
+
+```ts
+import { defineCommand } from '@vitejs/devtools-kit'
+
+const clearCache = defineCommand({
+  id: 'my-plugin:clear-cache',
+  title: 'Clear Build Cache',
+  description: 'Remove all cached build artifacts',
+  icon: 'ph:trash-duotone',
+  category: 'tools',
+  handler: async () => {
+    await fs.rm('.cache', { recursive: true })
+  },
+})
+
+// Register in plugin setup
+ctx.commands.register(clearCache)
+```
+
+## Command Options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | **Required.** Unique namespaced ID (e.g. `my-plugin:action`) |
+| `title` | `string` | **Required.** Human-readable title shown in the palette |
+| `description` | `string` | Optional description text |
+| `icon` | `string` | Iconify icon string (e.g. `ph:trash-duotone`) |
+| `category` | `string` | Category for grouping |
+| `showInPalette` | `boolean \| 'without-children'` | Whether to show in command palette (default: `true`). `'without-children'` shows the command but doesn't flatten children into search — only accessible via drill-down. |
+| `when` | `string` | Conditional visibility expression — see [When Clauses](./when-clauses.md) |
+| `keybindings` | `DevToolsCommandKeybinding[]` | Default keyboard shortcuts |
+| `handler` | `Function` | Server-side handler. Optional if the command is a group for children. |
+| `children` | `DevToolsServerCommandInput[]` | Static sub-commands (two levels max) |
+
+## Command Handle
+
+`register()` returns a handle for live updates:
+
+```ts
+const handle = ctx.commands.register({
+  id: 'my-plugin:status',
+  title: 'Show Status',
+  handler: () => { /* ... */ },
+})
+
+// Update later
+handle.update({ title: 'Show Status (3 items)' })
+
+// Remove
+handle.unregister()
+```
+
+## Sub-Commands
+
+Two-level hierarchy. Selecting a parent in the palette drills down into its children.
+
+```ts
+ctx.commands.register({
+  id: 'git',
+  title: 'Git',
+  icon: 'ph:git-branch-duotone',
+  category: 'tools',
+  // No handler — group-only parent
+  children: [
+    {
+      id: 'git:commit',
+      title: 'Commit',
+      icon: 'ph:check-duotone',
+      keybindings: [{ key: 'Mod+Shift+G' }],
+      handler: async () => { /* ... */ },
+    },
+    {
+      id: 'git:push',
+      title: 'Push',
+      handler: async () => { /* ... */ },
+    },
+  ],
+})
+```
+
+Each child must have a globally unique `id`. Use the pattern `parentId:childAction` (e.g. `git:commit`).
+
+Sub-commands with keybindings can be executed directly via the shortcut without opening the palette.
+
+## Keyboard Shortcuts
+
+### Key Format
+
+Use `Mod` as a platform-aware modifier — maps to `Cmd` on macOS and `Ctrl` on other platforms.
+
+| Key string | macOS | Windows/Linux |
+|------------|-------|---------------|
+| `Mod+K` | `Cmd+K` | `Ctrl+K` |
+| `Mod+Shift+P` | `Cmd+Shift+P` | `Ctrl+Shift+P` |
+| `Alt+N` | `Option+N` | `Alt+N` |
+
+```ts
+ctx.commands.register(defineCommand({
+  id: 'my-plugin:toggle-overlay',
+  title: 'Toggle Overlay',
+  keybindings: [{ key: 'Mod+Shift+O' }],
+  handler: () => { /* ... */ },
+}))
+```
+
+### User Overrides
+
+Users can customize shortcuts in Settings > **Keyboard Shortcuts**. Overrides persist across sessions. Setting an empty array disables a shortcut.
+
+The shortcut editor includes:
+- **Key capture** — click the input and press any key combination
+- **Modifier toggles** — toggle Cmd/Ctrl, Alt, Shift individually
+- **Conflict detection** — warns on browser shortcut conflicts, duplicate bindings, and weak shortcuts (single key without modifiers)
+
+`KNOWN_BROWSER_SHORTCUTS` is exported from `@vitejs/devtools-kit` and maps key combinations to human-readable descriptions.
+
+## Conditional Visibility
+
+Commands support a `when` expression for conditional visibility:
+
+```ts
+ctx.commands.register(defineCommand({
+  id: 'my-plugin:embedded-only',
+  title: 'Embedded-Only Action',
+  when: 'clientType == embedded',
+  handler: async () => { /* ... */ },
+}))
+```
+
+When set, the command only appears in the palette and is only triggerable via shortcuts when the expression evaluates to `true`.
+
+See [When Clauses](./when-clauses.md) for full syntax reference and context variables.
+
+## Client-Side Commands
+
+Client commands register in the webcomponent context and execute directly in the browser:
+
+```ts
+context.commands.register({
+  id: 'devtools:theme',
+  source: 'client',
+  title: 'Theme',
+  icon: 'ph:palette-duotone',
+  children: [
+    {
+      id: 'devtools:theme:light',
+      source: 'client',
+      title: 'Light',
+      action: () => setTheme('light'),
+    },
+    {
+      id: 'devtools:theme:dark',
+      source: 'client',
+      title: 'Dark',
+      action: () => setTheme('dark'),
+    },
+  ],
+})
+```
+
+Client commands can return dynamic sub-items:
+
+```ts
+context.commands.register({
+  id: 'devtools:docs',
+  source: 'client',
+  title: 'Documentation',
+  action: async () => {
+    const docs = await fetchDocs()
+    return docs.map(doc => ({
+      id: `docs:${doc.slug}`,
+      source: 'client' as const,
+      title: doc.title,
+      action: () => window.open(doc.url, '_blank'),
+    }))
+  },
+})
+```
+
+## Command Palette
+
+Built-in palette toggled with `Mod+K`. Features:
+
+- **Fuzzy search** across all registered commands (including sub-commands)
+- **Keyboard navigation** — Arrow keys, Enter to select, Escape to close
+- **Drill-down** — Commands with children show breadcrumb navigation
+- **Server command execution** — via RPC with loading indicator
+- **Dynamic sub-menus** — Client commands can return sub-items at runtime
+
+## Complete Example
+
+```ts
+/// <reference types="@vitejs/devtools-kit" />
+import type { Plugin } from 'vite'
+import { defineCommand } from '@vitejs/devtools-kit'
+
+export default function myPlugin(): Plugin {
+  return {
+    name: 'my-plugin',
+
+    devtools: {
+      setup(ctx) {
+        // Simple command with keybinding
+        ctx.commands.register(defineCommand({
+          id: 'my-plugin:restart',
+          title: 'Restart Dev Server',
+          icon: 'ph:arrow-clockwise-duotone',
+          keybindings: [{ key: 'Mod+Shift+R' }],
+          handler: async () => {
+            await ctx.viteServer?.restart()
+          },
+        }))
+
+        // Command group with sub-commands
+        ctx.commands.register(defineCommand({
+          id: 'my-plugin:cache',
+          title: 'Cache',
+          icon: 'ph:database-duotone',
+          children: [
+            {
+              id: 'my-plugin:cache:clear',
+              title: 'Clear Cache',
+              handler: async () => { /* ... */ },
+            },
+            {
+              id: 'my-plugin:cache:inspect',
+              title: 'Inspect Cache',
+              handler: async () => { /* ... */ },
+            },
+          ],
+        }))
+      },
+    },
+  }
+}
+```

--- a/skills/vite-devtools-kit/references/dock-entry-types.md
+++ b/skills/vite-devtools-kit/references/dock-entry-types.md
@@ -13,7 +13,7 @@ interface DockEntryBase {
   icon: string // URL, data URI, or Iconify name
   category?: string // Grouping category
   defaultOrder?: number // Sort order (higher = earlier)
-  when?: string // Conditional visibility expression (same syntax as command when clauses)
+  when?: string // Conditional visibility expression — see [When Clauses](./when-clauses.md)
   badge?: string // Badge text on dock icon (e.g., count)
 }
 ```

--- a/skills/vite-devtools-kit/references/when-clauses.md
+++ b/skills/vite-devtools-kit/references/when-clauses.md
@@ -1,0 +1,160 @@
+# When Clauses
+
+Conditional expressions controlling visibility and activation of commands and dock entries.
+
+## Usage
+
+### On Commands
+
+Controls whether the command appears in the palette and can be triggered via shortcuts:
+
+```ts
+ctx.commands.register(defineCommand({
+  id: 'my-plugin:embedded-only',
+  title: 'Embedded-Only Action',
+  when: 'clientType == embedded',
+  handler: async () => { /* ... */ },
+}))
+```
+
+### On Dock Entries
+
+Controls whether a dock entry is visible in the dock bar:
+
+```ts
+ctx.docks.register({
+  id: 'my-plugin:inspector',
+  title: 'Inspector',
+  type: 'action',
+  icon: 'ph:cursor-duotone',
+  when: 'clientType == embedded',
+  action: { importFrom: 'my-plugin/inspector' },
+})
+```
+
+Set `when: 'false'` to unconditionally hide a dock entry.
+
+## Expression Syntax
+
+### Operators
+
+| Operator | Example | Description |
+|----------|---------|-------------|
+| bare truthy | `dockOpen` | True if the value is truthy |
+| `true` / `false` | `true` | Literal boolean values |
+| `!` | `!paletteOpen` | Negation |
+| `==` | `clientType == embedded` | Equality (string comparison) |
+| `!=` | `clientType != standalone` | Inequality |
+| `&&` | `dockOpen && !paletteOpen` | Logical AND |
+| `\|\|` | `paletteOpen \|\| dockOpen` | Logical OR |
+
+### Precedence
+
+`||` (lowest) → `&&` → unary `!`
+
+Each `||` branch is evaluated as a chain of `&&` parts: `a && b || c && d` = `(a AND b) OR (c AND d)`.
+
+### Examples
+
+```ts
+// Always visible
+when: 'true'
+
+// Never visible (unconditionally hidden)
+when: 'false'
+
+// Only in embedded mode
+when: 'clientType == embedded'
+
+// Only when dock is open and palette is closed
+when: 'dockOpen && !paletteOpen'
+
+// When a specific dock is selected
+when: 'dockSelectedId == my-plugin'
+
+// Plugin-specific context
+when: 'vite.mode == development'
+
+// Compound: either in embedded with dock open, or in standalone
+when: 'clientType == embedded && dockOpen || clientType == standalone'
+```
+
+## Built-in Context Variables
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `clientType` | `'embedded' \| 'standalone'` | Current client mode |
+| `dockOpen` | `boolean` | Whether the dock panel is currently open |
+| `paletteOpen` | `boolean` | Whether the command palette is currently open |
+| `dockSelectedId` | `string` | ID of the currently selected dock entry. Empty string (falsy) when none selected. |
+
+## Namespaced Context Keys
+
+Plugins can register context variables using namespaced keys with `.` or `:` separators:
+
+```ts
+// Flat key (recommended)
+context['vite.mode'] = 'development'
+context['vite:buildMode'] = 'lib'
+
+// Nested object (also supported)
+context.vite = { mode: 'development', ssr: true }
+```
+
+Both styles work in `when` expressions:
+
+```ts
+when: 'vite.mode == development'
+when: 'vite:buildMode == lib'
+when: 'vite.ssr'
+```
+
+### Lookup Order
+
+When resolving a namespaced key like `vite.mode`:
+
+1. **Exact match** — looks for `ctx['vite.mode']` first
+2. **Nested path** — falls back to `ctx.vite?.mode`
+
+Flat keys take priority over nested objects if both exist. Use your plugin name as namespace prefix: `my-plugin.featureEnabled`, `rolldown:buildStep`.
+
+## API Reference
+
+```ts
+import type { WhenContext } from '@vitejs/devtools-kit'
+import { evaluateWhen, getContextValue } from '@vitejs/devtools-kit/utils/when'
+
+const ctx: WhenContext = {
+  'clientType': 'embedded',
+  'dockOpen': true,
+  'paletteOpen': false,
+  'dockSelectedId': 'my-dock',
+  'vite.mode': 'development',
+}
+
+evaluateWhen('dockOpen && vite.mode == development', ctx) // true
+evaluateWhen('clientType == standalone', ctx) // false
+
+getContextValue('vite.mode', ctx) // 'development'
+getContextValue('dockOpen', ctx) // true
+```
+
+### `evaluateWhen(expression, ctx)`
+
+Evaluates a when-clause expression string against a context object. Returns `boolean`.
+
+### `getContextValue(key, ctx)`
+
+Resolves a single context key (including namespaced keys) from the context object. Returns `unknown`.
+
+### `WhenContext`
+
+```ts
+interface WhenContext {
+  clientType: 'embedded' | 'standalone'
+  dockOpen: boolean
+  paletteOpen: boolean
+  dockSelectedId: string
+  [key: string]: unknown // custom plugin variables
+}
+```


### PR DESCRIPTION
### Description

Updates the vite-devtools-kit agent skills with comprehensive documentation for the commands system and when clauses. Adds two new reference guides covering command registration, keyboard shortcuts, command palette integration, and conditional visibility expressions. Updates SKILL.md with best practices and links to the new guides.

### Linked Issues

#247 - Commands system, commands palette, shortcuts and when clauses