### PR TITLE
feat: add copy button for stacktrace

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,7 +95,6 @@
     "@clack/prompts": "1.1.0",
     "@json-render/core": "0.13.0",
     "@json-render/vue": "0.13.0",
-    "@vueuse/components": "14.2.1",
     "@vueuse/core": "14.2.1",
     "@vueuse/shared": "14.2.1",
     "@xterm/addon-fit": "0.11.0",

--- a/packages/core/src/client/webcomponents/components/views-builtin/ViewBuiltinLogs.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/ViewBuiltinLogs.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { DevToolsLogEntry, DevToolsLogEntryFrom, DevToolsLogLevel } from '@vitejs/devtools-kit'
 import type { DocksContext } from '@vitejs/devtools-kit/client'
-import { UseClipboard } from '@vueuse/components'
-import { useTimeAgo } from '@vueuse/core'
+import { useClipboard, useTimeAgo } from '@vueuse/core'
 import { computed, onMounted, ref } from 'vue'
 import { markLogsAsRead, useLogs } from '../../state/logs'
 import FilterToggles from '../display/FilterToggles.vue'
@@ -163,6 +162,7 @@ const selectedEntry = computed(() => {
 })
 
 const selectedTimeAgo = useTimeAgo(computed(() => selectedEntry.value?.timestamp ?? Date.now()))
+const { copy: copyStacktrace, copied: stacktraceCopied } = useClipboard()
 
 async function openFile(entry: DevToolsLogEntry) {
   if (!entry.filePosition)
@@ -413,18 +413,16 @@ onMounted(() => {
           </div>
           <div class="group relative">
             <pre class="text-xs bg-gray/5 rounded p-2 of-x-auto whitespace-pre-wrap font-mono">{{ selectedEntry.stacktrace }}</pre>
-            <UseClipboard #="{ copy, copied }" :source="selectedEntry.stacktrace">
-              <button
-                class="group/bt absolute top-1.5 right-1.5 op0 group-hover:op100 p-1 rounded bg-base border border-base transition"
-                title="Copy"
-                @click="copy()"
-              >
-                <div
-                  :class="copied ? 'i-ph:check' : 'i-ph:copy'"
-                  class="op50 group-hover/bt:op100 size-3.5 "
-                />
-              </button>
-            </UseClipboard>
+            <button
+              class="group/bt absolute top-1.5 right-1.5 op0 group-hover:op100 p-1 rounded bg-base border border-base transition"
+              title="Copy"
+              @click="copyStacktrace(selectedEntry.stacktrace)"
+            >
+              <div
+                :class="stacktraceCopied ? 'i-ph:check' : 'i-ph:copy'"
+                class="op50 group-hover/bt:op100 size-3.5"
+              />
+            </button>
           </div>
         </div>
 

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
       '@vue/runtime-core',
       '@vue/runtime-dom',
       '@vue/shared',
-      '@vueuse/components',
       '@vueuse/core',
       '@vueuse/shared',
       '@xterm/addon-fit',


### PR DESCRIPTION
### Description

Easier to copy the full stack trace.

<img width="1695" height="1023" alt="2026-03-24 150516" src="https://github.com/user-attachments/assets/4dc70531-fa1b-493a-9ab9-a3c995d5a1ed" />

