### PR TITLE
fix(core): redirect devtools mount path to trailing slash

### DIFF
--- a/packages/core/src/node/plugins/server.ts
+++ b/packages/core/src/node/plugins/server.ts
@@ -3,6 +3,7 @@ import type { Plugin } from 'vite'
 import {
   DEVTOOLS_DOCK_IMPORTS_VIRTUAL_ID,
   DEVTOOLS_MOUNT_PATH,
+  DEVTOOLS_MOUNT_PATH_NO_TRAILING_SLASH,
 } from '@vitejs/devtools-kit/constants'
 import { createDevToolsContext } from '../context'
 import { createDevToolsMiddleware } from '../server'
@@ -53,6 +54,16 @@ export function DevToolsServer(): Plugin {
           host,
         },
         context,
+      })
+      viteDevServer.middlewares.use((req, res, next) => {
+        if (req.url === DEVTOOLS_MOUNT_PATH_NO_TRAILING_SLASH || req.url?.startsWith(`${DEVTOOLS_MOUNT_PATH_NO_TRAILING_SLASH}?`)) {
+          res.statusCode = 302
+          res.setHeader('Location', `${DEVTOOLS_MOUNT_PATH}${req.url.slice(DEVTOOLS_MOUNT_PATH_NO_TRAILING_SLASH.length)}`)
+          res.end()
+          return
+        }
+
+        next()
       })
       viteDevServer.middlewares.use(DEVTOOLS_MOUNT_PATH, middleware)
     },


### PR DESCRIPTION
Opening the standalone DevTools URL without a trailing slash currently serves the DevTools HTML at `/.devtools`, but the HTML references assets with relative `./assets/...` URLs. Browsers resolve those relative to the parent path and request `/assets/...` instead of `/.devtools/assets/...`, which causes JS/CSS MIME errors and a blank screen.

This redirects the exact DevTools mount path to the canonical directory URL while preserving query strings. Subpaths such as auth and assets continue to be handled by the existing middleware.

Probably there is better solutions, so I am open for another approach 