### PR TITLE
fix(self-inspect): declare jsonSerializable on agent-flagged RPCs

### DIFF
--- a/packages/self-inspect/src/node/rpc/functions/get-client-scripts.ts
+++ b/packages/self-inspect/src/node/rpc/functions/get-client-scripts.ts
@@ -4,6 +4,7 @@ import { defineRpcFunction } from '@vitejs/devtools-kit'
 export const getClientScripts = defineRpcFunction({
   name: 'devtoolskit:self-inspect:get-client-scripts',
   type: 'query',
+  jsonSerializable: true,
   agent: {
     description: 'List client-side scripts attached to UI docks (actions, custom renderers, and iframe clientScripts). Read-only — returns the stringified scripts, not their execution state.',
     title: 'List client scripts',

--- a/packages/self-inspect/src/node/rpc/functions/get-devtools-plugins.ts
+++ b/packages/self-inspect/src/node/rpc/functions/get-devtools-plugins.ts
@@ -4,6 +4,7 @@ import { defineRpcFunction } from '@vitejs/devtools-kit'
 export const getDevtoolsPlugins = defineRpcFunction({
   name: 'devtoolskit:self-inspect:get-devtools-plugins',
   type: 'query',
+  jsonSerializable: true,
   agent: {
     description: 'List every Vite plugin involved in the current project, flagging which ones export a `devtools` hook (and whether that hook sets up any devtools surface). Read-only.',
     title: 'List devtools plugins',

--- a/packages/self-inspect/src/node/rpc/functions/get-docks.ts
+++ b/packages/self-inspect/src/node/rpc/functions/get-docks.ts
@@ -3,6 +3,7 @@ import { defineRpcFunction } from '@vitejs/devtools-kit'
 export const getDocks = defineRpcFunction({
   name: 'devtoolskit:self-inspect:get-docks',
   type: 'query',
+  jsonSerializable: true,
   agent: {
     description: 'List every UI dock/panel registered on the devtools. Each entry includes id, title, icon, category, and how the dock is rendered (iframe, action, custom-render, launcher). Read-only.',
     title: 'List docks',

--- a/packages/self-inspect/src/node/rpc/functions/get-rpc-functions.ts
+++ b/packages/self-inspect/src/node/rpc/functions/get-rpc-functions.ts
@@ -3,6 +3,7 @@ import { defineRpcFunction } from '@vitejs/devtools-kit'
 export const getRpcFunctions = defineRpcFunction({
   name: 'devtoolskit:self-inspect:get-rpc-functions',
   type: 'query',
+  jsonSerializable: true,
   agent: {
     description: 'List every RPC function registered on the devtools server, with metadata (name, type, whether it has args/returns schemas, dump, setup, handler). Useful for discovering what functionality the running devtools expose. Read-only.',
     title: 'List RPC functions',

--- a/packages/self-inspect/src/node/rpc/functions/get-shared-state-keys.ts
+++ b/packages/self-inspect/src/node/rpc/functions/get-shared-state-keys.ts
@@ -3,6 +3,7 @@ import { defineRpcFunction } from '@vitejs/devtools-kit'
 export const getSharedStateKeys = defineRpcFunction({
   name: 'devtoolskit:self-inspect:get-shared-state-keys',
   type: 'query',
+  jsonSerializable: true,
   agent: {
     description: 'List the keys of all shared-state entries published by the devtools server. Read-only. Combine with the `devframe://state/<key>` MCP resource to inspect values.',
     title: 'List shared-state keys',


### PR DESCRIPTION
### Description

#301 introduced the `agent` => `jsonSerializable: true` contract but missed the 5 agent-flagged RPCs in `packages/self-inspect`, breaking `pnpm play` at registration with DF0019 error. 

### Additional context

https://github.com/vitejs/devtools/blob/72cfb9d194e0aa3653b3f22d46c4f482e1c59e50/devframe/packages/devframe/src/rpc/collector.ts#L100-L101