### PR TITLE
fix: merge command shortcuts into user settings for persistence

### DIFF
--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsAdvanced.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsAdvanced.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { DevToolsCommandKeybinding } from '@vitejs/devtools-kit'
 import type { DocksContext } from '@vitejs/devtools-kit/client'
 import type { SharedState } from '@vitejs/devtools-kit/utils/shared-state'
 import type { DevToolsDocksUserSettings } from '../../state/dock-settings'
@@ -16,19 +15,14 @@ function resetAllSettings() {
     props.settingsStore.mutate(() => {
       return DEFAULT_STATE_USER_SETTINGS()
     })
-    props.context.commands.shortcutOverrides.mutate((state: Record<string, DevToolsCommandKeybinding[]>) => {
-      for (const key of Object.keys(state))
-        delete state[key]
-    })
   }
 }
 
 function resetShortcuts() {
   // eslint-disable-next-line no-alert
   if (confirm('Reset all keyboard shortcuts to defaults?')) {
-    props.context.commands.shortcutOverrides.mutate((state: Record<string, DevToolsCommandKeybinding[]>) => {
-      for (const key of Object.keys(state))
-        delete state[key]
+    props.settingsStore.mutate((state) => {
+      state.commandShortcuts = {}
     })
   }
 }

--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsShortcuts.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsShortcuts.vue
@@ -12,7 +12,8 @@ const props = defineProps<{
 }>()
 
 const commandsCtx = props.context.commands
-const shortcutOverrides = sharedStateToRef(commandsCtx.shortcutOverrides)
+const settings = sharedStateToRef(commandsCtx.settings)
+const shortcutOverrides = computed(() => settings.value.commandShortcuts ?? {})
 const shortcutSearch = ref('')
 
 interface ShortcutRow {
@@ -58,14 +59,14 @@ function isOverridden(id: string): boolean {
 }
 
 function clearShortcut(commandId: string) {
-  commandsCtx.shortcutOverrides.mutate((state: Record<string, DevToolsCommandKeybinding[]>) => {
-    state[commandId] = []
+  commandsCtx.settings.mutate((state) => {
+    state.commandShortcuts[commandId] = []
   })
 }
 
 function resetShortcut(commandId: string) {
-  commandsCtx.shortcutOverrides.mutate((state: Record<string, DevToolsCommandKeybinding[]>) => {
-    delete state[commandId]
+  commandsCtx.settings.mutate((state) => {
+    delete state.commandShortcuts[commandId]
   })
 }
 
@@ -186,8 +187,8 @@ function onEditorKeyDown(e: KeyboardEvent) {
 function saveEditor() {
   if (!editorCommandId.value || !editorCanSave.value)
     return
-  commandsCtx.shortcutOverrides.mutate((state: Record<string, DevToolsCommandKeybinding[]>) => {
-    state[editorCommandId.value!] = [{ key: editorComposedKey.value }]
+  commandsCtx.settings.mutate((state) => {
+    state.commandShortcuts[editorCommandId.value!] = [{ key: editorComposedKey.value }]
   })
   closeEditor()
 }

--- a/packages/core/src/client/webcomponents/state/__tests__/context-cache.test.ts
+++ b/packages/core/src/client/webcomponents/state/__tests__/context-cache.test.ts
@@ -22,11 +22,6 @@ function createMockRpc(entries: DevToolsDockEntry[] = []): DevToolsRpcClient {
     enablePatches: false,
   })
 
-  const shortcutsState = createSharedState({
-    initialValue: {} as Record<string, any>,
-    enablePatches: false,
-  })
-
   return {
     sharedState: {
       get: async (key: string) => {
@@ -36,8 +31,6 @@ function createMockRpc(entries: DevToolsDockEntry[] = []): DevToolsRpcClient {
           return settingsState as any
         if (key === 'devtoolskit:internal:commands')
           return commandsState as any
-        if (key === 'devtoolskit:internal:command-shortcuts')
-          return shortcutsState as any
         throw new Error(`Unexpected shared state key: ${key}`)
       },
     },

--- a/packages/core/src/client/webcomponents/state/commands.ts
+++ b/packages/core/src/client/webcomponents/state/commands.ts
@@ -1,5 +1,6 @@
-import type { DevToolsClientCommand, DevToolsCommandEntry, DevToolsCommandKeybinding, DevToolsServerCommandEntry, WhenContext } from '@vitejs/devtools-kit'
+import type { DevToolsClientCommand, DevToolsCommandEntry, DevToolsCommandKeybinding, DevToolsDocksUserSettings, DevToolsServerCommandEntry, WhenContext } from '@vitejs/devtools-kit'
 import type { CommandsContext, DevToolsRpcClient } from '@vitejs/devtools-kit/client'
+import type { SharedState } from '@vitejs/devtools-kit/utils/shared-state'
 import type { ShallowRef } from 'vue'
 import { evaluateWhen } from '@vitejs/devtools-kit/utils/when'
 import { computed, markRaw, reactive, ref } from 'vue'
@@ -13,6 +14,7 @@ const commandsContextByRpc = new WeakMap<DevToolsRpcClient, CommandsContext>()
 export async function createCommandsContext(
   clientType: 'embedded' | 'standalone',
   rpc: DevToolsRpcClient,
+  settingsState: SharedState<DevToolsDocksUserSettings>,
   whenContextProvider?: () => WhenContext,
 ): Promise<CommandsContext> {
   if (commandsContextByRpc.has(rpc)) {
@@ -26,9 +28,9 @@ export async function createCommandsContext(
   // Client commands (local registry)
   const clientCommands = reactive(new Map<string, DevToolsClientCommand>())
 
-  // Shortcut overrides
-  const shortcutOverridesState = await rpc.sharedState.get('devtoolskit:internal:command-shortcuts', { initialValue: {} })
-  const shortcutOverrides = sharedStateToRef(shortcutOverridesState)
+  // Shortcut overrides from user settings
+  const settings = sharedStateToRef(settingsState)
+  const shortcutOverrides = computed(() => settings.value.commandShortcuts ?? {})
 
   const paletteOpen = ref(false)
 
@@ -135,7 +137,7 @@ export async function createCommandsContext(
     register,
     execute,
     getKeybindings,
-    shortcutOverrides: markRaw(shortcutOverridesState),
+    settings: markRaw(settingsState),
     paletteOpen,
   })
 

--- a/packages/core/src/client/webcomponents/state/context.ts
+++ b/packages/core/src/client/webcomponents/state/context.ts
@@ -124,7 +124,7 @@ export async function createDocksContext(
   })
 
   // Initialize commands context with reactive when-context
-  const commandsContextResult = await createCommandsContext(clientType, rpc, getWhenContext)
+  const commandsContextResult = await createCommandsContext(clientType, rpc, settingsStore, getWhenContext)
   commandsContext = commandsContextResult
 
   // Register built-in client commands

--- a/packages/core/src/node/rpc/index.ts
+++ b/packages/core/src/node/rpc/index.ts
@@ -1,4 +1,4 @@
-import type { DevToolsCommandShortcutOverrides, DevToolsDockEntry, DevToolsDocksUserSettings, DevToolsServerCommandEntry, DevToolsTerminalSessionStreamChunkEvent, RpcDefinitionsFilter, RpcDefinitionsToFunctions } from '@vitejs/devtools-kit'
+import type { DevToolsDockEntry, DevToolsDocksUserSettings, DevToolsServerCommandEntry, DevToolsTerminalSessionStreamChunkEvent, RpcDefinitionsFilter, RpcDefinitionsToFunctions } from '@vitejs/devtools-kit'
 import type { SharedStatePatch } from '@vitejs/devtools-kit/utils/shared-state'
 import { anonymousAuth } from './anonymous/auth'
 import { commandsExecute } from './internal/commands-execute'
@@ -80,7 +80,6 @@ declare module '@vitejs/devtools-kit' {
 
   // @keep-sorted
   export interface DevToolsRpcSharedStates {
-    'devtoolskit:internal:command-shortcuts': DevToolsCommandShortcutOverrides
     'devtoolskit:internal:commands': DevToolsServerCommandEntry[]
     'devtoolskit:internal:docks': DevToolsDockEntry[]
     'devtoolskit:internal:user-settings': DevToolsDocksUserSettings

--- a/packages/core/src/node/rpc/internal/state/get.ts
+++ b/packages/core/src/node/rpc/internal/state/get.ts
@@ -13,6 +13,8 @@ export const sharedStateGet = defineRpcFunction({
   setup: (context: DevToolsNodeContext) => {
     return {
       handler: async (key: string): Promise<any> => {
+        if (!context.rpc.sharedState.keys().includes(key))
+          return undefined
         const state = await context.rpc.sharedState.get(key as keyof DevToolsRpcSharedStates)
         return state.value()
       },

--- a/packages/core/src/node/rpc/internal/state/patch.ts
+++ b/packages/core/src/node/rpc/internal/state/patch.ts
@@ -8,6 +8,8 @@ export const sharedStatePatch = defineRpcFunction({
   setup: (context: DevToolsNodeContext) => {
     return {
       handler: async (key: string, patches: SharedStatePatch[], syncId: string) => {
+        if (!context.rpc.sharedState.keys().includes(key))
+          return
         const state = await context.rpc.sharedState.get(key as keyof DevToolsRpcSharedStates)
         state.patch(patches, syncId)
       },

--- a/packages/core/src/node/rpc/internal/state/set.ts
+++ b/packages/core/src/node/rpc/internal/state/set.ts
@@ -7,7 +7,7 @@ export const sharedStateSet = defineRpcFunction({
   setup: (context: DevToolsNodeContext) => {
     return {
       handler: async (key: string, value: any, syncId: string) => {
-        const state = await context.rpc.sharedState.get(key as keyof DevToolsRpcSharedStates)
+        const state = await context.rpc.sharedState.get(key as keyof DevToolsRpcSharedStates, { initialValue: value })
         state.mutate(() => value, syncId)
       },
     }

--- a/packages/kit/src/client/docks.ts
+++ b/packages/kit/src/client/docks.ts
@@ -1,5 +1,5 @@
 import type { RpcFunctionsCollector } from '@vitejs/devtools-rpc'
-import type { DevToolsClientCommand, DevToolsCommandEntry, DevToolsCommandKeybinding, DevToolsCommandShortcutOverrides, DevToolsDockEntriesGrouped, DevToolsDockEntry, DevToolsDocksUserSettings, DevToolsDockUserEntry, DevToolsRpcClientFunctions, EventEmitter, WhenContext } from '../types'
+import type { DevToolsClientCommand, DevToolsCommandEntry, DevToolsCommandKeybinding, DevToolsDockEntriesGrouped, DevToolsDockEntry, DevToolsDocksUserSettings, DevToolsDockUserEntry, DevToolsRpcClientFunctions, EventEmitter, WhenContext } from '../types'
 import type { SharedState } from '../utils/shared-state'
 import type { DevToolsRpcClient } from './rpc'
 
@@ -135,9 +135,9 @@ export interface CommandsContext {
    */
   getKeybindings: (id: string) => DevToolsCommandKeybinding[]
   /**
-   * Shortcut overrides (persisted via shared state)
+   * User settings store (persisted, includes command shortcuts)
    */
-  shortcutOverrides: SharedState<DevToolsCommandShortcutOverrides>
+  settings: SharedState<DevToolsDocksUserSettings>
   /**
    * Whether the command palette is open
    */

--- a/packages/kit/src/client/rpc-shared-state.ts
+++ b/packages/kit/src/client/rpc-shared-state.ts
@@ -69,7 +69,8 @@ export function createRpcSharedStateClientHost(rpc: DevToolsRpcClient): RpcShare
           sharedState.set(key, state)
           rpc.call('devtoolskit:internal:rpc:server-state:get', key)
             .then((serverState) => {
-              state.mutate(() => serverState)
+              if (serverState !== undefined)
+                state.mutate(() => serverState)
             })
             .catch((error) => {
               console.error('Error getting server state', error)

--- a/packages/kit/src/constants.ts
+++ b/packages/kit/src/constants.ts
@@ -28,4 +28,5 @@ export const DEFAULT_STATE_USER_SETTINGS: () => DevToolsDocksUserSettings = () =
   docksCustomOrder: {},
   showIframeAddressBar: false,
   closeOnOutsideClick: false,
+  commandShortcuts: {},
 })

--- a/packages/kit/src/types/settings.ts
+++ b/packages/kit/src/types/settings.ts
@@ -1,3 +1,5 @@
+import type { DevToolsCommandShortcutOverrides } from './commands'
+
 export interface DevToolsDocksUserSettings {
   docksHidden: string[]
   docksCategoriesHidden: string[]
@@ -5,4 +7,5 @@ export interface DevToolsDocksUserSettings {
   docksCustomOrder: Record<string, number>
   showIframeAddressBar: boolean
   closeOnOutsideClick: boolean
+  commandShortcuts: DevToolsCommandShortcutOverrides
 }


### PR DESCRIPTION
## Summary

Consolidate `devtoolskit:internal:command-shortcuts` shared state into `user-settings` so keyboard shortcut overrides are persisted to disk alongside other user preferences. Also improve RPC resilience by handling missing shared states gracefully when clients make out-of-order requests.

## What's fixed

- Keyboard shortcut overrides now persist to `node_modules/.vite/devtools/settings.json` instead of being lost on restart
- Server RPC handlers (`get`/`set`/`patch`) handle missing shared states gracefully instead of throwing errors
- Client no longer overwrites initial values with undefined server responses

## Test plan

- All 258 tests pass
- Build succeeds (tsdown + rolldown)
- No type errors (vue-tsc)