### PR TITLE
feat(core): `environments` devtools config

### DIFF
--- a/packages/core/src/node/config.ts
+++ b/packages/core/src/node/config.ts
@@ -4,6 +4,10 @@ import { isObject } from './utils'
 export interface DevToolsConfig extends Partial<StartOptions> {
   enabled: boolean
   /**
+   * Vite environments to enable DevTools for. Defaults to all environments.
+   */
+  environments?: string[]
+  /**
    * Disable client authentication.
    *
    * Beware that if you disable client authentication,


### PR DESCRIPTION
Be related to #292.

Extend devtools config to support an `environments` option, then add the Vite-side integration in the Vite repo. 
That way, Vite can enable DevTools only for the selected environments to avoid unnecessary overhead for environments that are not opted in.