### PR TITLE
refactor(devframe): rename `devtoolskit:internal:` prefix to `devframe:`

### DIFF
--- a/devframe/docs/guide/terminals.md
+++ b/devframe/docs/guide/terminals.md
@@ -104,11 +104,11 @@ ctx.terminals.events.on('terminal:session:updated', (session) => {
 })
 ```
 
-Output chunks aren't delivered as host events anymore — terminals now use the [streaming](./streaming) channel `devtoolskit:internal:terminals` keyed by session id. From the browser:
+Output chunks aren't delivered as host events anymore — terminals now use the [streaming](./streaming) channel `devframe:terminals` keyed by session id. From the browser:
 
 ```ts
 const reader = rpc.streaming.subscribe<string>(
-  'devtoolskit:internal:terminals',
+  'devframe:terminals',
   sessionId,
 )
 for await (const chunk of reader) writeToTerminal(chunk)

--- a/devframe/packages/devframe/src/client/rpc-shared-state.ts
+++ b/devframe/packages/devframe/src/client/rpc-shared-state.ts
@@ -19,7 +19,7 @@ export function createRpcSharedStateClientHost(rpc: DevToolsRpcClient): RpcShare
   }
 
   rpc.client.register({
-    name: 'devtoolskit:internal:rpc:client-state:updated',
+    name: 'devframe:rpc:client-state:updated',
     type: 'event',
     handler: (key: string, fullState: any, syncId: string) => {
       const state = sharedState.get(key)
@@ -30,7 +30,7 @@ export function createRpcSharedStateClientHost(rpc: DevToolsRpcClient): RpcShare
   })
 
   rpc.client.register({
-    name: 'devtoolskit:internal:rpc:client-state:patch',
+    name: 'devframe:rpc:client-state:patch',
     type: 'event',
     handler: (key: string, patches: SharedStatePatch[], syncId: string) => {
       const state = sharedState.get(key)
@@ -46,10 +46,10 @@ export function createRpcSharedStateClientHost(rpc: DevToolsRpcClient): RpcShare
       if (isStaticBackend)
         return
       if (patches) {
-        rpc.callEvent('devtoolskit:internal:rpc:server-state:patch', key, patches, syncId)
+        rpc.callEvent('devframe:rpc:server-state:patch', key, patches, syncId)
       }
       else {
-        rpc.callEvent('devtoolskit:internal:rpc:server-state:set', key, fullState, syncId)
+        rpc.callEvent('devframe:rpc:server-state:set', key, fullState, syncId)
       }
     }))
 
@@ -83,13 +83,13 @@ export function createRpcSharedStateClientHost(rpc: DevToolsRpcClient): RpcShare
 
       async function initSharedState() {
         if (!isStaticBackend) {
-          rpc.callEvent('devtoolskit:internal:rpc:server-state:subscribe', key)
+          rpc.callEvent('devframe:rpc:server-state:subscribe', key)
         }
         if (options?.initialValue !== undefined) {
           sharedState.set(key, state)
           for (const fn of keyAddedListeners)
             fn(key)
-          rpc.call('devtoolskit:internal:rpc:server-state:get', key)
+          rpc.call('devframe:rpc:server-state:get', key)
             .then((serverState) => {
               if (serverState !== undefined)
                 state.mutate(() => mergeWithInitialValue(key, serverState))
@@ -101,7 +101,7 @@ export function createRpcSharedStateClientHost(rpc: DevToolsRpcClient): RpcShare
           return state
         }
         else {
-          const serverValue = await rpc.call('devtoolskit:internal:rpc:server-state:get', key) as T
+          const serverValue = await rpc.call('devframe:rpc:server-state:get', key) as T
           state.mutate(() => mergeWithInitialValue(key, serverValue))
           sharedState.set(key, state)
           for (const fn of keyAddedListeners)

--- a/devframe/packages/devframe/src/client/rpc-streaming.ts
+++ b/devframe/packages/devframe/src/client/rpc-streaming.ts
@@ -46,7 +46,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
   const uploads = new Map<string, StreamSink<any>>()
 
   rpc.client.register({
-    name: 'devtoolskit:internal:streaming:chunk',
+    name: 'devframe:streaming:chunk',
     type: 'event',
     handler(channel: string, id: string, seq: number, chunk: any) {
       const reader = readers.get(streamKey(channel, id))
@@ -55,7 +55,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
   })
 
   rpc.client.register({
-    name: 'devtoolskit:internal:streaming:end',
+    name: 'devframe:streaming:end',
     type: 'event',
     handler(channel: string, id: string, error?: StreamErrorPayload) {
       const key = streamKey(channel, id)
@@ -68,7 +68,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
   })
 
   rpc.client.register({
-    name: 'devtoolskit:internal:streaming:upload-cancel',
+    name: 'devframe:streaming:upload-cancel',
     type: 'event',
     handler(channel: string, id: string) {
       const key = streamKey(channel, id)
@@ -99,7 +99,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
       const channel = key.slice(0, sepIdx)
       const id = key.slice(sepIdx + 1)
       rpc.callEvent(
-        'devtoolskit:internal:streaming:subscribe',
+        'devframe:streaming:subscribe',
         channel,
         id,
         { afterSeq: reader.lastSeenSeq },
@@ -127,7 +127,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
         )
       },
       onCancel() {
-        rpc.callEvent('devtoolskit:internal:streaming:cancel', channel, id)
+        rpc.callEvent('devframe:streaming:cancel', channel, id)
         readers.delete(key)
       },
     })
@@ -137,7 +137,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
     // Subscribe immediately if already trusted; otherwise wait for trust.
     // Mirrors `client/rpc-shared-state.ts` behavior.
     if (rpc.isTrusted) {
-      rpc.callEvent('devtoolskit:internal:streaming:subscribe', channel, id, {
+      rpc.callEvent('devframe:streaming:subscribe', channel, id, {
         afterSeq: 0,
       })
     }
@@ -146,7 +146,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
         if (trusted) {
           off()
           if (readers.has(key) && !reader.cancelled && !reader.done) {
-            rpc.callEvent('devtoolskit:internal:streaming:subscribe', channel, id, {
+            rpc.callEvent('devframe:streaming:subscribe', channel, id, {
               afterSeq: reader.lastSeenSeq,
             })
           }
@@ -167,7 +167,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
 
     sink.events.on('chunk', (seq, chunk) => {
       rpc.callEvent(
-        'devtoolskit:internal:streaming:upload-chunk',
+        'devframe:streaming:upload-chunk',
         channel,
         id,
         seq,
@@ -176,7 +176,7 @@ export function createRpcStreamingClientHost(rpc: DevToolsRpcClient): RpcStreami
     })
     sink.events.on('end', (error) => {
       rpc.callEvent(
-        'devtoolskit:internal:streaming:upload-end',
+        'devframe:streaming:upload-end',
         channel,
         id,
         error,

--- a/devframe/packages/devframe/src/client/rpc-ws.ts
+++ b/devframe/packages/devframe/src/client/rpc-ws.ts
@@ -62,7 +62,7 @@ export function createWsRpcClientMode(
 
   // Handle server-initiated auth revocation
   clientRpc.register({
-    name: 'devtoolskit:internal:auth:revoked',
+    name: 'devframe:auth:revoked',
     type: 'event',
     handler: () => {
       isTrusted = false

--- a/devframe/packages/devframe/src/node/__tests__/host-functions.test.ts
+++ b/devframe/packages/devframe/src/node/__tests__/host-functions.test.ts
@@ -133,7 +133,7 @@ describe('rpcFunctionsHost', () => {
     it('should not throw in build mode', async () => {
       const host = new RpcFunctionsHost({ mode: 'build' } as DevToolsNodeContext)
       await expect(host.broadcast({
-        method: 'devtoolskit:internal:terminals:updated',
+        method: 'devframe:terminals:updated',
         args: [],
       })).resolves.toBeUndefined()
     })
@@ -141,7 +141,7 @@ describe('rpcFunctionsHost', () => {
     it('should not throw in dev mode when rpc group is not yet set', async () => {
       const host = new RpcFunctionsHost({ mode: 'dev' } as DevToolsNodeContext)
       await expect(host.broadcast({
-        method: 'devtoolskit:internal:terminals:updated',
+        method: 'devframe:terminals:updated',
         args: [],
       })).resolves.toBeUndefined()
     })

--- a/devframe/packages/devframe/src/node/auth-revoke.ts
+++ b/devframe/packages/devframe/src/node/auth-revoke.ts
@@ -30,7 +30,7 @@ export async function revokeActiveConnectionsForToken(
     return
 
   await rpcHost.broadcast({
-    method: 'devtoolskit:internal:auth:revoked',
+    method: 'devframe:auth:revoked',
     args: [],
     filter: client => affectedSessionIds.has(client.$meta.id),
   })

--- a/devframe/packages/devframe/src/node/context.ts
+++ b/devframe/packages/devframe/src/node/context.ts
@@ -90,7 +90,7 @@ export async function createHostContext(options: CreateHostContextOptions): Prom
 
   let jrCounter = 0
   context.createJsonRenderer = (initialSpec: JsonRenderSpec): JsonRenderer => {
-    const stateKey = `devtoolskit:internal:json-render:${jrCounter++}`
+    const stateKey = `devframe:json-render:${jrCounter++}`
     const statePromise = rpcHost.sharedState.get(stateKey as any, {
       initialValue: initialSpec as any,
     })
@@ -123,7 +123,7 @@ export async function createHostContext(options: CreateHostContextOptions): Prom
 
   await docksHost.init()
 
-  const docksSharedState = await rpcHost.sharedState.get('devtoolskit:internal:docks', { initialValue: [] })
+  const docksSharedState = await rpcHost.sharedState.get('devframe:docks', { initialValue: [] })
 
   docksHost.events.on('dock:entry:updated', debounce(() => {
     docksSharedState.mutate(() => context.docks.values())
@@ -131,7 +131,7 @@ export async function createHostContext(options: CreateHostContextOptions): Prom
 
   terminalsHost.events.on('terminal:session:updated', debounce(() => {
     rpcHost.broadcast({
-      method: 'devtoolskit:internal:terminals:updated',
+      method: 'devframe:terminals:updated',
       args: [],
     })
     docksSharedState.mutate(() => context.docks.values())
@@ -139,7 +139,7 @@ export async function createHostContext(options: CreateHostContextOptions): Prom
 
   const debouncedMessagesUpdate = debounce(() => {
     rpcHost.broadcast({
-      method: 'devtoolskit:internal:messages:updated',
+      method: 'devframe:messages:updated',
       args: [],
     })
     docksSharedState.mutate(() => context.docks.values())
@@ -150,7 +150,7 @@ export async function createHostContext(options: CreateHostContextOptions): Prom
   messagesHost.events.on('message:removed', () => debouncedMessagesUpdate())
   messagesHost.events.on('message:cleared', () => debouncedMessagesUpdate())
 
-  const commandsSharedState = await rpcHost.sharedState.get('devtoolskit:internal:commands', { initialValue: [] })
+  const commandsSharedState = await rpcHost.sharedState.get('devframe:commands', { initialValue: [] })
   const debouncedCommandsSync = debounce(() => {
     commandsSharedState.mutate(() => commandsHost.list())
   }, mode === 'build' ? 0 : 10)

--- a/devframe/packages/devframe/src/node/host-docks.ts
+++ b/devframe/packages/devframe/src/node/host-docks.ts
@@ -65,7 +65,7 @@ export class DevToolsDockHost implements DevToolsDockHostType {
   }
 
   async init() {
-    this.userSettings = await this.context.rpc.sharedState.get('devtoolskit:internal:user-settings', {
+    this.userSettings = await this.context.rpc.sharedState.get('devframe:user-settings', {
       sharedState: createStorage({
         filepath: join(this.context.workspaceRoot, 'node_modules/.vite/devtools/settings.json'),
         initialValue: DEFAULT_STATE_USER_SETTINGS(),

--- a/devframe/packages/devframe/src/node/host-terminals.ts
+++ b/devframe/packages/devframe/src/node/host-terminals.ts
@@ -9,7 +9,7 @@ import { logger } from './diagnostics'
  * standalone client (`packages/core/src/client/webcomponents/state/terminals.ts`)
  * can subscribe by a stable, well-known name.
  */
-const TERMINAL_STREAM_CHANNEL = 'devtoolskit:internal:terminals' as const
+const TERMINAL_STREAM_CHANNEL = 'devframe:terminals' as const
 const TERMINAL_REPLAY_WINDOW = 1000
 
 export class DevToolsTerminalHost implements DevToolsTerminalHostType {
@@ -92,7 +92,7 @@ export class DevToolsTerminalHost implements DevToolsTerminalHostType {
     const channel = this.getStreamingChannel()
     // The streaming channel reuses `session.id` as the stream id so clients
     // can subscribe immediately after seeing the session in
-    // `devtoolskit:internal:terminals:list`.
+    // `devframe:terminals:list`.
     const sink = channel?.start({ id: session.id })
 
     const writer = new WritableStream<string>({

--- a/devframe/packages/devframe/src/node/rpc-shared-state.ts
+++ b/devframe/packages/devframe/src/node/rpc-shared-state.ts
@@ -21,7 +21,7 @@ export function createRpcSharedStateServerHost(
         if (patches) {
           debug('patch', { key, syncId })
           rpc.broadcast({
-            method: 'devtoolskit:internal:rpc:client-state:patch',
+            method: 'devframe:rpc:client-state:patch',
             args: [key, patches, syncId],
             filter: client => client.$meta.subscribedStates.has(key),
           })
@@ -29,7 +29,7 @@ export function createRpcSharedStateServerHost(
         else {
           debug('updated', { key, syncId })
           rpc.broadcast({
-            method: 'devtoolskit:internal:rpc:client-state:updated',
+            method: 'devframe:rpc:client-state:updated',
             args: [key, fullState, syncId],
             filter: client => client.$meta.subscribedStates.has(key),
           })
@@ -80,7 +80,7 @@ export function createRpcSharedStateServerHost(
   // server built on `RpcFunctionsHost` (devframe standalone or kit /
   // core) gets the full sync protocol out of the box.
   rpc.register({
-    name: 'devtoolskit:internal:rpc:server-state:subscribe',
+    name: 'devframe:rpc:server-state:subscribe',
     type: 'event',
     handler(key: string) {
       const session = rpc.getCurrentRpcSession()
@@ -92,7 +92,7 @@ export function createRpcSharedStateServerHost(
   })
 
   rpc.register({
-    name: 'devtoolskit:internal:rpc:server-state:get',
+    name: 'devframe:rpc:server-state:get',
     type: 'query',
     handler: async (key: string) => {
       if (!sharedState.has(key))
@@ -108,7 +108,7 @@ export function createRpcSharedStateServerHost(
   })
 
   rpc.register({
-    name: 'devtoolskit:internal:rpc:server-state:set',
+    name: 'devframe:rpc:server-state:set',
     type: 'query',
     handler: async (key: string, value: any, syncId: string) => {
       const state = await host.get(key as keyof DevToolsRpcSharedStates, {
@@ -119,7 +119,7 @@ export function createRpcSharedStateServerHost(
   })
 
   rpc.register({
-    name: 'devtoolskit:internal:rpc:server-state:patch',
+    name: 'devframe:rpc:server-state:patch',
     type: 'query',
     handler: async (key: string, patches: SharedStatePatch[], syncId: string) => {
       if (!sharedState.has(key))

--- a/devframe/packages/devframe/src/node/rpc-streaming.ts
+++ b/devframe/packages/devframe/src/node/rpc-streaming.ts
@@ -92,7 +92,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
   }
 
   rpc.register({
-    name: 'devtoolskit:internal:streaming:subscribe',
+    name: 'devframe:streaming:subscribe',
     type: 'event',
     handler(channelName: string, id: string, opts?: { afterSeq?: number }) {
       const state = channels.get(channelName)
@@ -118,7 +118,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
       for (const buffered of record.sink.buffer) {
         if (buffered.seq > afterSeq) {
           rpc.broadcast({
-            method: 'devtoolskit:internal:streaming:chunk',
+            method: 'devframe:streaming:chunk',
             args: [channelName, id, buffered.seq, buffered.chunk],
             event: true,
             optional: true,
@@ -128,7 +128,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
       }
       if (record.sink.closed) {
         rpc.broadcast({
-          method: 'devtoolskit:internal:streaming:end',
+          method: 'devframe:streaming:end',
           args: [channelName, id, undefined],
           event: true,
           optional: true,
@@ -139,7 +139,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
   })
 
   rpc.register({
-    name: 'devtoolskit:internal:streaming:unsubscribe',
+    name: 'devframe:streaming:unsubscribe',
     type: 'event',
     handler(channelName: string, id: string) {
       const state = channels.get(channelName)
@@ -156,7 +156,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
   })
 
   rpc.register({
-    name: 'devtoolskit:internal:streaming:cancel',
+    name: 'devframe:streaming:cancel',
     type: 'event',
     handler(channelName: string, id: string) {
       const record = findStream(channelName, id)
@@ -175,7 +175,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
   })
 
   rpc.register({
-    name: 'devtoolskit:internal:streaming:upload-chunk',
+    name: 'devframe:streaming:upload-chunk',
     type: 'event',
     handler(channelName: string, id: string, seq: number, chunk: any) {
       const state = channels.get(channelName)
@@ -201,7 +201,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
   })
 
   rpc.register({
-    name: 'devtoolskit:internal:streaming:upload-end',
+    name: 'devframe:streaming:upload-end',
     type: 'event',
     handler(channelName: string, id: string, error?: StreamErrorPayload) {
       const state = channels.get(channelName)
@@ -250,7 +250,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
       record.unbinders.push(
         sink.events.on('chunk', (seq, chunk) => {
           rpc.broadcast({
-            method: 'devtoolskit:internal:streaming:chunk',
+            method: 'devframe:streaming:chunk',
             args: [name, sink.id, seq, chunk],
             event: true,
             optional: true,
@@ -261,7 +261,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
       record.unbinders.push(
         sink.events.on('end', (error) => {
           rpc.broadcast({
-            method: 'devtoolskit:internal:streaming:end',
+            method: 'devframe:streaming:end',
             args: [name, sink.id, error],
             event: true,
             optional: true,
@@ -304,7 +304,7 @@ export function createRpcStreamingServerHost(rpc: RpcFunctionsHost): RpcStreamin
           if (!targetMeta)
             return
           rpc.broadcast({
-            method: 'devtoolskit:internal:streaming:upload-cancel',
+            method: 'devframe:streaming:upload-cancel',
             args: [name, reader.id],
             event: true,
             optional: true,

--- a/devframe/packages/devframe/src/types/rpc-augments.ts
+++ b/devframe/packages/devframe/src/types/rpc-augments.ts
@@ -8,21 +8,21 @@ export interface DevToolsRpcClientFunctions {
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:chunk': (channel: string, id: string, seq: number, chunk: any) => Promise<void>
+  'devframe:streaming:chunk': (channel: string, id: string, seq: number, chunk: any) => Promise<void>
   /**
    * Streaming terminator pushed from server to subscribed clients. Wired by
    * `RpcStreamingHost`; do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:end': (channel: string, id: string, error?: { name: string, message: string }) => Promise<void>
+  'devframe:streaming:end': (channel: string, id: string, error?: { name: string, message: string }) => Promise<void>
   /**
    * Server→client cancel for an in-flight upload. Wired by
    * `RpcStreamingHost`; do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:upload-cancel': (channel: string, id: string) => Promise<void>
+  'devframe:streaming:upload-cancel': (channel: string, id: string) => Promise<void>
 }
 
 /**
@@ -35,63 +35,63 @@ export interface DevToolsRpcServerFunctions {
    *
    * @internal
    */
-  'devtoolskit:internal:rpc:server-state:subscribe': (key: string) => Promise<void>
+  'devframe:rpc:server-state:subscribe': (key: string) => Promise<void>
   /**
    * Read the current value for a shared-state key. Wired by
    * `RpcSharedStateHost`; do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:rpc:server-state:get': (key: string) => Promise<any>
+  'devframe:rpc:server-state:get': (key: string) => Promise<any>
   /**
    * Replace a shared-state value (from the client). Wired by
    * `RpcSharedStateHost`; do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:rpc:server-state:set': (key: string, value: any, syncId: string) => Promise<void>
+  'devframe:rpc:server-state:set': (key: string, value: any, syncId: string) => Promise<void>
   /**
    * Apply a patch to a shared-state value (from the client). Wired by
    * `RpcSharedStateHost`; do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:rpc:server-state:patch': (key: string, patches: any[], syncId: string) => Promise<void>
+  'devframe:rpc:server-state:patch': (key: string, patches: any[], syncId: string) => Promise<void>
   /**
    * Client→server streaming subscription with optional replay cursor.
    * Wired by `RpcStreamingHost`; do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:subscribe': (channel: string, id: string, opts?: { afterSeq?: number }) => Promise<void>
+  'devframe:streaming:subscribe': (channel: string, id: string, opts?: { afterSeq?: number }) => Promise<void>
   /**
    * Client→server streaming unsubscribe. Wired by `RpcStreamingHost`;
    * do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:unsubscribe': (channel: string, id: string) => Promise<void>
+  'devframe:streaming:unsubscribe': (channel: string, id: string) => Promise<void>
   /**
    * Client→server streaming cancellation request. Wired by
    * `RpcStreamingHost`; do not register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:cancel': (channel: string, id: string) => Promise<void>
+  'devframe:streaming:cancel': (channel: string, id: string) => Promise<void>
   /**
    * Client→server upload chunk. Wired by `RpcStreamingHost`; do not
    * register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:upload-chunk': (channel: string, id: string, seq: number, chunk: any) => Promise<void>
+  'devframe:streaming:upload-chunk': (channel: string, id: string, seq: number, chunk: any) => Promise<void>
   /**
    * Client→server upload terminator. Wired by `RpcStreamingHost`; do not
    * register manually.
    *
    * @internal
    */
-  'devtoolskit:internal:streaming:upload-end': (channel: string, id: string, error?: { name: string, message: string }) => Promise<void>
+  'devframe:streaming:upload-end': (channel: string, id: string, error?: { name: string, message: string }) => Promise<void>
 }
 
 /**

--- a/docs/kit/remote-client.md
+++ b/docs/kit/remote-client.md
@@ -194,7 +194,7 @@ The session token is:
 
 - **Pre-approved** — no interactive "trust this browser?" prompt fires. The user already agreed to the integration when they installed your plugin.
 - **Session-scoped** — stored in memory only, regenerated on every dev-server restart.
-- **Re-register-scoped** — calling `ctx.docks.register(..., true)` again for the same id revokes the previous token before allocating a new one. Any live WS clients using the old token receive `devtoolskit:internal:auth:revoked` and become untrusted.
+- **Re-register-scoped** — calling `ctx.docks.register(..., true)` again for the same id revokes the previous token before allocating a new one. Any live WS clients using the old token receive `devframe:auth:revoked` and become untrusted.
 - **Origin-locked by default** — only connections whose `Origin` header matches the dock URL's origin are accepted.
 
 Because the token rides in the URL (fragment or query), it should be treated as a session secret: don't log URLs to external services on the hosted page, and prefer `transport: 'fragment'` unless you have a specific reason not to.

--- a/docs/kit/remote-demo.md
+++ b/docs/kit/remote-demo.md
@@ -57,7 +57,7 @@ onMounted(async () => {
 
     // Subscribe to the built-in docks shared state to show a live list
     // of dock entries registered on the local dev server.
-    const docks = await client.sharedState.get('devtoolskit:internal:docks' as any)
+    const docks = await client.sharedState.get('devframe:docks' as any)
     const toSummary = (entries: any[]) => (entries ?? [])
       .filter(e => e?.type !== '~builtin')
       .map(e => ({ id: String(e.id), title: String(e.title ?? e.id), type: String(e.type) }))
@@ -117,7 +117,7 @@ ctx.docks.register({
   </table>
 
   <h3>Live dock registry</h3>
-  <p class="remote-demo-dim">Subscribed to the built-in <code>devtoolskit:internal:docks</code> shared state — this list updates whenever a dock is registered, updated, or removed on the local dev server.</p>
+  <p class="remote-demo-dim">Subscribed to the built-in <code>devframe:docks</code> shared state — this list updates whenever a dock is registered, updated, or removed on the local dev server.</p>
   <ul v-if="docksList.length > 0" class="remote-demo-list">
     <li v-for="dock in docksList" :key="dock.id">
       <code>{{ dock.id }}</code> — {{ dock.title }} <span class="remote-demo-dim">({{ dock.type }})</span>
@@ -176,6 +176,6 @@ ctx.docks.register({
 1. Your plugin registers an iframe dock with `remote: true` pointing at this page.
 2. The DevTools core allocates a session-only auth token and appends the connection descriptor to the iframe URL: `#vite-devtools-kit-connection=…`
 3. When this page loads, [`parseRemoteConnection()`](./remote-client#connect-from-the-hosted-page) reads the descriptor, and [`connectRemoteDevTools()`](./remote-client#connect-from-the-hosted-page) opens a WebSocket back to the local dev server.
-4. The live "dock registry" list above subscribes to the `devtoolskit:internal:docks` shared state — it re-renders on every registration change.
+4. The live "dock registry" list above subscribes to the `devframe:docks` shared state — it re-renders on every registration change.
 
 See the [Remote Client guide](./remote-client) for the full API and the underlying security model.

--- a/packages/core/src/client/webcomponents/state/__tests__/context-cache.test.ts
+++ b/packages/core/src/client/webcomponents/state/__tests__/context-cache.test.ts
@@ -25,11 +25,11 @@ function createMockRpc(entries: DevToolsDockEntry[] = []): DevToolsRpcClient {
   return {
     sharedState: {
       get: async (key: string) => {
-        if (key === 'devtoolskit:internal:docks')
+        if (key === 'devframe:docks')
           return docksState as any
-        if (key === 'devtoolskit:internal:user-settings')
+        if (key === 'devframe:user-settings')
           return settingsState as any
-        if (key === 'devtoolskit:internal:commands')
+        if (key === 'devframe:commands')
           return commandsState as any
         throw new Error(`Unexpected shared state key: ${key}`)
       },

--- a/packages/core/src/client/webcomponents/state/commands.ts
+++ b/packages/core/src/client/webcomponents/state/commands.ts
@@ -22,7 +22,7 @@ export async function createCommandsContext(
   }
 
   // Server commands from shared state
-  const serverCommandsState = await rpc.sharedState.get('devtoolskit:internal:commands', { initialValue: [] })
+  const serverCommandsState = await rpc.sharedState.get('devframe:commands', { initialValue: [] })
   const serverCommands: ShallowRef<DevToolsServerCommandEntry[]> = sharedStateToRef(serverCommandsState)
 
   // Client commands (local registry)

--- a/packages/core/src/client/webcomponents/state/context.ts
+++ b/packages/core/src/client/webcomponents/state/context.ts
@@ -101,7 +101,7 @@ export async function createDocksContext(
   const getSettingsStore = async () => {
     if (!_settingsStorePromise) {
       _settingsStorePromise = rpc.sharedState.get(
-        'devtoolskit:internal:user-settings',
+        'devframe:user-settings',
         { initialValue: DEFAULT_STATE_USER_SETTINGS() },
       )
     }

--- a/packages/core/src/client/webcomponents/state/docks.ts
+++ b/packages/core/src/client/webcomponents/state/docks.ts
@@ -79,7 +79,7 @@ export async function useDocksEntries(rpc: DevToolsRpcClient): Promise<Ref<DevTo
   if (docksEntriesRefByRpc.has(rpc)) {
     return docksEntriesRefByRpc.get(rpc)!
   }
-  const state = await rpc.sharedState.get('devtoolskit:internal:docks', { initialValue: [] })
+  const state = await rpc.sharedState.get('devframe:docks', { initialValue: [] })
   const docksEntriesRef = sharedStateToRef(state)
   docksEntriesRefByRpc.set(rpc, docksEntriesRef)
   return docksEntriesRef

--- a/packages/core/src/client/webcomponents/state/messages.ts
+++ b/packages/core/src/client/webcomponents/state/messages.ts
@@ -62,7 +62,7 @@ export function useMessages(context: DocksContext): Reactive<MessagesState> {
   }
 
   context.rpc.client.register({
-    name: 'devtoolskit:internal:messages:updated' satisfies keyof DevToolsRpcClientFunctions,
+    name: 'devframe:messages:updated' satisfies keyof DevToolsRpcClientFunctions,
     type: 'action',
     handler: () => {
       if (context.rpc.isTrusted)

--- a/packages/core/src/client/webcomponents/state/terminals.ts
+++ b/packages/core/src/client/webcomponents/state/terminals.ts
@@ -4,7 +4,7 @@ import type { Terminal } from '@xterm/xterm'
 import type { Reactive } from 'vue'
 import { reactive } from 'vue'
 
-const TERMINAL_STREAM_CHANNEL = 'devtoolskit:internal:terminals'
+const TERMINAL_STREAM_CHANNEL = 'devframe:terminals'
 
 export interface TerminalState {
   info: DevToolsTerminalSessionBase
@@ -61,7 +61,7 @@ export function useTerminals(context: DocksContext): Reactive<Map<string, Termin
     console.log('[VITE DEVTOOLS] Terminals Updated', [...map.values()])
   }
   context.rpc.client.register({
-    name: 'devtoolskit:internal:terminals:updated' satisfies keyof DevToolsRpcClientFunctions,
+    name: 'devframe:terminals:updated' satisfies keyof DevToolsRpcClientFunctions,
     type: 'action',
     handler: () => updateTerminals(),
   })

--- a/packages/core/src/node/rpc/index.ts
+++ b/packages/core/src/node/rpc/index.ts
@@ -61,18 +61,18 @@ declare module '@vitejs/devtools-kit' {
 
   // @keep-sorted
   export interface DevToolsRpcClientFunctions {
-    'devtoolskit:internal:auth:revoked': () => Promise<void>
-    'devtoolskit:internal:messages:updated': () => Promise<void>
-    'devtoolskit:internal:rpc:client-state:patch': (key: string, patches: SharedStatePatch[], syncId: string) => Promise<void>
-    'devtoolskit:internal:rpc:client-state:updated': (key: string, fullState: any, syncId: string) => Promise<void>
+    'devframe:auth:revoked': () => Promise<void>
+    'devframe:messages:updated': () => Promise<void>
+    'devframe:rpc:client-state:patch': (key: string, patches: SharedStatePatch[], syncId: string) => Promise<void>
+    'devframe:rpc:client-state:updated': (key: string, fullState: any, syncId: string) => Promise<void>
 
-    'devtoolskit:internal:terminals:updated': () => Promise<void>
+    'devframe:terminals:updated': () => Promise<void>
   }
 
   // @keep-sorted
   export interface DevToolsRpcSharedStates {
-    'devtoolskit:internal:commands': DevToolsServerCommandEntry[]
-    'devtoolskit:internal:docks': DevToolsDockEntry[]
-    'devtoolskit:internal:user-settings': DevToolsDocksUserSettings
+    'devframe:commands': DevToolsServerCommandEntry[]
+    'devframe:docks': DevToolsDockEntry[]
+    'devframe:user-settings': DevToolsDocksUserSettings
   }
 }

--- a/packages/self-inspect/src/app/components/SharedStateView.vue
+++ b/packages/self-inspect/src/app/components/SharedStateView.vue
@@ -15,7 +15,7 @@ const selectedKey = ref<string>()
 const filteredKeys = computed(() => {
   if (showInternal.value)
     return props.keys
-  return props.keys.filter(key => !key.startsWith('devtoolskit:internal:') && !key.startsWith('__'))
+  return props.keys.filter(key => !key.startsWith('devframe:') && !key.startsWith('__'))
 })
 const stateValue = shallowRef<any>()
 const loading = ref(false)
@@ -23,7 +23,7 @@ const loading = ref(false)
 async function loadState(key: string) {
   loading.value = true
   try {
-    stateValue.value = await rpc.value.call('devtoolskit:internal:rpc:server-state:get', key)
+    stateValue.value = await rpc.value.call('devframe:rpc:server-state:get', key)
   }
   finally {
     loading.value = false
@@ -45,7 +45,7 @@ async function handleChange(value: any) {
     return
   const syncId = nanoid()
   stateValue.value = value
-  await rpc.value.call('devtoolskit:internal:rpc:server-state:set', selectedKey.value, value, syncId)
+  await rpc.value.call('devframe:rpc:server-state:set', selectedKey.value, value, syncId)
 }
 </script>
 

--- a/skills/vite-devtools-kit/references/remote-client-patterns.md
+++ b/skills/vite-devtools-kit/references/remote-client-patterns.md
@@ -137,7 +137,7 @@ JSON-encoded then base64url-encoded, appended to the iframe URL under the key `v
 
 - **Pre-approved session token** — no interactive "trust this browser?" prompt. The user agreed to the integration when they installed your plugin.
 - **Session-scoped** — in-memory only, regenerated on every dev-server restart.
-- **Re-register revokes** — registering the same id again revokes the previous token; live clients using the old token receive `devtoolskit:internal:auth:revoked` and become untrusted.
+- **Re-register revokes** — registering the same id again revokes the previous token; live clients using the old token receive `devframe:auth:revoked` and become untrusted.
 - **Origin-locked by default** — only connections whose `Origin` matches the dock URL origin are accepted.
 
 Treat the token as a session secret: don't log URLs to external analytics on the hosted page, and prefer `transport: 'fragment'` unless you have a specific reason not to.


### PR DESCRIPTION
### Description

Renames legacy `devtoolskit:internal:*` identifiers owned by `devframe` to the `devframe:*` prefix. This aligns with the convention already used by newer code in the package (e.g. `devframe:open-in-editor`, `devframe:agent:list-tools`, `devframe://resource/<id>`) and fits devframe's positioning to be extracted into its own repo.

Scope is the wire-protocol IDs that originate inside `devframe/packages/devframe/`: streaming (`streaming:chunk/end/subscribe/...`), shared-state RPC (`rpc:server-state:*`, `rpc:client-state:*`), the auth-revoked event, the `terminals:updated` / `messages:updated` server→client events, the `terminals` stream channel, and the `user-settings` / `docks` / `commands` / `json-render:N` shared-state keys. Consumers in `packages/core` and `packages/self-inspect` are updated in lockstep so the WS protocol stays consistent. Core-owned RPC function names (`terminals:read`, `messages:add`, `commands:execute`, `docks:on-launch`, `rpc:server:list`, etc.) are intentionally **not** renamed.

### Linked Issues

### Additional context

`pnpm typecheck` / `test` (450 passing) / `lint` / `build` all green.