### PR TITLE
feat(devframe): ship skills folder in published package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ packages/rolldown/src/public/fonts
 packages/rolldown/src/app/public/fonts
 packages/rolldown/runtime
 packages/kit/skills
+devframe/packages/devframe/skills
 .rolldown
 *.tsbuildinfo
 docs/.vitepress/cache

--- a/devframe/packages/devframe/package.json
+++ b/devframe/packages/devframe/package.json
@@ -51,12 +51,13 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "scripts": {
     "build": "tsdown",
     "watch": "tsdown --watch",
-    "prepack": "pnpm build"
+    "prepack": "pnpm build && mkdir -p ./skills && cp -r ../../../skills/devframe ./skills/devframe"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
### Description

The `devframe` npm package now bundles the `skills/devframe/` agent skill at publish time, the same way `@vitejs/devtools-kit` already does. The `prepack` script copies `skills/devframe/` from the repo root into the package as `skills/devframe/`, and the folder is added to the `files` array so it lands in the tarball. The generated copy is gitignored.

The `skills/devframe/README.md` already anticipates this — it tells users to symlink the skill manually "until devframe publishes an installable skill." This PR closes that gap, so installing `devframe` makes the skill discoverable to skills-aware agent tooling. devframe ships only its own skill (not the `vite-devtools-kit` one) since it is the lower-level foundation.

### Linked Issues

### Additional context

🤖 Generated with [Claude Code](https://claude.com/claude-code)