### PR TITLE
fix: preserve user app output in build.withApp mode

### DIFF
--- a/packages/core/src/node/build-static.ts
+++ b/packages/core/src/node/build-static.ts
@@ -19,12 +19,13 @@ import { MARK_NODE } from './constants'
 export interface BuildStaticOptions {
   context: DevToolsNodeContext
   outDir: string
+  withApp?: boolean
 }
 
 export async function buildStaticDevTools(options: BuildStaticOptions): Promise<void> {
-  const { context, outDir } = options
+  const { context, outDir, withApp } = options
 
-  if (existsSync(outDir))
+  if (!withApp && existsSync(outDir))
     await fs.rm(outDir, { recursive: true })
 
   const devToolsRoot = join(outDir, DEVTOOLS_DIRNAME)
@@ -55,24 +56,26 @@ export async function buildStaticDevTools(options: BuildStaticOptions): Promise<
     await fs.writeFile(fullpath, JSON.stringify(data, null, 2), 'utf-8')
   }
   await fs.writeFile(resolve(devToolsRoot, DEVTOOLS_RPC_DUMP_MANIFEST_FILENAME), JSON.stringify(dump.manifest, null, 2), 'utf-8')
-  await fs.writeFile(
-    resolve(outDir, 'index.html'),
-    [
-      '<!doctype html>',
-      '<html lang="en">',
-      '<head>',
-      '  <meta charset="UTF-8">',
-      '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
-      '  <title>Vite DevTools</title>',
-      `  <meta http-equiv="refresh" content="0; url=${DEVTOOLS_MOUNT_PATH}">`,
-      '</head>',
-      '<body>',
-      `  <script>location.replace(${JSON.stringify(DEVTOOLS_MOUNT_PATH)})</script>`,
-      '</body>',
-      '</html>',
-    ].join('\n'),
-    'utf-8',
-  )
+  if (!existsSync(resolve(outDir, 'index.html'))) {
+    await fs.writeFile(
+      resolve(outDir, 'index.html'),
+      [
+        '<!doctype html>',
+        '<html lang="en">',
+        '<head>',
+        '  <meta charset="UTF-8">',
+        '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+        '  <title>Vite DevTools</title>',
+        `  <meta http-equiv="refresh" content="0; url=${DEVTOOLS_MOUNT_PATH}">`,
+        '</head>',
+        '<body>',
+        `  <script>location.replace(${JSON.stringify(DEVTOOLS_MOUNT_PATH)})</script>`,
+        '</body>',
+        '</html>',
+      ].join('\n'),
+      'utf-8',
+    )
+  }
 
   console.log(c.green`${MARK_NODE} Built DevTools to ${relative(context.cwd, outDir)}`)
 }

--- a/packages/core/src/node/plugins/build.ts
+++ b/packages/core/src/node/plugins/build.ts
@@ -35,7 +35,7 @@ export function DevToolsBuild(options: DevToolsBuildOptions = {}): Plugin {
         : resolve(resolvedConfig.root, resolvedConfig.build.outDir)
 
       const { buildStaticDevTools } = await import('../build-static')
-      await buildStaticDevTools({ context, outDir })
+      await buildStaticDevTools({ context, outDir, withApp: true })
     },
   }
 }


### PR DESCRIPTION
## Description

When building DevTools alongside the user's app (via `build.withApp`), the build process no longer clears the output directory or overrides the user's `index.html`. DevTools files are isolated in `.devtools/` and other base-path subdirectories, allowing safe coexistence with the user's app output.

Changes:
- Skip clearing `outDir` when `withApp` is true
- Only write redirect `index.html` if one doesn't already exist
- Pass `withApp: true` from the build plugin to indicate coexistence mode

This ensures users can build both their app and DevTools together without losing the app's output.

## Linked Issues

<!-- Add issue references if applicable -->

## Additional context

<!-- Reviewers should note: The build plugin runs after the app build completes, so preserving existing files is important for the withApp use case. -->