### PR TITLE
fix: make KeybindingBadge reactive to prop changes

### DIFF
--- a/packages/core/src/client/webcomponents/components/command-palette/KeybindingBadge.vue
+++ b/packages/core/src/client/webcomponents/components/command-palette/KeybindingBadge.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { formatKeybinding } from '../../state/keybindings'
 
 const props = defineProps<{
   keyString: string
 }>()
 
-const keys = formatKeybinding(props.keyString)
+const keys = computed(() => formatKeybinding(props.keyString))
 </script>
 
 <template>


### PR DESCRIPTION
When using it, changing a shortcut doesn’t immediately update the UI — the panel must be closed and reopened to see the change.

For features other than "Toggle Command Palette," adding a shortcut currently only allows opening the feature, not closing it. Will the close functionality be added later?

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
