### PR TITLE
fix(core): skip devtools injection for SSR builds

### DIFF
--- a/packages/core/src/node/plugins/injection.ts
+++ b/packages/core/src/node/plugins/injection.ts
@@ -7,7 +7,9 @@ export function DevToolsInjection(): Plugin {
   return {
     name: 'vite:devtools:injection',
     enforce: 'post',
-    apply: 'serve',
+    apply(_config, env) {
+      return env.command === 'serve' && !env.isSsrBuild
+    },
     transformIndexHtml() {
       const fileUrl = process.env.VITE_DEVTOOLS_LOCAL_DEV
         ? normalize(join(dirDist, '..', 'src/client/inject/index.ts'))


### PR DESCRIPTION
### Description

Change the `DevToolsInjection` plugin's `apply` from a static `'serve'` string to a function that also explicitly guards against SSR builds (`!env.isSsrBuild`). This makes the intent clear and future-proofs against SSR build scenarios.

### Linked Issues

### Additional context