### PR TITLE
fix: prevent out-of-workspace-root access for open-in-editor and open-in-file

### DIFF
--- a/packages/core/src/node/__tests__/open-in-editor.test.ts
+++ b/packages/core/src/node/__tests__/open-in-editor.test.ts
@@ -10,41 +10,44 @@ vi.mock('launch-editor', () => ({
 
 describe('openInEditor – path traversal protection', () => {
   const cwd = resolve('/project/root')
-  const mockContext = { cwd } as DevToolsNodeContext
+  const workspaceRoot = resolve('/project')
+  const mockContext = { cwd, workspaceRoot } as DevToolsNodeContext
 
-  function getHandler() {
-    const { handler } = openInEditor?.setup(mockContext)
-    return handler
+  async function getHandler() {
+    const setup = openInEditor.setup!
+    const { handler } = await setup(mockContext)
+    expect(handler).toBeTypeOf('function')
+    return handler as (path: string) => Promise<void>
   }
 
   it('allows opening a file inside the project root', async () => {
-    const handler = getHandler()
+    const handler = await getHandler()
     await expect(handler('src/main.ts')).resolves.not.toThrow()
   })
 
   it('allows opening a nested file inside the project root', async () => {
-    const handler = getHandler()
+    const handler = await getHandler()
     await expect(handler('src/utils/helper.ts')).resolves.not.toThrow()
   })
 
   it('rejects path traversal with ../', async () => {
-    const handler = getHandler()
+    const handler = await getHandler()
     await expect(handler('../../etc/passwd')).rejects.toThrow(
-      'Path is outside the project root',
+      'Path is outside the workspace root',
     )
   })
 
   it('rejects absolute path outside project root', async () => {
-    const handler = getHandler()
+    const handler = await getHandler()
     await expect(handler('/etc/passwd')).rejects.toThrow(
-      'Path is outside the project root',
+      'Path is outside the workspace root',
     )
   })
 
   it('rejects traversal disguised within a subpath', async () => {
-    const handler = getHandler()
+    const handler = await getHandler()
     await expect(handler('src/../../secret/file.txt')).rejects.toThrow(
-      'Path is outside the project root',
+      'Path is outside the workspace root',
     )
   })
 })

--- a/packages/core/src/node/rpc/public/open-in-editor.ts
+++ b/packages/core/src/node/rpc/public/open-in-editor.ts
@@ -7,12 +7,12 @@ export const openInEditor = defineRpcFunction({
   setup: (context) => {
     return {
       handler: async (path: string) => {
-        const resolved = resolve(context.cwd, path)
-        const rel = relative(context.cwd, resolved)
+        const resolved = resolve(context.workspaceRoot, path)
+        const rel = relative(context.workspaceRoot, resolved)
 
-        // Prevent escaping the root
+        // Prevent escaping the workspace root
         if (rel.startsWith('..') || rel.includes('\0')) {
-          throw new Error('Path is outside the project root')
+          throw new Error('Path is outside the workspace root')
         }
 
         await import('launch-editor').then(r => r.default(resolved))

--- a/packages/core/src/node/rpc/public/open-in-finder.ts
+++ b/packages/core/src/node/rpc/public/open-in-finder.ts
@@ -7,15 +7,15 @@ export const openInFinder = defineRpcFunction({
   setup: (context) => {
     return {
       handler: async (path: string) => {
-        const resolved = resolve(context.cwd, path)
-        const rel = relative(context.cwd, resolved)
+        const resolved = resolve(context.workspaceRoot, path)
+        const rel = relative(context.workspaceRoot, resolved)
 
-        // Ensure the path stays within project root
+        // Ensure the path stays within workspace root
         if (rel.startsWith('..') || rel.includes('\0')) {
-          throw new Error('Path is outside the project root')
+          throw new Error('Path is outside the workspace root')
         }
 
-        await import('launch-editor').then(r => r.default(resolved))
+        await import('open').then(r => r.default(resolved))
       },
     }
   },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

this PR won't allow user to open files outside of project directory for better security

### Linked Issues

closes #254 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
