### PR TITLE
docs: revise tone — positive framing, fewer callouts, kit-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,3 +182,42 @@ pnpm lint && pnpm test && pnpm typecheck && pnpm build
 ```
 
 Follow conventional commits (`feat:`, `fix:`, etc.).
+
+## Documentation style
+
+These rules apply to every Markdown file under `docs/` and `devframe/docs/` (the error reference pages are template-driven and exempt). Apply them on every doc edit, not just dedicated revision passes.
+
+### 1. Positive framing
+
+Describe what *is*, not what *isn't*. Replace constructions like "X is for Y, not Z" or "there is no X for Y" with the closest natural positive phrasing. Don't document features that don't exist yet — release notes are the place for "now supported" announcements; docs describe what works today.
+
+- ❌ "Build mode only; dev mode is not supported yet."
+- ✅ "Analyses production builds in Vite 8+."
+
+- ❌ "For tools that don't need Vite at all."
+- ✅ "Standalone tools can build directly on DevFrame."
+
+### 2. Use callouts sparingly
+
+Callouts (`> [!NOTE]`, `> [!TIP]`, `> [!INFO]`, `::: tip`, etc.) interrupt the reading flow and should earn their visual weight. Default to prose; reach for a callout only for genuinely critical material.
+
+- **`[!WARNING]` / `[!DANGER]`** — security hazards, footguns, breaking-change pitfalls, experimental-API stability warnings. Keep these.
+- **Bad-practice "✗" inline blocks** — fine inside code samples to contrast with a `✓` good example.
+- **Everything else** — fold into the surrounding prose. A `[!NOTE]` that says "you only need this as a dev dependency" reads better as a sentence in the install section.
+
+### 3. Kit-first in `/docs/`
+
+The main docs site is for **Vite DevTools** and **`@vitejs/devtools-kit`** users. DevFrame is the framework-neutral foundation underneath; mention it where relevant ("Kit is built on DevFrame; standalone tools can use DevFrame directly — see [DevFrame](https://devfra.me/guide/)") but lead examples and guides with the Kit / Vite plugin path.
+
+`devframe/docs/` is the inverse: DevFrame-first, with cross-links to Kit for hub-only features (docks, terminals, messages, commands).
+
+### 4. Concise and precise
+
+Trim filler intros, redundant cross-links (one link per page is enough — VitePress sidebars handle navigation), and code samples that demonstrate more than the point being made. Lead each page with one sentence that says what the reader can build with this. Strip out promises about future work, marketing language ("powerful", "seamless"), and exposition that the surrounding code already conveys.
+
+### What goes where
+
+- Critical security / data-loss hazard → `[!WARNING]` callout.
+- Experimental API / stability caveat → `[!WARNING]` callout at the top of the page.
+- Bad-practice contrast → inline `// ✗ Bad` / `// ✓ Good` comments inside code blocks.
+- Anything else worth saying → prose.

--- a/devframe/docs/guide/adapters.md
+++ b/devframe/docs/guide/adapters.md
@@ -4,9 +4,9 @@ outline: deep
 
 # Adapters
 
-An adapter takes a `DevtoolDefinition` and deploys it into a specific runtime — a standalone CLI, a Vite plugin, a static snapshot, an SPA, a Kit plugin, an embedded host, or an MCP server. Each adapter lives at its own entry point (`devframe/adapters/<name>`), so only the adapters you actually use are pulled into your bundle.
+An adapter takes a `DevtoolDefinition` and deploys it into a specific runtime — a standalone CLI, a Vite plugin, a static snapshot, an SPA, a Kit plugin, an embedded host, or an MCP server. Each adapter ships at its own entry point (`devframe/adapters/<name>`); the bundler pulls in only the ones you use.
 
-All adapter factories share the same shape: `createXxx(devtoolDef, options?)`.
+Every adapter factory has the shape `createXxx(devtoolDef, options?)`.
 
 ## Comparison
 
@@ -22,7 +22,7 @@ All adapter factories share the same shape: `createXxx(devtoolDef, options?)`.
 
 ## CLI
 
-The CLI adapter wraps a `DevtoolDefinition` in a `cac`-powered command-line interface. It spins up an `h3` dev server with WebSocket RPC, builds static snapshots, builds SPA bundles, or starts an MCP server — all from one entry.
+The CLI adapter wraps a `DevtoolDefinition` in a `cac`-powered command-line interface. From one entry it spins up an `h3` dev server with WebSocket RPC, builds static snapshots, builds SPA bundles, or starts an MCP server.
 
 ```ts
 import { defineDevtool } from 'devframe'
@@ -48,7 +48,7 @@ my-devtool build --out-dir dist-static --base /devtools/
 my-devtool mcp                 # stdio MCP server (experimental)
 ```
 
-> Standalone CLI serves the SPA at `/` by default — no `/__devtools/` prefix. That prefix is reserved for *hosted* adapters where devframe mounts alongside an existing app. See [Mount paths](#mount-paths) below.
+Standalone CLI serves the SPA at `/` by default. The `/__devtools/` prefix is for *hosted* adapters where devframe mounts alongside an existing app — see [Mount paths](#mount-paths).
 
 ### Options
 
@@ -69,7 +69,7 @@ interface CliHandle {
 }
 ```
 
-The `cli` property lets the caller add ad-hoc commands and flags right before `parse()` for cases where a `configureCli` callback is inconvenient.
+The `cli` property lets the caller add ad-hoc commands and flags right before `parse()` when a `configureCli` callback is inconvenient.
 
 ### Definition-level `cli` fields
 
@@ -102,7 +102,7 @@ defineDevtool({
 
 ### Headless logging
 
-Devframe deliberately does not print a startup banner of its own. Wire `onReady` if you want one:
+Devframe leaves startup output to the application. Wire `onReady` to print your own banner:
 
 ```ts
 await createCli(devtool, {
@@ -116,7 +116,7 @@ Structured diagnostics (via `logs-sdk`) continue to surface through their normal
 
 ### Use your own CLI framework
 
-When `createCli`'s baked-in `dev` / `build` / `mcp` triplet doesn't fit — e.g. integrating devframe into an existing commander/yargs program, or exposing a different command structure — drop down to the peer factories. Same `DevtoolDefinition`, different shell:
+To integrate devframe into an existing commander / yargs program — or to expose a different command structure than `createCli`'s `dev` / `build` / `mcp` triplet — drop down to the peer factories. Same `DevtoolDefinition`, different shell:
 
 | Building block | Entry | Purpose |
 |----------------|-------|---------|
@@ -129,7 +129,7 @@ See the [Standalone CLI guide](./standalone-cli#use-your-own-cli-framework) for 
 
 ## Dev
 
-The `dev` adapter is the building block `createCli` uses internally — h3 + WebSocket RPC + the author's SPA mounted at the resolved base path. Reach for it directly when you want to mount the dev server inside an existing CLI program (commander, yargs, hand-rolled CAC) or attach custom middleware to the underlying h3 app.
+The `dev` adapter is the building block `createCli` uses internally — h3 + WebSocket RPC + the author's SPA mounted at the resolved base path. Reach for it directly to mount the dev server inside an existing CLI program (commander, yargs, hand-rolled CAC) or to attach custom middleware to the underlying h3 app.
 
 ```ts
 import { createDevServer } from 'devframe/adapters/dev'
@@ -144,7 +144,7 @@ const handle = await createDevServer(devtool, {
 process.on('SIGINT', () => handle.close().then(() => process.exit(0)))
 ```
 
-`createDevServer` returns the underlying `StartedServer` (origin, port, h3 app, WS server, RPC group, `close()`), so callers integrate cleanly into their own process lifecycle.
+`createDevServer` returns the underlying `StartedServer` (origin, port, h3 app, WS server, RPC group, `close()`) so callers can integrate it into their own process lifecycle.
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -159,7 +159,7 @@ process.on('SIGINT', () => handle.close().then(() => process.exit(0)))
 
 ### Port resolution
 
-`resolveDevServerPort(def, opts?)` is exposed separately so authors can resolve a port up-front (to print it, log it, etc.) before starting the server:
+`resolveDevServerPort(def, opts?)` resolves a port up-front (to print or log it) before the server starts:
 
 ```ts
 import { resolveDevServerPort } from 'devframe/adapters/dev'
@@ -175,12 +175,12 @@ const port = await resolveDevServerPort(devtool, { host: '127.0.0.1' })
 
 ## Mount paths
 
-The basePath where a devtool's SPA is mounted depends on the adapter it's running under:
+A devtool's SPA basePath depends on which adapter is running it:
 
 | Adapter kind | Default basePath | Reason |
 |--------------|------------------|--------|
-| `cli`, `spa`, `build` (standalone) | `/` | The devtool is the only thing on the origin. |
-| `vite`, `kit`, `embedded` (hosted) | `/__<id>/` | The devtool shares the origin with a host app and must namespace itself. |
+| `cli`, `spa`, `build` (standalone) | `/` | The devtool owns the origin. |
+| `vite`, `kit`, `embedded` (hosted) | `/__<id>/` | The devtool shares the origin with a host app and namespaces itself. |
 
 Override either side explicitly with `DevtoolDefinition.basePath`:
 
@@ -192,11 +192,11 @@ defineDevtool({
 })
 ```
 
-SPA authors should **build with relative asset paths** (`vite.base: './'`) rather than baking an absolute base into the output; the client resolves its connection descriptor relative to the page at runtime. See the [Client](./client#runtime-basepath-discovery) page for the discovery rules.
+SPA authors should build with relative asset paths (`vite.base: './'`); the client resolves its connection descriptor relative to the page at runtime. See [Client](./client#runtime-basepath-discovery) for the discovery rules.
 
 ## Vite
 
-A thin Vite plugin that mounts a devtool's SPA into an existing Vite dev server as a *hosted* adapter — the mount path defaults to `/__<id>/` to avoid colliding with the app. It **does not** start an RPC WebSocket server — use `kit` or `cli` when you need RPC.
+A thin Vite plugin that mounts a devtool's SPA into an existing Vite dev server as a *hosted* adapter — the mount path defaults to `/__<id>/` to namespace away from the app. The plugin mounts the SPA only; for RPC, use `kit` or `cli`.
 
 ```ts
 import { createVitePlugin } from 'devframe/adapters/vite'
@@ -212,7 +212,7 @@ export default defineConfig({
 |--------|---------|-------------|
 | `base` | `def.basePath ?? '/__<id>/'` | Mount path inside the Vite dev server. |
 
-Use this adapter when a devtool's UI is purely static (no server calls) and you want to surface it during Vite `serve` without shipping a separate dev server. Set `DevtoolDefinition.basePath` on the definition if you want a custom path that stays consistent across adapters.
+Use this adapter when a devtool's UI is purely static and you want to surface it during Vite `serve` without shipping a separate dev server. Set `DevtoolDefinition.basePath` on the definition for a custom path that stays consistent across adapters.
 
 ## Build
 
@@ -240,10 +240,9 @@ await createBuild(devtool, {
 | `base` | `/` | Absolute URL base the output is served from. |
 | `distDir` | `def.cli?.distDir` | Override the SPA dist directory. |
 
-The resulting directory can be hosted by any static web server (`serve`, nginx, GitHub Pages, …). The client auto-detects `static` mode via `./__connection.json` resolved against `document.baseURI` and runs in read-only form.
+The resulting directory hosts on any static web server (`serve`, nginx, GitHub Pages, …). The client auto-detects `static` mode by resolving `./__connection.json` against `document.baseURI` and runs in read-only form.
 
-> [!TIP]
-> `createBuild` copies the SPA verbatim. To deploy under a custom URL base, build your SPA with relative asset paths (`vite.base: './'`) — the client discovers the effective base at runtime. No HTML rewriting is performed at build time.
+`createBuild` copies the SPA verbatim, so deploying under a custom URL base just means building the SPA with relative asset paths (`vite.base: './'`) — the client discovers the effective base at runtime.
 
 When `def.spa` is set on the definition, `createBuild` also writes `spa-loader.json` next to `index.html` describing how the deployed SPA sources its data:
 
@@ -251,12 +250,11 @@ When `def.spa` is set on the definition, `createBuild` also writes `spa-loader.j
 - `'query'` — hydrate from URL search params.
 - `'upload'` — accept a drag-and-drop file.
 
-> [!NOTE]
-> `setupBrowser` bundling is not yet automated. Deployed SPAs that rely on it must ship their own client entry that registers the handlers.
+Deployed SPAs that use `setupBrowser` ship their own client entry that registers the handlers.
 
 ## Kit
 
-Wraps a `DevtoolDefinition` so that Vite DevTools Kit's plugin-scan picks it up. The factory lives in `@vitejs/devtools-kit/node` (kit owns docking + process management; devframe stays portable).
+Wraps a `DevtoolDefinition` so Vite DevTools Kit's plugin-scan picks it up. The factory lives in `@vitejs/devtools-kit/node` — kit owns docking and process management while devframe stays portable.
 
 ```ts
 import { createPluginFromDevframe } from '@vitejs/devtools-kit/node'
@@ -267,7 +265,7 @@ export default function myVitePlugin() {
 }
 ```
 
-The returned object has the shape `{ name, devtools: { setup, capabilities } }`. Use this adapter when your devtool should live inside the Vite DevTools dock alongside other integrations. The kit synthesises an iframe dock entry from the definition's `id` / `name` / `icon` / `basePath` automatically; for richer kit-specific behaviour (extra terminals, commands, dock overrides) pass `options.setup`. For a Vite-specific plugin guide, see the [DevTools Kit → DevTools Plugin](https://devtools.vite.dev/kit/devtools-plugin) page.
+The returned object has the shape `{ name, devtools: { setup, capabilities } }`. Use this adapter when your devtool should live inside the Vite DevTools dock alongside other integrations. Kit synthesises an iframe dock entry from the definition's `id` / `name` / `icon` / `basePath`; for richer kit-specific behaviour (extra terminals, commands, dock overrides) pass `options.setup`. See the [DevTools Kit → DevTools Plugin](https://devtools.vite.dev/kit/devtools-plugin) page for the Vite-specific guide.
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -278,7 +276,7 @@ The returned object has the shape `{ name, devtools: { setup, capabilities } }`.
 
 ## Embedded
 
-Register a devtool into an already-running context at runtime. Mirrors the internal plugin-scan that Kit runs at startup, but exposes it for callers that need dynamic, post-startup registration. The host decides the mount path; `embedded` is treated as a hosted adapter and inherits the `/__<id>/` default when one is needed.
+Register a devtool into an already-running context at runtime. Mirrors Kit's internal plugin-scan, but for callers that need dynamic, post-startup registration. The host decides the mount path; `embedded` is a hosted adapter and inherits the `/__<id>/` default when one is needed.
 
 ```ts
 import { createEmbedded } from 'devframe/adapters/embedded'
@@ -291,7 +289,7 @@ await createEmbedded(devtool, { ctx: existingCtx })
 |--------|----------|-------------|
 | `ctx` | ✓ | Target `DevToolsNodeContext` the devtool is registered into. |
 
-Useful when a host wants to load devtools based on runtime conditions (feature flags, user opt-in, dynamic discovery) rather than static config.
+Useful when a host loads devtools based on runtime conditions (feature flags, user opt-in, dynamic discovery) rather than static config.
 
 ## MCP
 
@@ -307,6 +305,6 @@ import devtool from './devtool'
 await createMcpServer(devtool, { transport: 'stdio' })
 ```
 
-`@modelcontextprotocol/sdk` is a peer dependency — install it when shipping MCP support. Today only `stdio` transport is implemented; HTTP / streamable transports are planned.
+`@modelcontextprotocol/sdk` is a peer dependency — install it when shipping MCP support. The current transport is `stdio`.
 
 See the [Agent-Native](./agent-native) page for the full API, safety model, and Claude Desktop integration example.

--- a/devframe/docs/guide/agent-native.md
+++ b/devframe/docs/guide/agent-native.md
@@ -8,15 +8,15 @@ outline: deep
 The agent-native surface (`agent` field on `defineRpcFunction`, `DevToolsAgentHost`, and the `devframe/adapters/mcp` adapter) is experimental and may change without a major version bump until it stabilizes.
 :::
 
-DevFrame can expose the same surface the browser DevTools UI consumes — RPC functions, resources, and shared state — to coding agents (Claude Desktop / Cursor / Zed / Claude Code, or any MCP-speaking client). Plugins opt in to agent exposure explicitly; everything else stays private by default.
+DevFrame can expose the same surface the browser DevTools UI consumes — RPC functions, resources, and shared state — to coding agents (Claude Desktop / Cursor / Zed / Claude Code, or any MCP-speaking client). Agent exposure is opt-in per function; functions stay private by default.
 
 ## How it works
 
 Three building blocks:
 
-1. **An `agent` field on `defineRpcFunction`.** Add `agent: { description, ... }` to opt a function in. Omit the field (default) to keep it private.
-2. **`ctx.agent`** — a host exposed on `DevToolsNodeContext`. Plugins can register tools that aren't backed by an RPC, or expose readable resources (e.g. a Markdown build summary).
-3. **The MCP adapter** (`devframe/adapters/mcp`) — translates the agent host into a [Model Context Protocol](https://modelcontextprotocol.io) server. Today it speaks `stdio`; HTTP transport is planned.
+1. **An `agent` field on `defineRpcFunction`.** Add `agent: { description, ... }` to opt a function in. Functions without the field stay private.
+2. **`ctx.agent`** — a host exposed on `DevToolsNodeContext`. Plugins register tools that aren't backed by an RPC, and expose readable resources (e.g. a Markdown build summary).
+3. **The MCP adapter** (`devframe/adapters/mcp`) — translates the agent host into a [Model Context Protocol](https://modelcontextprotocol.io) server, currently over `stdio`.
 
 ## Exposing an RPC function
 
@@ -41,11 +41,11 @@ export const getSessionSummary = defineRpcFunction({
 })
 ```
 
-Tip: agent tools take a single object input. If your RPC uses positional args (`args: [A, B]`), the MCP adapter synthesizes `arg0`, `arg1`, ... automatically — but agents work best with a single object schema (`args: [v.object({ ... })]`) so property names are self-describing.
+Agent tools take a single object input. The MCP adapter synthesises `arg0`, `arg1`, … from positional args (`args: [A, B]`); a single object schema (`args: [v.object({ ... })]`) reads better at the agent boundary because property names are self-describing.
 
 ## Registering a plugin tool
 
-When a tool doesn't naturally correspond to an RPC — e.g. an on-demand narrative summary — register it directly:
+For tools without a matching RPC — say, an on-demand narrative summary — register them directly:
 
 ```ts
 export default defineDevtool({
@@ -88,7 +88,7 @@ The simplest path is the CLI:
 devframe mcp
 ```
 
-You can also call it programmatically:
+Programmatic equivalent:
 
 ```ts
 import { defineDevtool } from 'devframe'
@@ -101,7 +101,7 @@ await createMcpServer(devtool, { transport: 'stdio' })
 
 `@modelcontextprotocol/sdk` is a peer dependency — add it to your package when you want to ship an MCP-enabled devtool.
 
-## Hooking into Claude Desktop
+## Connecting Claude Desktop
 
 Add an entry to `claude_desktop_config.json`:
 
@@ -120,7 +120,7 @@ Restart Claude Desktop. The tools you flagged with `agent: { ... }` (plus any `r
 
 ## Safety model
 
-- **Default-deny.** Functions without an `agent` field are not exposed.
+- **Opt-in exposure.** Functions opt in via the `agent` field; everything else stays private.
 - **`safety`** — one of `'read'`, `'action'`, `'destructive'`. Inferred from the RPC `type` (`static`/`query` → `read`, `action`/`event` → `action`), with explicit override available.
 - The MCP adapter maps `safety` to tool annotations (`readOnlyHint`, `destructiveHint`). MCP clients use these to decide whether to prompt for confirmation before calling.
 
@@ -129,11 +129,3 @@ Restart Claude Desktop. The tools you flagged with `agent: { ... }` (plus any `r
 | Command | Description |
 |---------|-------------|
 | `devframe mcp` | Start an MCP server on `stdio`. |
-
-More CLI subcommands (`devframe agent list / call / read`) are planned.
-
-## What's next
-
-- HTTP (streamable) MCP transport with a real auth model.
-- A `devframe agent ...` CLI for agents that drive via bash rather than MCP.
-- A built-in `~agent` dock in the browser UI for auditing the agent surface.

--- a/devframe/docs/guide/client.md
+++ b/devframe/docs/guide/client.md
@@ -18,19 +18,19 @@ const rpc = await connectDevtool()
 const modules = await rpc.call('my-devtool:get-modules', { limit: 10 })
 ```
 
-`connectDevtool` auto-detects the backend via `__devtools/__connection.json` and falls back through a sequence of base URLs. No arguments are needed when the client is hosted from the default mount path.
+`connectDevtool` auto-detects the backend via `__devtools/__connection.json`, with a sequence of base URLs as fallback. No arguments are needed when the client is hosted from the default mount path.
 
 ### Runtime basePath discovery
 
-SPAs built for devframe are designed to be **base-agnostic**: the same artifact can be served at `/`, at `/__<id>/`, or at any custom subpath, without rebuilding. `connectDevtool` resolves `__connection.json` relative to the page at runtime by reading `document.baseURI` and the executing script's URL.
+DevFrame SPAs are base-agnostic — the same artifact can be served at `/`, `/__<id>/`, or any custom subpath without rebuilding. `connectDevtool` resolves `__connection.json` at runtime by reading `document.baseURI` and the executing script's URL.
 
-The practical consequence for SPA authors:
+For SPA authors, that means:
 
-- Build with relative asset paths — in Vite use `base: './'`, in Nuxt set `vite.base: './'` and `app.baseURL: './'`.
-- Don't bake the mount path into the HTML. The server only needs to serve the files at *some* base; the client figures out which.
-- You don't need an explicit `baseURL` option on `connectDevtool` unless you're connecting across origins or to a non-colocated devtool server.
+- Build with relative asset paths — Vite `base: './'`, Nuxt `vite.base: './'` + `app.baseURL: './'`.
+- Leave the mount path out of the HTML. The server serves files at *some* base; the client figures out which.
+- Skip the `baseURL` option on `connectDevtool` unless you're connecting across origins or to a non-colocated devtool server.
 
-This lets `createBuild` copy SPA output verbatim — no build-time HTML rewriting is performed, and the resulting bundle deploys under any URL.
+That's how `createBuild` deploys SPA output verbatim under any URL — no build-time HTML rewriting needed.
 
 ### Options
 
@@ -46,27 +46,27 @@ await connectDevtool({
 
 | Option | Description |
 |--------|-------------|
-| `baseURL` | Mount path to probe for `__connection.json`. Accepts an array for fallback. Default: `'./'` — resolved relative to `document.baseURI` so the SPA finds its meta wherever it was deployed. Pass an explicit absolute path (e.g. `'/__devtools/'`) when calling from outside the SPA — for instance, an embedded webcomponent injected into a host app. |
+| `baseURL` | Mount path to probe for `__connection.json`. Accepts an array for fallback. Default: `'./'` — resolved relative to `document.baseURI` so the SPA finds its meta wherever it was deployed. Pass an explicit absolute path (e.g. `'/__devtools/'`) when calling from outside the SPA — say, an embedded webcomponent injected into a host app. |
 | `authToken` | Override the auth token. Defaults to a locally-persisted human-readable id. |
 | `cacheOptions` | `true` to enable caching with defaults, or an options object. |
 | `wsOptions` | Forwarded to the WebSocket transport (reconnect, heartbeat, etc.). |
 | `rpcOptions` | Forwarded to `birpc`. |
-| `connectionMeta` | Skip the `__connection.json` fetch with a pre-known descriptor. |
+| `connectionMeta` | Pre-known descriptor that skips the `__connection.json` fetch. |
 
 ## Modes
 
-The client runs in one of two modes depending on what the server advertises in `__devtools/__connection.json`:
+The client runs in one of two modes depending on the backend advertised in `__devtools/__connection.json`:
 
 | Backend | When | Capabilities |
 |---------|------|--------------|
 | `websocket` | Dev mode (`createCli`, Kit) | Full read/write, broadcasts, shared-state mutation. Requires auth. |
 | `static` | Build / SPA output | Read-only — all calls resolve against the baked RPC dump. |
 
-You don't pick a mode — the client reads the backend field and chooses automatically. Code paths that only make sense in one mode (e.g. `broadcast`) throw in the other.
+The client picks a mode automatically from the backend field. Mode-specific code paths like `broadcast` are scoped to `websocket`.
 
-## Trust & Auth (WebSocket mode)
+## Trust & auth (WebSocket mode)
 
-Dev-mode connections must be trusted before the server accepts calls. The client handles this automatically: on first connect it submits the locally-stored auth token, and resolves `ensureTrusted()` once the server accepts.
+Dev-mode connections require trust before the server accepts calls. The client handles this automatically: on first connect it submits the locally-stored auth token, and `ensureTrusted()` resolves once the server accepts.
 
 ```ts
 const rpc = await connectDevtool()
@@ -81,7 +81,7 @@ if (!trusted) {
 
 ### Replacing the token
 
-If the user provides a token from a different source (e.g. a copy-paste from the CLI output), swap it in without reloading:
+For tokens supplied from a different source (e.g. copy-pasted from CLI output), swap one in without reloading:
 
 ```ts
 const ok = await rpc.requestTrustWithToken('another-token')
@@ -89,9 +89,9 @@ const ok = await rpc.requestTrustWithToken('another-token')
 
 ### Broadcast-channel sync
 
-`connectDevtool` listens on a `BroadcastChannel('vite-devtools-auth')` for `auth-update` messages. When an auth page in another tab announces a new token, every open client requests trust with it automatically — no reload required.
+`connectDevtool` listens on `BroadcastChannel('vite-devtools-auth')` for `auth-update` messages. When an auth page in another tab announces a new token, every open client requests trust with it automatically — no reload required.
 
-## Calling Functions
+## Calling functions
 
 ```ts
 const rpc = await connectDevtool()
@@ -99,7 +99,7 @@ const rpc = await connectDevtool()
 // Standard call — awaits a response or throws.
 const modules = await rpc.call('my-devtool:get-modules', { limit: 10 })
 
-// Optional — returns undefined if no handler responds (useful while HMR is restarting).
+// Optional — returns undefined when no handler responds (useful while HMR is restarting).
 const maybe = await rpc.callOptional('my-devtool:get-modules', { limit: 10 })
 
 // Event — fire-and-forget, no response expected.
@@ -108,9 +108,9 @@ rpc.callEvent('my-devtool:notify', { message: 'hello' })
 
 TypeScript types flow through from the server's `defineRpcFunction` definitions, so argument and return shapes are known at the call site.
 
-## Registering Client Functions
+## Registering client functions
 
-The client can register its own functions that the server calls via `ctx.rpc.broadcast`:
+The client can register functions that the server calls via `ctx.rpc.broadcast`:
 
 ```ts
 import { defineRpcFunction } from 'devframe'
@@ -126,9 +126,9 @@ rpc.client.register(defineRpcFunction({
 }))
 ```
 
-This is how the server pushes live updates into the UI — file watcher events, shared-state sync, etc.
+That's how the server pushes live updates into the UI — file-watcher events, shared-state sync, and so on.
 
-## Shared State
+## Shared state
 
 ```ts
 const state = await rpc.sharedState.get('my-devtool:state')
@@ -158,7 +158,7 @@ With caching on, `query` / `static` function responses are memoized per argument
 
 ## Discovery (`__connection.json`)
 
-DevFrame writes a small JSON descriptor at `<base>/__connection.json` so the client knows where to connect:
+DevFrame writes a JSON descriptor at `<base>/__connection.json` so the client knows where to connect:
 
 ```json
 {
@@ -173,7 +173,7 @@ or for static mode:
 { "backend": "static" }
 ```
 
-You almost never need to read this yourself — the client handles it. If you do need to override discovery, pass `connectionMeta` directly:
+The client handles this for you. To override discovery (testing, advanced setups), pass `connectionMeta` directly:
 
 ```ts
 await connectDevtool({
@@ -181,9 +181,9 @@ await connectDevtool({
 })
 ```
 
-## Remote Docks
+## Remote docks
 
-Remote docks are a kit-side feature (see [Vite DevTools Kit → Remote Client](https://devtools.vite.dev/kit/remote-client)). The kit injects a connection descriptor into the iframe URL; on the hosted page, `connectDevtool` auto-detects the descriptor from the URL fragment / query string — no code change required beyond calling it as usual:
+Remote docks are a kit-side feature (see [Vite DevTools Kit → Remote Client](https://devtools.vite.dev/kit/remote-client)). The kit injects a connection descriptor into the iframe URL; on the hosted page, `connectDevtool` auto-detects the descriptor from the URL fragment / query string — call it as usual:
 
 ```ts
 import { connectDevtool } from 'devframe/client'
@@ -205,4 +205,4 @@ rpc.events.on('rpc:is-trusted:updated', (isTrusted) => {
 })
 ```
 
-Use `rpc.isTrusted` at any time for a synchronous read, and subscribe to `rpc:is-trusted:updated` to drive reauth flows or gate rendering until the client is trusted.
+`rpc.isTrusted` is the synchronous read. Subscribe to `rpc:is-trusted:updated` to drive reauth flows or gate rendering until the client is trusted.

--- a/devframe/docs/guide/devtool-definition.md
+++ b/devframe/docs/guide/devtool-definition.md
@@ -6,7 +6,7 @@ outline: deep
 
 Every DevFrame tool starts with a single `defineDevtool` call. The returned `DevtoolDefinition` is a portable value that any of the [adapters](./adapters) can consume — the same definition runs under `createCli`, `createBuild`, `createMcpServer`, kit's `createPluginFromDevframe`, and so on.
 
-## Minimal Definition
+## Minimal definition
 
 ```ts twoslash
 import { defineDevtool, defineRpcFunction } from 'devframe'
@@ -28,9 +28,9 @@ export default defineDevtool({
 })
 ```
 
-> The dock entry / iframe mount is auto-derived from `id`, `name`, `icon`, and `basePath` when the devtool is mounted into Vite DevTools via [`createPluginFromDevframe`](./adapters#kit). Hub-level features like `docks`, `terminals`, `messages`, and `commands` belong to the kit-augmented context — not to the devframe-level `setup`.
+When mounted into Vite DevTools via [`createPluginFromDevframe`](./adapters#kit), the dock entry and iframe mount are derived from `id`, `name`, `icon`, and `basePath` automatically. Hub-level features (`docks`, `terminals`, `messages`, `commands`) live on the kit-augmented context.
 
-## Definition Fields
+## Definition fields
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -45,7 +45,7 @@ export default defineDevtool({
 | `cli` | `DevtoolCliOptions` | Defaults for the CLI adapter. See [CLI options](#cli-options) below. |
 | `spa` | `DevtoolSpaOptions` | Defaults for the SPA adapter (`base`, `loader`). |
 
-### Runtime Flags
+### Runtime flags
 
 The `ctx.mode` field is either `'dev'` or `'build'`. Use it to gate work that should only run in one runtime:
 
@@ -66,7 +66,7 @@ defineDevtool({
 
 The CLI dev server sets `mode: 'dev'`; `createBuild` sets `mode: 'build'`.
 
-## The Setup Context
+## The setup context
 
 `setup(ctx)` receives a `DevToolsNodeContext`:
 
@@ -86,7 +86,7 @@ interface DevToolsNodeContext {
 }
 ```
 
-Hub-level subsystems — `docks`, `terminals`, `messages`, `commands` — are owned by `@vitejs/devtools-kit` and only present on the kit-augmented context. A devframe app that wants to register kit-only behavior does so via the optional `setup` hook on `createPluginFromDevframe`.
+Hub-level subsystems — `docks`, `terminals`, `messages`, `commands` — live on the kit-augmented context owned by `@vitejs/devtools-kit`. A devframe app that wants to register kit-only behavior does so through the optional `setup` hook on `createPluginFromDevframe`.
 
 Each host has a dedicated page:
 - [RPC](./rpc) — `ctx.rpc`
@@ -95,9 +95,9 @@ Each host has a dedicated page:
 - [Agent-Native](./agent-native) — `ctx.agent`
 - Hub-side surfaces — [Dock System](https://devtools.vite.dev/kit/dock-system), [Commands](https://devtools.vite.dev/kit/commands), [Messages](https://devtools.vite.dev/kit/messages), [Terminals](https://devtools.vite.dev/kit/terminals) — live in the [Vite DevTools Kit](https://devtools.vite.dev/kit/) docs.
 
-## Browser Setup
+## Browser setup
 
-The SPA adapter supports a `setupBrowser(ctx)` hook that runs inside the deployed client bundle. Use it for tools that perform their own in-browser work rather than fetching from a server (e.g. parsing a dropped file, calling public APIs from the client).
+The SPA adapter supports a `setupBrowser(ctx)` hook that runs inside the deployed client bundle. Use it for tools that perform their own in-browser work — parsing a dropped file, calling public APIs from the client, etc.
 
 ```ts
 defineDevtool({
@@ -110,12 +110,11 @@ defineDevtool({
 })
 ```
 
-> [!NOTE]
-> Automatic bundling of `setupBrowser` into the SPA output is not yet implemented. Until then, deployed SPAs that use it must ship their own client entry that registers the handlers.
+Deployed SPAs that use `setupBrowser` ship their own client entry that registers the handlers.
 
-## CLI Options
+## CLI options
 
-`cli` lets you configure the CLI adapter's defaults and plug additional flags/commands into the CAC instance:
+`cli` configures the CLI adapter's defaults and plugs additional flags/commands into the CAC instance:
 
 ```ts
 defineDevtool({
@@ -155,9 +154,9 @@ defineDevtool({
 | `auth` | `boolean` | Disable the WS trust flow when the tool is localhost-only and single-user. Default `true`. |
 | `configure` | `(cli: CAC) => void` | Contribute capability flags/commands. Runs before `createCli`'s `configureCli` option so the final tool author always has the last word. |
 
-`setup(ctx, info)` receives `info.flags` populated from both devframe's built-in flags and any you declare via `configure`. Use this to avoid duplicating flag parsing yourself.
+`setup(ctx, info)` receives `info.flags` populated from both devframe's built-in flags and any you declared via `configure` — saves duplicating flag parsing.
 
-## SPA Options
+## SPA options
 
 ```ts
 defineDevtool({
@@ -171,9 +170,9 @@ defineDevtool({
 
 See [Adapters](./adapters) for how each adapter consumes these.
 
-## Multiple Runtimes, One Definition
+## Multiple runtimes, one definition
 
-Because the definition is a plain value, you can wire it into multiple adapters from the same file:
+The definition is a plain value, so wire it into multiple adapters from the same file:
 
 ```ts
 import { createPluginFromDevframe } from '@vitejs/devtools-kit/node'
@@ -192,7 +191,7 @@ export const myPlugin = () => createPluginFromDevframe(devtool)
 await createBuild(devtool, { outDir: 'dist-static' })
 ```
 
-## What's Next
+## What's next
 
 - [Adapters](./adapters) — pick a deployment target
 - [RPC](./rpc) — register server functions

--- a/devframe/docs/guide/diagnostics.md
+++ b/devframe/docs/guide/diagnostics.md
@@ -4,9 +4,7 @@ outline: deep
 
 # Structured Diagnostics
 
-`ctx.diagnostics` is a thin layer over [`logs-sdk`](https://github.com/vercel-labs/logs-sdk) that lets integrations register their own coded errors and warnings into a shared logger — without taking a direct dependency on `logs-sdk`.
-
-Use it for *author-defined coded diagnostics* (errors, warnings, deprecations) that have a stable code, a documentation URL, and a structured payload. For free-form runtime output that should appear in the DevTools UI, use [`ctx.messages`](https://devtools.vite.dev/kit/messages) instead.
+`ctx.diagnostics` is a thin layer over [`logs-sdk`](https://github.com/vercel-labs/logs-sdk) that lets integrations register coded errors and warnings into a shared logger without depending on `logs-sdk` directly. Use it for author-defined coded diagnostics — errors, warnings, deprecations — with a stable code, a documentation URL, and a structured payload. For free-form runtime output that should appear in the DevTools UI, use [`ctx.messages`](https://devtools.vite.dev/kit/messages).
 
 | Surface | Purpose | Example |
 |---------|---------|---------|
@@ -33,7 +31,7 @@ interface DevToolsDiagnosticsHost {
 
 The host ships pre-seeded with devframe's own `DF*` codes, plus the host package's codes (`DTK*` for `@vitejs/devtools`, etc.). Call `register()` to add your own.
 
-## Register Your Own Codes
+## Register your own codes
 
 ```ts
 export function MyPlugin(): PluginWithDevTools {
@@ -65,9 +63,9 @@ export function MyPlugin(): PluginWithDevTools {
 }
 ```
 
-## Code Conventions
+## Code conventions
 
-Use a **4-letter prefix + 4-digit number** for your codes (e.g. `MYP0001`). Pick a prefix that's specific to your plugin or tool — short enough to type, distinctive enough not to collide with other integrations.
+Codes are 4-letter prefix + 4-digit number (e.g. `MYP0001`). Pick a prefix specific to your plugin or tool — short enough to type, distinctive enough to avoid collisions with other integrations.
 
 Prefixes already in use in this monorepo:
 
@@ -80,7 +78,7 @@ Prefixes already in use in this monorepo:
 
 Each definition supports a `message` (string or function), an optional `hint`, an optional `level` (`'error'` / `'warn'` / `'suggestion'` / `'deprecation'` — defaults to `'error'`), and a `docsBase` for generating documentation URLs. See [`logs-sdk`](https://github.com/vercel-labs/logs-sdk) for the full schema.
 
-## Emit a Diagnostic
+## Emit a diagnostic
 
 Each registered code becomes a callable factory on `ctx.diagnostics.logger`. The factory returns an object with `.throw()`, `.warn()`, `.error()`, `.log()`, and `.format()`.
 
@@ -98,15 +96,15 @@ ctx.diagnostics.logger.MYP0002().warn()
 ctx.diagnostics.logger.MYP0001({ name: 'foo' }, { cause: error }).log()
 ```
 
-`.throw()` is also typed `never` — TypeScript will treat the line after it as unreachable, so prefix it with `throw` for control-flow narrowing:
+`.throw()` is typed `never`, so TypeScript treats the line after as unreachable. Prefix the call with `throw` for control-flow narrowing:
 
 ```ts
 throw ctx.diagnostics.logger.MYP0001({ name }).throw()
 ```
 
-## Typed Logger Reference
+## Typed logger reference
 
-`ctx.diagnostics.logger` is loosely typed (it covers an unbounded set of registered codes). If you want full type narrowing — e.g. autocompletion for your plugin's specific codes — keep your own typed reference returned from `createLogger`:
+`ctx.diagnostics.logger` is loosely typed — it covers an unbounded set of registered codes, beyond what TypeScript can narrow. For autocompletion on your plugin's specific codes, keep a typed reference returned from `createLogger`:
 
 ```ts
 const myDiagnostics = ctx.diagnostics.defineDiagnostics({
@@ -126,9 +124,9 @@ logger.MYP0001({ name: 'foo' }).warn()
 
 Both loggers share the formatter and reporter defaults set by the host (ANSI console output).
 
-## Updating the Combined Logger
+## Updating the combined logger
 
-`ctx.diagnostics.logger` is a *getter* — it always returns the freshest combined logger, rebuilt each time `register()` is called. Don't cache it:
+`ctx.diagnostics.logger` is a getter — it returns the freshest combined logger, rebuilt each time `register()` is called. Don't cache it:
 
 ```ts
 // ❌ Stale after a later register() call
@@ -139,9 +137,9 @@ log.MYP0001({ name: 'foo' }).log()
 ctx.diagnostics.logger.MYP0001({ name: 'foo' }).log()
 ```
 
-If you want a stable reference, use `ctx.diagnostics.createLogger({ diagnostics: [myDiagnostics] })` — that one stays bound to *your* definitions.
+For a stable reference, use `ctx.diagnostics.createLogger({ diagnostics: [myDiagnostics] })` — that one stays bound to your definitions.
 
-## Document Your Codes
+## Document your codes
 
 Pair each code with a documentation page. devframe and the published Vite DevTools packages follow this layout:
 
@@ -152,11 +150,11 @@ docs/errors/
   MYP0002.md
 ```
 
-Each page covers the message, cause, example, and fix — see any [DF code page](https://devfra.me/errors/) for the canonical template. Set `docsBase` on `defineDiagnostics({...})` so the URL is auto-attached to every emitted diagnostic.
+Each page covers the message, cause, example, and fix — see any [DF code page](https://devfra.me/errors/) for the canonical template. Setting `docsBase` on `defineDiagnostics({...})` auto-attaches the URL to every emitted diagnostic.
 
-## When to Use What
+## When to use what
 
-- **`ctx.diagnostics`** — Coded conditions you want users (or other tools) to be able to look up: misconfiguration, deprecations, validation failures, internal invariants. Always have a docs page. Often `.throw()`.
-- **`ctx.messages`** — User-facing activity surfaces in the DevTools UI: progress indicators, audit results, "URL copied" toasts. No code, no docs URL — just a message and a level.
+- **`ctx.diagnostics`** — coded conditions worth looking up: misconfiguration, deprecations, validation failures, internal invariants. Always docs-backed. Often `.throw()`.
+- **`ctx.messages`** — user-facing activity surfaces in the DevTools UI: progress indicators, audit results, "URL copied" toasts. Just a message and a level.
 
-The two systems are intentionally separate: diagnostics are for tool authors and CI; messages are for the human in front of the DevTools panel.
+Diagnostics target tool authors and CI; messages target the human in front of the DevTools panel.

--- a/devframe/docs/guide/index.md
+++ b/devframe/docs/guide/index.md
@@ -4,25 +4,25 @@ outline: deep
 
 # DevFrame
 
-**DevFrame** is *the container for one devtool integration, portable across viewers.* You describe a single tool — its RPC surface, its data model, its SPA, its CLI shape — and DevFrame deploys the same definition through any number of runtime adapters: a standalone CLI, a self-contained static report, an embedded SPA, an MCP server, or mounted inside a multi-integration hub.
+**DevFrame** is the container for one devtool integration, portable across viewers. You describe a single tool — its RPC surface, its data model, its SPA, its CLI shape — and DevFrame deploys the same definition through any number of runtime adapters: a standalone CLI, a self-contained static report, an embedded SPA, an MCP server, or mounted inside a multi-integration hub.
 
-DevFrame deliberately stops at the boundary of one tool. **Docking, the command palette, terminal aggregation, cross-tool toasts** — anything that only makes sense when *multiple* devtools share a UI — lives in [`@vitejs/devtools-kit`](https://devtools.vite.dev/kit/), the hub layer. To drop a DevFrame app into Vite DevTools, wrap it with `createPluginFromDevframe` from `@vitejs/devtools-kit/node`; the kit synthesizes the dock entry from your definition's `id` / `name` / `icon` / `basePath` and routes its hub-level ctx fields (`docks`, `terminals`, …) accordingly.
+DevFrame's surface is one tool. Hub-level features — docking, the command palette, terminal aggregation, cross-tool toasts — live in [`@vitejs/devtools-kit`](https://devtools.vite.dev/kit/). To drop a DevFrame app into Vite DevTools, wrap it with `createPluginFromDevframe` from `@vitejs/devtools-kit/node`; the kit synthesises the dock entry from your definition's `id` / `name` / `icon` / `basePath` and routes the hub-level ctx fields (`docks`, `terminals`, …) accordingly.
 
 > [!WARNING] Experimental
-> The DevFrame API is still in development and may change between versions. The agent-native surface (`agent` field on `defineRpcFunction`, `ctx.agent`, and the MCP adapter) is additionally flagged as experimental.
+> The DevFrame API is still in development and may change between versions. The agent-native surface (`agent` on `defineRpcFunction`, `ctx.agent`, and the MCP adapter) is additionally flagged as experimental.
 
-## Design Principles
+## Design principles
 
 DevFrame keeps its surface small and pushes hub-level UX to the kit consuming it:
 
-- **Single-integration scope.** DevFrame describes one tool. Anything that only matters across tools — docks, palette, cross-tool toasts, unified terminals — is the [DevTools Kit's](https://devtools.vite.dev/kit/) job, not DevFrame's.
-- **Headless.** No default startup banners, logging, or styling. Hook into `onReady`, `cli.configure`, and friends to print your own output.
-- **App-owned file watching.** Wire your own watcher (chokidar, fs.watch, …) and signal change via `ctx.rpc.sharedState.set(...)` or event-type RPCs. DevFrame does not ship a watcher primitive.
+- **Single-integration scope.** DevFrame describes one tool. Anything that only matters across tools — docks, palette, cross-tool toasts, unified terminals — belongs in the [DevTools Kit](https://devtools.vite.dev/kit/).
+- **Headless.** Hook into `onReady`, `cli.configure`, and friends to print your own startup banners and styling — DevFrame stays out of the way.
+- **App-owned file watching.** Wire your own watcher (chokidar, fs.watch, …) and signal change via `ctx.rpc.sharedState.set(...)` or event-typed RPCs.
 - **Context-aware mount paths.** Standalone adapters (`cli`, `spa`, `build`) serve at `/` by default; hosted adapters (`vite`, `embedded`, kit's `createPluginFromDevframe`) serve at `/.<id>/`. Override via `DevtoolDefinition.basePath`.
-- **SPAs own their base at runtime.** Build with relative asset paths (`vite.base: './'`); `connectDevtool` discovers the effective base from the executing script's location. No HTML rewrites at build time.
+- **SPAs own their base at runtime.** Build with relative asset paths (`vite.base: './'`); `connectDevtool` discovers the effective base from the executing script's location.
 - **CLI flags compose.** The `cac` instance is exposed to both the devtool (`cli.configure`) and the caller of `createCli`, so capability flags and app flags merge cleanly.
 
-## What DevFrame Provides
+## What DevFrame provides
 
 | Subsystem | What it does |
 |-----------|--------------|
@@ -35,7 +35,7 @@ DevFrame keeps its surface small and pushes hub-level UX to the kit consuming it
 | **[Client](./client)** | Browser-side RPC client (`connectDevtool`) with auto-auth and WebSocket / static modes. |
 | **[Agent-Native](./agent-native)** | Opt-in exposure of your tool's surface to coding agents over MCP. |
 
-> Hub-only subsystems — **[Dock System](https://devtools.vite.dev/kit/dock-system)**, **[Commands](https://devtools.vite.dev/kit/commands)**, **[Messages](https://devtools.vite.dev/kit/messages)**, **[Terminals](https://devtools.vite.dev/kit/terminals)** — are documented in the [Vite DevTools Kit](https://devtools.vite.dev/kit/) since they only matter when multiple integrations share a UI.
+Hub-only subsystems — [Dock System](https://devtools.vite.dev/kit/dock-system), [Commands](https://devtools.vite.dev/kit/commands), [Messages](https://devtools.vite.dev/kit/messages), [Terminals](https://devtools.vite.dev/kit/terminals) — live in the [Vite DevTools Kit](https://devtools.vite.dev/kit/) docs.
 
 ## Architecture
 
@@ -74,7 +74,7 @@ flowchart TB
 pnpm add devframe
 ```
 
-`devframe` ships ESM-only and has no Vite dependency. Adapters that need optional peers (MCP needs `@modelcontextprotocol/sdk`) surface that requirement at import time.
+`devframe` ships ESM-only and has no Vite dependency. Adapters with optional peers (the MCP adapter needs `@modelcontextprotocol/sdk`) surface the requirement at import time.
 
 ## Hello, DevFrame
 
@@ -126,31 +126,31 @@ node ./my-devtool.js mcp    # stdio MCP server (experimental)
 
 The CLI adapter serves the SPA at `/` by default. When the same devtool is embedded inside a host (`vite`, `kit`, `embedded`), the default becomes `/.my-devtool/`. Override either side via `defineDevtool({ basePath })`.
 
-## Adapters at a Glance
+## Adapters at a glance
 
 DevFrame deploys the same `DevtoolDefinition` through one of these adapters:
 
 | Adapter | Entry | Target |
 |---------|-------|--------|
 | `cli` | `createCli(d).parse()` | Standalone CLI with dev / build / mcp subcommands |
-| `vite` | `createVitePlugin(d, opts?)` | Plain Vite plugin — mounts the SPA only (no RPC server, no hub) |
+| `vite` | `createVitePlugin(d, opts?)` | Plain Vite plugin that mounts the SPA |
 | `build` | `createBuild(d, opts?)` | Self-contained static deploy with baked RPC dumps |
 | **kit (bridge)** | `createPluginFromDevframe(d, opts?)` *(from `@vitejs/devtools-kit/node`)* | Mount the devtool into Vite DevTools' hub UI |
 | `embedded` | `createEmbedded(d, { ctx })` | Runtime registration into an existing host |
 | `mcp` | `createMcpServer(d, opts)` | Model Context Protocol server |
 
-`createPluginFromDevframe` lives in the kit, not in DevFrame, because mounting *into a multi-integration hub* is by definition a kit responsibility. See [Adapters](./adapters) for the full reference.
+`createPluginFromDevframe` lives in the kit because mounting into a multi-integration hub is a kit responsibility. See [Adapters](./adapters) for the full reference.
 
-## Dependency Boundary
+## Dependency boundary
 
-DevFrame is the lowest-level package in the Vite DevTools monorepo and is positioned to be extracted into its own repo. It **must not** import from Vite or any `@vitejs/*` package — neither as a dependency nor as a source import. Hub-only concepts (docks, terminals, messages, commands) belong in the layers above:
+DevFrame is the lowest-level package in the Vite DevTools monorepo and is positioned to be extracted into its own repo. Imports from Vite or any `@vitejs/*` package are out of scope, in source and at the dependency-graph level. Hub-only concepts (docks, terminals, messages, commands) belong in the layers above:
 
-- `@vitejs/devtools-kit` — *the hub*. Owns docking, terminals, messages, the command palette; provides `createPluginFromDevframe` to bridge a DevFrame app into Vite DevTools.
-- `@vitejs/devtools` — *the integration*. The Vite plugin that wraps the kit and exposes Vite DevTools' own UI.
+- `@vitejs/devtools-kit` — the hub. Owns docking, terminals, messages, and the command palette; provides `createPluginFromDevframe` to bridge a DevFrame app into Vite DevTools.
+- `@vitejs/devtools` — the integration. Vite plugin that wraps the kit and exposes Vite DevTools' own UI.
 
-If you are porting an existing inspector, prefer the [`cli`](./adapters#cli) adapter for standalone use and `createPluginFromDevframe` (from `@vitejs/devtools-kit/node`) to surface it inside Vite DevTools.
+For porting an existing inspector, use the [`cli`](./adapters#cli) adapter standalone and `createPluginFromDevframe` (from `@vitejs/devtools-kit/node`) to surface it inside Vite DevTools.
 
-## What's Next
+## What's next
 
 - [Devtool Definition](./devtool-definition) — understand `defineDevtool` and the `DevToolsNodeContext`
 - [Adapters](./adapters) — pick the right deployment target for your tool

--- a/devframe/docs/guide/nuxt.md
+++ b/devframe/docs/guide/nuxt.md
@@ -4,11 +4,11 @@ outline: deep
 
 # Nuxt Helper
 
-The `@devframes/nuxt` module wires a Nuxt-built SPA up as a devframe client. It's an integration helper, not a deployment adapter — it runs inside the Nuxt app that consumes your devtool, not as part of the CLI that serves it.
+The `@devframes/nuxt` module wires a Nuxt-built SPA as a devframe client. It runs inside the Nuxt app that consumes your devtool — separate from the CLI that serves it.
 
-It handles the three things every Nuxt-powered standalone devtool needs to get right:
+It handles the three things every Nuxt-powered standalone devtool needs:
 
-1. **Base-agnostic assets.** Forces `app.baseURL: './'` and `vite.base: './'` so the same production build works at `/`, at `/tool/`, and on any other deployment path without build-time URL rewriting.
+1. **Base-agnostic assets.** Sets `app.baseURL: './'` and `vite.base: './'` so the same production build works at `/`, `/tool/`, and any other deployment path without build-time URL rewriting.
 2. **Runtime RPC connection.** Adds a client plugin that calls [`connectDevtool()`](./client) once on page load and provides the result as `$rpc` on the Nuxt app.
 3. **TypeScript augmentation.** `useNuxtApp().$rpc` is typed as `DevToolsRpcClient` out of the box.
 
@@ -52,8 +52,8 @@ export default defineNuxtConfig({
 })
 ```
 
-- **`baseURL`** defaults to `'./'`, which resolves against `document.baseURI` at runtime. The connection meta and dump shards sit next to `index.html`, so the same build works at any deployment path — no need to pass `--base` at build time.
-- **`skipAppDefaults: true`** disables the `app.baseURL: './'` / `vite.base: './'` defaults. Use this only if you're deliberately shipping with absolute asset paths and have your own base-URL story.
+- **`baseURL`** defaults to `'./'`, which resolves against `document.baseURI` at runtime. The connection meta and dump shards sit next to `index.html`, so the same build works at any deployment path.
+- **`skipAppDefaults: true`** disables the `app.baseURL: './'` / `vite.base: './'` defaults. Use this when you're shipping with absolute asset paths and have your own base-URL story.
 
 ## How it works
 
@@ -72,7 +72,7 @@ At runtime the built SPA fetches `./__connection.json` (resolved against `docume
 
 ## Relationship to `createCli`
 
-The Nuxt helper is a client-side integration; it does **not** start a server. The typical shape is:
+The Nuxt helper is a client-side integration — `createCli` runs the server side. The typical shape is:
 
 ```
 my-tool/
@@ -88,7 +88,7 @@ my-tool/
 - `createCli` (from `devframe/adapters/cli`) runs the Node side — HTTP + WS + static build + MCP.
 - `@devframes/nuxt` handles the client side — RPC connection + base-URL plumbing.
 
-They're decoupled: swap Nuxt for any other SPA framework as long as it calls `connectDevtool()` in the browser.
+They're decoupled: swap Nuxt for any other SPA framework that calls `connectDevtool()` in the browser.
 
 ## See also
 

--- a/devframe/docs/guide/rpc.md
+++ b/devframe/docs/guide/rpc.md
@@ -4,7 +4,7 @@ outline: deep
 
 # RPC
 
-DevFrame's RPC layer is type-safe bidirectional communication between your server (Node.js) and client (browser), built on [`birpc`](https://github.com/antfu/birpc) and validated at runtime with [`valibot`](https://valibot.dev/). In dev mode it runs over WebSocket; in build / SPA mode it falls back to a pre-computed static dump so the client still works offline.
+DevFrame's RPC layer is type-safe bidirectional communication between your server (Node.js) and client (browser), built on [`birpc`](https://github.com/antfu/birpc) and validated at runtime with [`valibot`](https://valibot.dev/). In dev mode it runs over WebSocket; in build / SPA mode it serves a pre-computed static dump so the client still works offline.
 
 ## Overview
 
@@ -18,7 +18,7 @@ sequenceDiagram
   Server-->>Client: [{ id, size }, …]
 ```
 
-## Defining a Function
+## Defining a function
 
 ```ts
 import { defineRpcFunction } from 'devframe'
@@ -53,14 +53,11 @@ export default defineDevtool({
 })
 ```
 
-### Naming Convention
+### Naming convention
 
-1. Scope with your devtool id: `<id>:<action>`.
-2. Use kebab-case for the action segment.
+Scope with your devtool id and use kebab-case for the action: `my-devtool:get-modules`, `my-devtool:read-file`, `my-devtool:trigger-rebuild`.
 
-Examples: `my-devtool:get-modules`, `my-devtool:read-file`, `my-devtool:trigger-rebuild`.
-
-### Function Types
+### Function types
 
 | Type | Description | Cached | Static Dump |
 |------|-------------|--------|-------------|
@@ -71,9 +68,9 @@ Examples: `my-devtool:get-modules`, `my-devtool:read-file`, `my-devtool:trigger-
 
 Use `static` for data collected once during `setup` and shipped to read-only static / SPA clients.
 
-### Handler Arguments
+### Handler arguments
 
-Handlers accept any serializable arguments. When `args` supplies valibot schemas, arguments are validated at the boundary:
+Handlers accept any serializable arguments. With `args` valibot schemas, arguments are validated at the boundary:
 
 ```ts
 defineRpcFunction({
@@ -90,14 +87,14 @@ defineRpcFunction({
 })
 ```
 
-Prefer **a single object argument** (`args: [v.object({ ... })]`) over positional args — property names are self-describing and agents / IDEs work best with object shapes.
+Prefer a single object argument (`args: [v.object({ ... })]`) over positional args — property names are self-describing and agents/IDEs work best with object shapes.
 
-### Setup vs Handler
+### Setup vs handler
 
 Two ways to wire a handler:
 
-- **`setup(ctx)`** — receives the `DevToolsNodeContext` and returns `{ handler, dump? }`. Use this when you need access to the context (shared state, logs, `ctx.mode`, etc.).
-- **`handler(...)`** — shorthand when the handler is pure and doesn't need the context.
+- **`setup(ctx)`** — receives the `DevToolsNodeContext` and returns `{ handler, dump? }`. Use this when you need the context (shared state, logs, `ctx.mode`, etc.).
+- **`handler(...)`** — shorthand when the handler is pure and doesn't touch the context.
 
 ```ts
 // With setup:
@@ -146,7 +143,7 @@ defineDevtool({
 
 ## Streaming
 
-For chunk-style server→client feeds (chat deltas, log lines, build progress), reach for [streaming channels](./streaming) instead of hand-rolling `action + delta/end events`. The streaming API gives you stream IDs, cancellation, replay, and Web Streams interop for free:
+For chunk-style server→client feeds (chat deltas, log lines, build progress), use [streaming channels](./streaming) — they handle stream IDs, cancellation, replay, and Web Streams interop for you:
 
 ```ts
 const channel = ctx.rpc.streaming.create<string>('my-devtool:chat', {
@@ -158,17 +155,17 @@ sourceReadable.pipeTo(stream.writable)
 
 See the [Streaming guide](./streaming) for the full API.
 
-## Local Invocation
+## Local invocation
 
-`ctx.rpc.invokeLocal` calls a registered server function directly without going through a transport — useful for cross-function composition on the server side:
+`ctx.rpc.invokeLocal` calls a registered server function directly, skipping the transport — useful for cross-function composition on the server side:
 
 ```ts
 const modules = await ctx.rpc.invokeLocal('my-devtool:get-modules', { limit: 10 })
 ```
 
-## Client-Side Calls
+## Client-side calls
 
-From the browser, use [`connectDevtool`](./client) (or `getDevToolsRpcClient`) to obtain a client and call registered functions:
+From the browser, [`connectDevtool`](./client) (or `getDevToolsRpcClient`) returns a client for calling registered functions:
 
 ```ts
 import { connectDevtool } from 'devframe/client'
@@ -180,9 +177,9 @@ const modules = await rpc.call('my-devtool:get-modules', { limit: 10 })
 
 Client-side registration (for server→client calls) goes through `rpc.client.register()` — the mirror API of `ctx.rpc.register()`.
 
-## Static Dumps
+## Static dumps
 
-For `static` functions, DevFrame automatically records the handler's output during `createBuild` and bakes it into the output:
+For `static` functions, DevFrame records the handler's output during `createBuild` and bakes it into the build:
 
 ```ts
 defineRpcFunction({
@@ -212,22 +209,22 @@ defineRpcFunction({
 })
 ```
 
-At runtime, static clients resolve `rpc.call('my-devtool:get-session', 'session-a')` from the baked dump; misses fall back to `dump.fallback` (or throw if not provided).
+At runtime, static clients resolve `rpc.call('my-devtool:get-session', 'session-a')` from the baked dump; unmatched arguments resolve to `dump.fallback` (or throw without one).
 
-## JSON-Serializable Declaration
+## JSON-serializable declaration
 
-DevFrame's WS transport ships payloads using one of two encoders, picked **per RPC function**:
+DevFrame's WS transport ships payloads using one of two encoders, picked per RPC function:
 
 | `jsonSerializable` | Encoder | Wire prefix | Round-trips |
 |---|---|---|---|
 | `false` (default) | `structured-clone-es` | `s:` | `Map`, `Set`, `Date`, `BigInt`, cycles, class instances |
 | `true` (opt-in) | strict `JSON.stringify` | _(unprefixed)_ | JSON-only |
 
-The wire is plain JSON when all participating functions are JSON-flagged — debuggable in DevTools, friendlier to MCP, and a good default for tools that already speak JSON.
+The wire stays plain JSON when every participating function is JSON-flagged — debuggable in DevTools, friendly to MCP, and a good default for tools that already speak JSON.
 
 ### Discovering shape errors during dev
 
-Setting `jsonSerializable: true` is a contract: if your handler ever returns a value JSON cannot round-trip losslessly (a `Map`, a `Date`, a class instance, …), the strict serializer **throws `DF0020` synchronously** on the offending call. The error fires in dev, not at build time, so you see it next to the call site that introduced the bad value:
+`jsonSerializable: true` is a contract. When a handler returns a value JSON cannot round-trip (a `Map`, a `Date`, a class instance, …), the strict serializer throws [`DF0020`](../errors/DF0020) synchronously on the offending call — surfacing the bad value next to the call site in dev:
 
 ```ts
 defineRpcFunction({
@@ -238,15 +235,15 @@ defineRpcFunction({
 })
 ```
 
-If you do need fancy types, leave the flag unset (or `false`) — `structured-clone-es` will preserve them on the wire and in build dumps. The flag is opt-in, so existing code keeps working untouched.
+For richer types, leave the flag unset (or `false`) — `structured-clone-es` preserves them on the wire and in build dumps. The flag is opt-in, so existing code keeps working untouched.
 
 ### MCP requires JSON
 
-MCP tools expose their schemas as JSON Schema, and agent harnesses assume JSON-shaped data. So **`agent: {...}` requires `jsonSerializable: true`** — otherwise registration throws `DF0019`. See the next section for how to attach the `agent` field once your function is JSON-safe.
+MCP tools expose their schemas as JSON Schema, and agent harnesses assume JSON-shaped data. `agent: {...}` therefore requires `jsonSerializable: true`; registering one without the other throws [`DF0019`](../errors/DF0019). See the next section for how to attach the `agent` field once your function is JSON-safe.
 
-## Agent Exposure
+## Agent exposure
 
-Add an `agent` field to surface the function to coding agents over MCP. Functions without an `agent` field are not exposed (default-deny). Agent-exposed functions must also declare `jsonSerializable: true` (see above).
+Add an `agent` field to surface the function to coding agents over MCP. Agent exposure is opt-in; functions without an `agent` field stay private. Agent-exposed functions must also declare `jsonSerializable: true` (see above).
 
 ```ts
 defineRpcFunction({
@@ -268,7 +265,7 @@ defineRpcFunction({
 
 See [Agent-Native](./agent-native) for the full safety model and MCP integration.
 
-## What's Next
+## What's next
 
 - [Shared State](./shared-state) — observable state synced across clients
 - [Client](./client) — connecting from the browser

--- a/devframe/docs/guide/shared-state.md
+++ b/devframe/docs/guide/shared-state.md
@@ -4,9 +4,9 @@ outline: deep
 
 # Shared State
 
-Shared state is observable, immutable-by-default state synced between the server and every connected client. It is built on [`immer`](https://immerjs.github.io/immer/) so you mutate a draft and DevFrame computes the patches to broadcast.
+Shared state is observable, immutable-by-default state synced between the server and every connected client. It's built on [`immer`](https://immerjs.github.io/immer/): you mutate a draft, DevFrame computes the patches to broadcast.
 
-Shared state survives reconnects — a newly connected client receives the current snapshot before any further updates. Prefer it over ad-hoc RPC events for anything that should stay reactive.
+Shared state survives reconnects — a newly connected client receives the current snapshot before any further updates. Use it for anything that should stay reactive.
 
 ## Overview
 
@@ -25,7 +25,7 @@ flowchart LR
   S <-->|RPC sync| B
 ```
 
-## Creating State
+## Creating state
 
 Use `ctx.rpc.sharedState.get(key, options)` in your `setup`:
 
@@ -48,11 +48,11 @@ export default defineDevtool({
 })
 ```
 
-Keys should be namespaced (`<devtool-id>:<key>`) to avoid collisions with other devtools sharing the same host.
+Namespace keys with `<devtool-id>:<key>` to avoid collisions when multiple devtools share a host.
 
 ## Reading
 
-`state.value()` returns an **immutable** snapshot:
+`state.value()` returns an immutable snapshot:
 
 ```ts
 const current = state.value()
@@ -77,11 +77,11 @@ Under the hood, DevFrame:
 2. Emits an `updated` event with the new state (and patches, if enabled).
 3. Broadcasts the update to all connected clients.
 
-Mutations are idempotent across replay — DevFrame tracks a `syncIds` set internally so a patch round-tripped back from a client doesn't reapply.
+Mutations are idempotent across replay — DevFrame tracks a `syncIds` set internally so a patch round-tripped back from a client applies once.
 
 ## Patches (advanced)
 
-Enable patches when you need minimal network diffs instead of full snapshots:
+Enable patches for minimal network diffs instead of full snapshots:
 
 ```ts
 const state = await ctx.rpc.sharedState.get('my-devtool:big-state', {
@@ -91,19 +91,19 @@ const state = await ctx.rpc.sharedState.get('my-devtool:big-state', {
 })
 ```
 
-When enabled, the `updated` event carries a `Patch[]` alongside the new state so listeners can apply incremental updates.
+With patches enabled, the `updated` event carries a `Patch[]` alongside the new state so listeners can apply incremental updates.
 
 ## Subscribing
 
 ```ts
 state.on('updated', (fullState, patches, syncId) => {
-  // `patches` is undefined unless enablePatches was set.
+  // `patches` is populated only when enablePatches is set.
 })
 ```
 
-## Client-Side Access
+## Client-side access
 
-From the browser, the same key is available on the RPC client:
+The same key is available on the RPC client in the browser:
 
 ```ts
 import { connectDevtool } from 'devframe/client'
@@ -121,7 +121,7 @@ state.mutate((draft) => {
 
 Client-side mutations round-trip through the server before reappearing locally, so `state.value()` always reflects the authoritative source.
 
-## Enumerating Keys
+## Enumerating keys
 
 Both server and client hosts expose `keys()` and `onKeyAdded`:
 
@@ -135,9 +135,9 @@ const unsubscribe = ctx.rpc.sharedState.onKeyAdded((key) => {
 })
 ```
 
-This is how protocol adapters (e.g. the [MCP adapter](./agent-native)) surface shared state as dynamic resources.
+Protocol adapters (the [MCP adapter](./agent-native), for example) use this to surface shared state as dynamic resources.
 
-## When to Use Shared State vs RPC
+## When to use shared state vs RPC
 
 | Use shared state for | Use RPC for |
 |----------------------|-------------|
@@ -145,4 +145,4 @@ This is how protocol adapters (e.g. the [MCP adapter](./agent-native)) surface s
 | Cross-client coordination | Commands / actions with side effects |
 | Data that should reappear after reconnect | Event streams (prefer `broadcast` / `callEvent`) |
 
-For short-lived actions and events, stick with `ctx.rpc.register` + `ctx.rpc.broadcast` from the [RPC](./rpc) page.
+For short-lived actions and events, use `ctx.rpc.register` + `ctx.rpc.broadcast` from the [RPC](./rpc) page.

--- a/devframe/docs/guide/standalone-cli.md
+++ b/devframe/docs/guide/standalone-cli.md
@@ -6,7 +6,7 @@ outline: deep
 
 This recipe walks through building a standalone CLI devtool on top of DevFrame — the shape where a user runs `npx my-tool` and gets a local dev server serving a Vue / Nuxt / React SPA backed by type-safe RPC, plus `build` / `spa` / `mcp` subcommands for free.
 
-It's the pattern used by tools like an ESLint config inspector or a bundler-config viewer: no Vite plugin, no host app — just a binary that opens a browser.
+It's the pattern used by tools like an ESLint config inspector or a bundler-config viewer: a binary that opens a browser.
 
 ## What you ship
 
@@ -192,7 +192,7 @@ At build time the handler runs once with no arguments; the result is stored as b
 
 ## On-disk caching
 
-DevFrame deliberately doesn't ship a storage primitive — [`unstorage`](https://unstorage.unjs.io/) is the recommended pattern for anything you want to cache between runs. Keep cache paths under `node_modules/.cache/<your-devtool-id>/` so the cache rotates with the project's `pnpm install`:
+Persistence between runs is the application's job — [`unstorage`](https://unstorage.unjs.io/) is the recommended pattern. Keep cache paths under `node_modules/.cache/<your-devtool-id>/` so the cache rotates with the project's `pnpm install`:
 
 ```ts
 import { resolve } from 'pathe'
@@ -223,7 +223,7 @@ defineDevtool({
 
 ## Live-reload on config changes
 
-DevFrame does not own the filesystem-watching concern — wire your own chokidar and signal the client via shared state:
+Filesystem watching belongs to the application layer — wire your own chokidar and signal the client via shared state:
 
 ```ts [src/cli.ts]
 defineDevtool({
@@ -307,12 +307,12 @@ await program.parseAsync()
 
 `createDevServer` returns the underlying `StartedServer` handle (`origin`, `port`, `app`, `wss`, `rpcGroup`, `close()`) so the surrounding program can drive graceful shutdown — SIGINT, hot reload, integration tests.
 
-For typed flag schemas, `parseCliFlags(schema, rawBag)` (from `devframe/adapters/cli`) validates a commander/yargs flag bag against a `CliFlagsSchema` (the same `defineCliFlags(...)` value you'd put on `cli.flags`). Typed-schema validation isn't tied to cac.
+For typed flag schemas, `parseCliFlags(schema, rawBag)` (from `devframe/adapters/cli`) validates a commander/yargs flag bag against a `CliFlagsSchema` (the same `defineCliFlags(...)` value you'd put on `cli.flags`). Typed-schema validation works with any CLI framework.
 
 ## Why this shape
 
 - **One command, one binary.** `createCli` is a complete CLI — dev, build, spa, mcp all from a single `defineDevtool` value.
-- **Headless.** No default banner; your `onReady` callback is the only stdout output that represents your tool.
+- **Headless.** Your `onReady` callback owns startup output, so your tool's stdout stays yours.
 - **Base-agnostic.** Same SPA build works at `/` (dev, standalone static) and at any deployment base.
 - **Typed end-to-end.** RPC function definitions flow their types through to the client `rpc.call` site.
 - **Agent-ready.** Add `agent: { description }` to any RPC function to expose it through the `mcp` subcommand.

--- a/devframe/docs/guide/streaming.md
+++ b/devframe/docs/guide/streaming.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Streaming
 
-Devframe's streaming-channel API provides server→client push for chunk-style data — chat deltas, log lines, build progress, anything you'd otherwise express as a sequence of fire-and-forget events. It builds on the same WebSocket transport as the rest of the RPC layer, but adds the conventions every chunked feed needs: stream IDs, cooperative cancellation, replay on reconnect, and first-class **Web Streams** interop.
+Devframe's streaming-channel API provides server→client push for chunk-style data — chat deltas, log lines, build progress. It runs over the same WebSocket transport as the rest of the RPC layer and adds the conventions every chunked feed needs: stream IDs, cooperative cancellation, replay on reconnect, and first-class Web Streams interop.
 
 ## Overview
 
@@ -23,9 +23,9 @@ sequenceDiagram
 
 A **channel** owns a wire namespace. Each call to `channel.start()` produces an individual **stream** keyed by an id (auto-generated unless you pass one). Subscribers join by `(channelName, id)`.
 
-## Defining a Channel
+## Defining a channel
 
-In your `setup`, create the channel once. Channels are framework-neutral, so the same code works for `cli`, `vite`, `kit`, and `embedded` adapters:
+Create the channel once in `setup`. Channels are framework-neutral, so the same code works under every adapter (`cli`, `vite`, `kit`, `embedded`):
 
 ```ts
 import { defineDevtool, defineRpcFunction } from 'devframe'
@@ -62,7 +62,7 @@ export default defineDevtool({
 
 The channel name follows the same `<plugin-id>:<name>` convention as RPC functions.
 
-## Producing — Three Surfaces, One Stream
+## Producing — three surfaces, one stream
 
 The handle returned by `channel.start({ id? })` is both an imperative producer and a Web Streams `WritableStream<T>`:
 
@@ -94,9 +94,9 @@ for (const token of source) {
 stream.close()
 ```
 
-### Node.js Stream Interop
+### Node.js stream interop
 
-Web Streams are the canonical surface, but Node 17+ ships free converters that bridge to `node:stream`:
+Web Streams are the canonical surface. Node 17+ ships standard-library converters for bridging to `node:stream`:
 
 ```ts
 import { Readable, Writable } from 'node:stream'
@@ -107,8 +107,6 @@ sourceNodeReadable.pipe(Writable.fromWeb(stream.writable))
 // Pipe the channel out to a Node Writable
 Readable.fromWeb(reader.readable).pipe(targetNodeWritable)
 ```
-
-Devframe doesn't wrap these — they're standard library, and the surface stays small.
 
 ## Consuming — `for await` or `pipeTo`
 
@@ -134,9 +132,9 @@ await reader.readable.pipeTo(downloadWritable)
 reader.cancel() // sends cancel upstream; server stream.signal flips
 ```
 
-Pick one surface per reader — they share a single internal queue, so concurrent draining will race.
+Use one surface per reader — they share a single internal queue, so concurrent draining races.
 
-## Lifecycle and Cancellation
+## Lifecycle and cancellation
 
 | Event | Server side | Client side |
 |-------|-------------|-------------|
@@ -145,11 +143,11 @@ Pick one surface per reader — they share a single internal queue, so concurren
 | WS disconnects | When the **last** subscriber drops, server aborts `stream.signal` | Reader stays alive; resubscribes automatically when trust is re-established |
 | `chat` panel closes mid-stream | Reader cancel cascades upstream | — |
 
-A stream with multiple subscribers stays alive until the last one cancels or disconnects. Producers should always make `stream.signal.aborted` part of their inner loop.
+A stream with multiple subscribers stays alive until the last one cancels or disconnects. Producers should make `stream.signal.aborted` part of their inner loop.
 
-## Client-to-Server Uploads
+## Client-to-server uploads
 
-The same channel works in reverse for chunk-style uploads — file content, mic / screen-share frames, browser-side logs forwarded to disk, anything you'd otherwise hand-roll as `multipart` over HTTP. The pattern uses one normal RPC call to allocate the id, then dedicated streaming events for the chunks:
+The same channel works in reverse for chunk-style uploads — file content, mic / screen-share frames, browser-side logs forwarded to disk, anything that would otherwise need a hand-rolled multipart-over-HTTP. The pattern: one regular RPC call allocates the id, then dedicated streaming events carry the chunks.
 
 ```ts
 // Server — typically inside an action handler
@@ -197,11 +195,11 @@ Lifecycle mirrors the outbound case:
 - `upload.error(err)` propagates as a thrown error inside the server's `for await`.
 - If the client disconnects mid-upload, the server's `for await` exits with an `UploadDisconnected` error so consumers can clean up.
 
-Each `openInbound()` allocates a fresh server-allocated id and is owned by exactly one uploading session — there's no fan-in, no shared subscribers, and no replay (the producer is the client, so reconnect means restart).
+Each `openInbound()` allocates a fresh server-side id owned by exactly one uploading session. Uploads are point-to-point: one producer, no fan-in, no shared subscribers, no replay (reconnect means the client restarts).
 
-## Replay on Reconnect
+## Replay on reconnect
 
-When the channel is created with `replayWindow: N`, the server keeps a rolling buffer of the last `N` chunks per stream. On (re)subscribe, the client passes the highest sequence number it has seen, and the server replays anything newer before resuming live.
+With `replayWindow: N`, the server keeps a rolling buffer of the last `N` chunks per stream. On (re)subscribe, the client passes the highest sequence number it has seen, and the server replays anything newer before resuming live.
 
 ```ts
 ctx.rpc.streaming.create<string>('my-devtool:chat', {
@@ -210,11 +208,11 @@ ctx.rpc.streaming.create<string>('my-devtool:chat', {
 })
 ```
 
-`closedStreamRetention` defaults to 30 seconds when `replayWindow > 0` (so a panel re-opened a few seconds after a chat finishes still gets the full transcript), or 0 when replay is disabled. Set it explicitly to opt in or out.
+`closedStreamRetention` defaults to 30 seconds when `replayWindow > 0` (so a panel re-opened seconds after a chat finishes still gets the full transcript). Set it explicitly to tune retention.
 
 ## Backpressure
 
-The client maintains a bounded queue per subscription (`highWaterMark`, default 256). When the consumer can't keep up, the **oldest** queued chunk is dropped and a [`DF0029`](../errors/DF0029) warning is logged. This is best-effort — proper transport-level backpressure isn't worth threading through birpc for the streaming use cases that exist today.
+The client maintains a bounded queue per subscription (`highWaterMark`, default 256). When the consumer falls behind, the oldest queued chunk drops and a [`DF0029`](../errors/DF0029) warning is logged. This is best-effort — sufficient for current streaming use cases without threading transport-level backpressure through birpc.
 
 ```ts
 const reader = rpc.streaming.subscribe('my-devtool:chat', id, {
@@ -222,9 +220,9 @@ const reader = rpc.streaming.subscribe('my-devtool:chat', id, {
 })
 ```
 
-If you need authoritative state rather than every intermediate value, prefer [shared state](./shared-state) — it carries Immer patches with delivery guarantees, at the cost of being structured rather than streaming.
+When you need authoritative state rather than every intermediate value, [shared state](./shared-state) carries Immer patches with delivery guarantees — structured rather than streaming.
 
-## When to Use Streaming vs Events vs Shared State
+## When to use streaming vs events vs shared state
 
 | Use streaming for | Use `event`-typed RPC for | Use shared state for |
 |-------------------|---------------------------|----------------------|

--- a/devframe/docs/guide/when-clauses.md
+++ b/devframe/docs/guide/when-clauses.md
@@ -4,13 +4,13 @@ outline: deep
 
 # When Clauses
 
-When clauses are conditional expressions that gate the visibility and executability of docks, commands, and any other UI surface you wire them into. The syntax is the same one [VS Code uses for its when-clause contexts](https://code.visualstudio.com/api/references/when-clause-contexts), evaluated against a reactive context object.
+When clauses are conditional expressions that gate the visibility and executability of docks, commands, and any other UI surface you wire them into. The syntax matches [VS Code's when-clause contexts](https://code.visualstudio.com/api/references/when-clause-contexts), evaluated against a reactive context object.
 
-The evaluator is provided by the external [`whenexpr`](https://github.com/antfu/whenexpr) package. DevFrame re-exports `evaluateWhen`, `resolveContextValue`, and the `WhenExpression<Ctx, S>` type helper from `devframe/utils/when`.
+The evaluator is the external [`whenexpr`](https://github.com/antfu/whenexpr) package. DevFrame re-exports `evaluateWhen`, `resolveContextValue`, and the `WhenExpression<Ctx, S>` type helper from `devframe/utils/when`.
 
 ## Usage
 
-### On Commands
+### On commands
 
 Controls whether the command appears in the palette and whether it can be triggered via shortcuts:
 
@@ -23,7 +23,7 @@ ctx.commands.register({
 })
 ```
 
-### On Dock Entries
+### On dock entries
 
 Controls whether a dock is visible in the dock bar:
 
@@ -38,9 +38,9 @@ ctx.docks.register({
 })
 ```
 
-Set `when: 'false'` to unconditionally hide an entry.
+`when: 'false'` hides an entry unconditionally.
 
-## Expression Syntax
+## Expression syntax
 
 ### Operators
 
@@ -81,7 +81,7 @@ when: '(clientType == embedded && dockOpen) || clientType == standalone'
 when: 'my-devtool.ready' // custom plugin context
 ```
 
-## Built-in Context Variables
+## Built-in context variables
 
 | Variable | Type | Description |
 |----------|------|-------------|
@@ -90,9 +90,9 @@ when: 'my-devtool.ready' // custom plugin context
 | `paletteOpen` | `boolean` | Whether the command palette is currently open. |
 | `dockSelectedId` | `string` | ID of the currently selected dock entry. Empty string `''` when none. |
 
-## Namespaced Context Keys
+## Namespaced context keys
 
-Plugins can add keys using `.` or `:` separators:
+Plugins add keys using `.` or `:` separators:
 
 ```ts
 context['my-devtool.ready'] = true
@@ -108,16 +108,16 @@ when: 'my-devtool:step == build'
 when: 'myDevtool.ready'
 ```
 
-### Lookup Order
+### Lookup order
 
 When resolving a key like `my-devtool.ready`:
 
-1. Exact match — `ctx['my-devtool.ready']`
-2. Nested path — `ctx['my-devtool']?.ready`
+1. Exact match — `ctx['my-devtool.ready']`.
+2. Nested path — `ctx['my-devtool']?.ready`.
 
-Flat keys win if both exist.
+Flat keys take priority when both exist.
 
-## Type-Safe `when` Clauses
+## Type-safe `when` clauses
 
 `defineCommand` and `defineDockEntry` capture `when:` as a TypeScript literal and validate it against `WhenContext` via `whenexpr`'s `WhenExpression<Ctx, S>` helper — syntax errors surface at compile time:
 
@@ -142,7 +142,7 @@ defineCommand({
 
 ### Key validation with plugin contexts
 
-The default `WhenContext` allows any namespaced key (`[key: string]: unknown`), so the type checker only validates **syntax**. For key-level validation, declare a narrower context and build a typed wrapper:
+The default `WhenContext` keeps namespaced plugin keys open-ended (`[key: string]: unknown`); built-in syntax checking covers expression shape. For key-name validation, declare a narrower context and build a typed wrapper:
 
 ```ts
 import type { WhenContext, WhenExpression } from 'devframe/utils/when'
@@ -180,7 +180,7 @@ defineMyCommand({
 })
 ```
 
-## API Reference
+## API reference
 
 ```ts
 import type { WhenContext } from 'devframe/utils/when'
@@ -202,11 +202,11 @@ resolveContextValue('my-devtool.ready', ctx) // true
 
 ### `evaluateWhen(expression, ctx, options?)`
 
-Returns `boolean`. Pass `{ strict: true }` in `options` to throw when the expression references an unknown key — useful in tests to catch typos.
+Returns `boolean`. Pass `{ strict: true }` to throw on unknown keys — useful in tests to catch typos.
 
 ### `resolveContextValue(key, ctx)`
 
-Returns the current value of a single (possibly namespaced) key. Used internally by the evaluator; exposed for integrations that want to surface live context values.
+Returns the current value of a single (possibly namespaced) key. Used internally by the evaluator and exposed for integrations that surface live context values.
 
 ### `WhenExpression<Ctx, S>`
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,37 +6,26 @@ outline: deep
 
 ## What is Vite DevTools?
 
-Vite DevTools is a devtools framework for the Vite ecosystem. Instead of each tool building its own devtools from scratch, Vite DevTools provides shared infrastructure — a unified dock system, type-safe RPC, shared state management, and flexible UI hosting — so that different tools compose together seamlessly, users get a consistent experience, and tool authors can focus on what makes their integration unique.
+Vite DevTools is a devtools framework for the Vite ecosystem. It provides shared infrastructure — a unified dock, type-safe RPC, shared state, flexible UI hosting — so individual tools compose into one consistent UI and authors focus on what makes their integration unique. Any Vite plugin opts in with a `devtools.setup` hook.
 
-Any Vite plugin can hook into Vite DevTools with just a few lines of code, instantly gaining access to the full platform: panels, action buttons, server-client communication, and more.
+### Built-in integrations
 
-### Built-in Integrations
-
-- **[DevTools for Rolldown](/rolldown/)** — Build analysis, module graphs, chunks, assets, plugins, and performance insights
-- **DevTools for Vite** — Vite-specific developer tools *(in development)*
+[DevTools for Rolldown](/rolldown/) ships in the box: build analysis, module graphs, chunks, assets, plugins, and performance insights.
 
 ### Ecosystem
 
-Vite DevTools Kit is already powering a growing ecosystem of integrations:
+A growing set of integrations already build on Vite DevTools Kit:
 
-- **[Nuxt DevTools v4](https://github.com/nuxt/devtools)** — Built on top of Vite DevTools Kit
-- **[Oxc Inspector](https://github.com/yuyinws/oxc-inspector)** — Integrates via DevTools Kit with custom RPC functions
-- **[UnoCSS Inspector](https://github.com/unocss/unocss)** — Dock integration for UnoCSS
-- **[vite-plugin-vue-tracer](https://github.com/antfu/vite-plugin-vue-tracer)** — Action button that triggers a DOM inspector
-
-### Key Features
-
-- **🧩 Extensible Framework**: Any Vite plugin can extend the devtools with a simple hook
-- **🔍 [DevTools for Rolldown](/rolldown/)**: Built-in build analysis with module graphs, dependencies, and build metadata
-- **🎨 Unified Interface**: All DevTools integrations appear in a consistent dock interface
-- **🔌 Type-Safe RPC**: Built-in bidirectional communication between server and client
-- **⚡ Shared State**: Automatic synchronization of data between server and client
+- **[Nuxt DevTools v4](https://github.com/nuxt/devtools)** — built on Vite DevTools Kit
+- **[Oxc Inspector](https://github.com/yuyinws/oxc-inspector)** — Kit integration with custom RPC functions
+- **[UnoCSS Inspector](https://github.com/unocss/unocss)** — dock integration for UnoCSS
+- **[vite-plugin-vue-tracer](https://github.com/antfu/vite-plugin-vue-tracer)** — action button that triggers a DOM inspector
 
 ## Installation
 
-If you want to give an early preview, you can try it out by building this project from source, or install the preview build with the following steps:
+Vite DevTools is in early preview. Build from source, or install the preview release with the following steps.
 
-Install or upgrade your Vite to version 8:
+Install or upgrade Vite to version 8:
 
 <!-- eslint-skip -->
 ```json [package.json]
@@ -53,11 +42,11 @@ Install the required DevTools package:
 pnpm add -D @vitejs/devtools
 ```
 
-Vite DevTools has two client modes. Configure one mode at a time.
+Vite DevTools has two client modes. Pick one.
 
 ### Standalone mode
 
-The DevTools client runs in a standalone window (no user app).
+The DevTools client runs in a standalone window.
 
 Configure `vite.config.ts`:
 
@@ -77,11 +66,11 @@ Run:
 pnpm build
 ```
 
-After the build completes, open the DevTools URL shown in the terminal.
+After the build completes, open the DevTools URL printed in the terminal.
 
 ### Embedded mode
 
-The DevTools client runs inside an embedded floating panel.
+The DevTools client runs as a floating panel inside the user app.
 
 Configure `vite.config.ts`:
 
@@ -108,23 +97,21 @@ pnpm build
 pnpm dev
 ```
 
-Then open your app in the browser and open the DevTools panel.
+Open your app in the browser; the DevTools panel appears in the corner.
 
 #### Projects without an HTML entry
 
-The embedded DevTools client is usually injected through Vite's `transformIndexHtml` hook. If your app does not start from an HTML entry, keep the `DevTools()` plugin enabled and import the client injector manually in your client entry instead:
+The embedded client is normally injected through Vite's `transformIndexHtml` hook. For apps that start from a JS entry instead, import the client injector from a browser entry (`main.ts`, `entry.client.ts`) and skip server-only or shared SSR files:
 
 ```ts twoslash
 import '@vitejs/devtools/client/inject'
 ```
 
-This loads the same DevTools client that would normally be added to `index.html`. Put it in a browser entry such as `main.ts` or `entry.client.ts`, not in server-only files or shared SSR entry files.
+Use this only when there's no HTML entry — combining it with HTML injection mounts the client twice.
 
-If your project does have an HTML entry, avoid importing `@vitejs/devtools/client/inject` in addition to the HTML injection, as that would inject the client twice and create duplicate dock elements.
+#### Building with the app
 
-#### Building with the App
-
-You can also generate a static DevTools build alongside your app's build output by enabling the `build.withApp` option:
+Generate a static DevTools build alongside the app build by enabling `build.withApp`:
 
 ```ts [vite.config.ts] twoslash
 import { DevTools } from '@vitejs/devtools'
@@ -147,35 +134,16 @@ export default defineConfig({
 })
 ```
 
-When `build.withApp` is enabled, running `pnpm build` will automatically generate the static DevTools output into the build output directory. This captures real build data from the same build context, so DevTools can display accurate build analysis without a separate build step.
+`build.withApp` writes the DevTools static output into the build directory using the same build context, so the analysis panels reflect the real build with no separate command.
 
-## What's Next?
+## What's next
 
-Now that you have Vite DevTools set up, you can:
+- **Explore the built-in tools** — open the [DevTools for Rolldown](/rolldown/) panels.
+- **Build custom integrations** — extend DevTools with the [Vite DevTools Kit](/kit/).
+- **Contribute** — see the [contributing guide](https://github.com/antfu/contribute).
 
-- **Explore the built-in tools**: Check out the [DevTools for Rolldown](/rolldown/) panels and visualizations
-- **Build custom integrations**: Learn how to extend the devtools with your own tools using the [Vite DevTools Kit](/kit/)
-- **Build a standalone CLI tool**: For tools that don't need Vite at all (ESLint inspectors, bundler-config viewers, etc.), follow the [Standalone CLI](https://devfra.me/guide/standalone-cli) recipe
-- **Contribute**: Help improve Vite DevTools by checking out our [contributing guide](https://github.com/antfu/contribute)
+## Architecture
 
-## Current Limitations
+Vite DevTools is built on **`@vitejs/devtools-kit`**, the integration hub that owns the dock, command palette, terminal aggregation, and the `Plugin.devtools.setup` hook every integration uses. Kit in turn builds on **DevFrame**, a framework-neutral foundation that any single tool can use directly — including standalone CLIs, MCP servers, or static dashboards that have no Vite dependency. See [DevFrame](https://devfra.me/guide/) for that path.
 
-> [!NOTE]
-> Vite DevTools is currently in active development.
-
-- **[DevTools for Rolldown](/rolldown/)**: Currently supports build mode only, requires Vite 8+
-- **Dev mode**: Dev mode support is planned for future releases
-
-## Architecture Overview
-
-Vite DevTools consists of several core packages:
-
-- **`devframe`**: The framework-neutral foundation — RPC layer, runtime hosts, and seven adapters. Usable standalone without Vite. See [DevFrame](https://devfra.me/guide/).
-- **`@vitejs/devtools`**: The Vite plugin, CLI, and client that wraps DevFrame for the Vite ecosystem
-- **`@vitejs/devtools-kit`**: Vite DevTools Kit — a Vite-specific superset of DevFrame for building integrations
-- **`@vitejs/devtools-rolldown`**: [DevTools for Rolldown](/rolldown/) — built-in build analysis UI
-- **`@vitejs/devtools-vite`**: DevTools for Vite *(in development)*
-
-Third-party integrations like [Oxc Inspector](https://github.com/yuyinws/oxc-inspector) can integrate via the DevTools Kit plugin API. Tools that don't need Vite at all (standalone CLIs, MCP servers, static dashboards) can build directly on [DevFrame](https://devfra.me/guide/).
-
-For more details on extending the devtools, see the [Vite DevTools Kit documentation](/kit/). For the framework-neutral foundation, see [DevFrame](https://devfra.me/guide/).
+Third-party integrations like [Oxc Inspector](https://github.com/yuyinws/oxc-inspector) plug into Kit's plugin API. To extend Vite DevTools, see [Vite DevTools Kit](/kit/).

--- a/docs/kit/commands.md
+++ b/docs/kit/commands.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Commands & Command Palette
 
-DevTools Kit provides a commands system that lets plugins register executable commands — both on the server and client side. Users can discover and run commands through a built-in command palette, and customize keyboard shortcuts.
+DevTools Kit's commands system lets plugins register executable commands on the server and client. Users discover and run them through the built-in command palette, and rebind keyboard shortcuts to taste.
 
 ## Overview
 
@@ -27,11 +27,11 @@ sequenceDiagram
   Client->>Client: Direct action (client commands)
 ```
 
-## Server-Side Commands
+## Server-side commands
 
-### Defining Commands
+### Defining commands
 
-Use `defineCommand` and register via `ctx.commands.register()`:
+Use `defineCommand` and register through `ctx.commands.register()`:
 
 ```ts
 import { defineCommand } from '@vitejs/devtools-kit'
@@ -60,7 +60,7 @@ const plugin: Plugin = {
 }
 ```
 
-### Command Options
+### Command options
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -75,7 +75,7 @@ const plugin: Plugin = {
 | `handler` | `Function` | Server-side handler. Optional if the command is a group for children. |
 | `children` | `DevToolsServerCommandInput[]` | Static sub-commands (two levels max) |
 
-### Command Handle
+### Command handle
 
 `register()` returns a handle for live updates:
 
@@ -93,9 +93,9 @@ handle.update({ title: 'Show Status (3 items)' })
 handle.unregister()
 ```
 
-## Sub-Commands
+## Sub-commands
 
-Commands can have static children, creating a two-level hierarchy. In the palette, selecting a parent drills down into its children.
+Commands can have static children, forming a two-level hierarchy. Selecting a parent in the palette drills into its children.
 
 ```ts
 ctx.commands.register({
@@ -126,14 +126,13 @@ ctx.commands.register({
 })
 ```
 
-In the palette, users see **Git** → select it → drill down to see **Commit**, **Push**, **Pull**. Sub-commands with keybindings (like `Mod+Shift+G` above) can be executed directly via the shortcut without opening the palette.
+In the palette, users see **Git** → select → drill into **Commit**, **Push**, **Pull**. Sub-commands with keybindings (like `Mod+Shift+G` above) execute directly from the shortcut without opening the palette.
 
-> [!NOTE]
-> Each child must have a globally unique `id`. We recommend the pattern `parentId:childAction` (e.g. `git:commit`).
+Each child needs a globally unique `id`; the recommended pattern is `parentId:childAction` (`git:commit`).
 
-## Keyboard Shortcuts
+## Keyboard shortcuts
 
-### Defining Shortcuts
+### Defining shortcuts
 
 Add default keybindings when registering a command:
 
@@ -148,7 +147,7 @@ ctx.commands.register({
 })
 ```
 
-### Key Format
+### Key format
 
 Use `Mod` as a platform-aware modifier — it maps to `Cmd` on macOS and `Ctrl` on other platforms.
 
@@ -158,7 +157,7 @@ Use `Mod` as a platform-aware modifier — it maps to `Cmd` on macOS and `Ctrl` 
 | `Mod+Shift+P` | `Cmd+Shift+P` | `Ctrl+Shift+P` |
 | `Alt+N` | `Option+N` | `Alt+N` |
 
-### Conditional `when` Clauses
+### Conditional `when` clauses
 
 Commands support a `when` expression for conditional visibility and activation:
 
@@ -171,45 +170,39 @@ ctx.commands.register(defineCommand({
 }))
 ```
 
-When set, the command is only shown in the palette and only triggerable via shortcuts when the expression evaluates to `true`. Supports `==`, `!=`, `&&`, `||`, `!`, bare truthy, literal `true`/`false`, and namespaced keys like `vite.mode`.
+When set, the command shows in the palette and triggers via its shortcut only while the expression evaluates to `true`. The grammar covers `==`, `!=`, `&&`, `||`, `!`, bare truthy, literal `true`/`false`, and namespaced keys like `vite.mode` — see [When Clauses](/kit/when-clauses) for the full reference.
 
-See [When Clauses](/kit/when-clauses) for the full syntax reference, context variables, and namespaced key support.
+### User overrides
 
-### User Overrides
+Users customise shortcuts in the DevTools Settings page under **Keyboard Shortcuts**. Overrides land in shared state and persist across sessions; setting an empty array disables a shortcut.
 
-Users can customize shortcuts in the DevTools Settings page under **Keyboard Shortcuts**. Overrides are stored in shared state and persist across sessions. Setting an empty array disables a shortcut.
-
-### Shortcut Editor
+### Shortcut editor
 
 The Settings page includes an inline shortcut editor with:
 
-- **Key capture** — click the input and press any key combination
-- **Modifier toggles** — toggle Cmd/Ctrl, Alt, Shift individually
-- **Conflict detection** — warns when a shortcut conflicts with:
-  - Common browser shortcuts (e.g. `Cmd+T` → "Open new tab", `Cmd+W` → "Close tab")
-  - Other registered commands
-  - Weak shortcuts (single key without modifiers)
+- **Key capture** — click the input and press any key combination.
+- **Modifier toggles** — toggle Cmd/Ctrl, Alt, Shift individually.
+- **Conflict detection** — warns when a shortcut conflicts with common browser shortcuts (`Cmd+T` → "Open new tab", `Cmd+W` → "Close tab"), with another registered command, or with a weak single-key combo without modifiers.
 
-The list of known browser shortcuts (`KNOWN_BROWSER_SHORTCUTS`) is exported from `@vitejs/devtools-kit` and maps each key combination to a human-readable description.
+`KNOWN_BROWSER_SHORTCUTS` is exported from `@vitejs/devtools-kit` and maps each key combination to a human-readable description.
 
-## Command Palette
+## Command palette
 
-The built-in command palette is toggled with `Mod+K` (or `Ctrl+K` on Windows/Linux). It provides:
+`Mod+K` (or `Ctrl+K` on Windows/Linux) toggles the built-in palette. It offers:
 
-- **Fuzzy search** across all registered commands (including sub-commands)
-- **Keyboard navigation** — Arrow keys to navigate, Enter to select, Escape to close
-- **Drill-down** — Commands with children show a breadcrumb navigation
-- **Server command execution** — Server commands are executed via RPC with a loading indicator
-- **Dynamic sub-menus** — Client commands can return sub-items at runtime
+- **Fuzzy search** across all registered commands (including sub-commands).
+- **Keyboard navigation** — arrow keys, Enter to select, Escape to close.
+- **Drill-down** — commands with children show breadcrumb navigation.
+- **Server-command execution** — RPC with a loading indicator.
+- **Dynamic sub-menus** — client commands can return sub-items at runtime.
 
-### Embedded vs Standalone
+### Embedded vs standalone
 
-- **Embedded mode**: The palette floats over the user's application as part of the DevTools overlay
-- **Standalone mode**: The palette appears as a modal dialog in the standalone DevTools window
+In embedded mode, the palette floats over the user's app as part of the DevTools overlay. In standalone mode, it appears as a modal dialog in the standalone DevTools window.
 
-## Client-Side Commands
+## Client-side commands
 
-Client commands are registered in the webcomponent context and execute directly in the browser:
+Client commands register in the webcomponent context and execute directly in the browser:
 
 ```ts
 // From within the DevTools client context
@@ -254,9 +247,9 @@ context.commands.register({
 })
 ```
 
-## Executing Programmatically
+## Executing programmatically
 
-Any code with access to the kit context can trigger a command by id:
+Code with access to the kit context can trigger a command by id:
 
 ```ts
 await ctx.commands.execute('my-plugin:clear-cache')
@@ -265,11 +258,11 @@ await ctx.commands.execute('my-plugin:clear-cache')
 await ctx.commands.execute('my-plugin:open-file', '/src/main.ts')
 ```
 
-`execute` throws if the command isn't registered or has no handler. It searches both top-level commands and children.
+`execute` searches both top-level commands and children, and throws when the command isn't registered or has no handler.
 
-## Listing & Introspection
+## Listing & introspection
 
-The host exposes a `list()` method returning serializable command entries (without handlers) — useful when implementing your own palette UI or exporting the current command set:
+The host exposes a `list()` method returning serializable command entries (without handlers) — useful for custom palette UIs or exporting the current command set:
 
 ```ts
 const commands = ctx.commands.list()
@@ -289,7 +282,7 @@ ctx.commands.events.on('command:unregistered', (id) => {
 })
 ```
 
-## Complete Example
+## Complete example
 
 ::: code-group
 

--- a/docs/kit/devtools-plugin.md
+++ b/docs/kit/devtools-plugin.md
@@ -4,18 +4,13 @@ outline: deep
 
 # DevTools Plugin
 
-A DevTools plugin is a **superset** of a Vite plugin — any Vite plugin can become one by adding a `devtools` hook. The hook's `setup(ctx)` receives the **kit-augmented context** (`KitNodeContext`) — DevFrame's framework-neutral surface plus the hub-level subsystems the kit owns: `docks`, `terminals`, `messages`, `commands`.
+A DevTools plugin is a Vite plugin with one extra hook: `devtools.setup(ctx)`. The hook receives the kit-augmented context (`KitNodeContext`) — RPC, views, and the four hub subsystems Kit owns: `docks`, `terminals`, `messages`, `commands`.
 
-There are two common ways to author one:
-
-- **From a portable [DevFrame](https://devfra.me/guide/) app.** Wrap the definition with `createPluginFromDevframe(d, opts?)` from `@vitejs/devtools-kit/node`. The kit auto-mounts the SPA via `views.hostStatic`, synthesizes an iframe dock entry from the definition's `id` / `name` / `icon` / `basePath`, runs the devtool's own `setup`, then runs your optional kit-only `opts.setup` for hub features (terminals, commands, custom dock metadata).
-- **As a Vite-specific plugin from scratch.** Implement the `Plugin.devtools.setup` hook directly — useful when the integration is intrinsically tied to Vite's lifecycle (e.g. inspecting the resolved config, reading the dev-server middleware stack).
-
-The rest of this page covers the manual hook approach. See `createPluginFromDevframe` for the portable path.
+This page covers the direct hook approach. To bring in a portable [DevFrame](https://devfra.me/guide/) app instead, see [`createPluginFromDevframe`](https://devfra.me/guide/adapters#kit) — Kit auto-mounts the SPA, derives the iframe dock entry from `id` / `name` / `icon` / `basePath`, then runs an optional kit-only `setup` for hub features.
 
 ## Installation
 
-Install the `@vitejs/devtools-kit` package in your Vite plugin project:
+`@vitejs/devtools-kit` is fine as a dev dependency — Node-side code only consumes it for types.
 
 ::: code-group
 
@@ -33,10 +28,7 @@ yarn add -D @vitejs/devtools-kit
 
 :::
 
-> [!NOTE]
-> It's typically fine to add it as a dev dependency since we only need it for types on the Node.js side.
-
-## Basic Setup
+## Basic setup
 
 Add the triple-slash reference to augment Vite's `Plugin` interface with the `devtools` property:
 
@@ -72,12 +64,11 @@ export default function myPlugin(): Plugin {
 }
 ```
 
-> [!TIP] When is `setup` called?
-> The `devtools.setup` function is called when users run their app with Vite DevTools enabled via `vite dev --ui` or `vite build --ui` (not implemented in Vite yet). It runs once during Vite server initialization.
+`devtools.setup` runs once during Vite server initialization, when DevTools is enabled.
 
-## DevTools Context
+## DevTools context
 
-The `setup` function receives a `DevToolsNodeContext` object that provides access to all DevTools APIs:
+The `setup` function receives a `DevToolsNodeContext` providing access to every DevTools API:
 
 ```ts
 const plugin: Plugin = {
@@ -89,7 +80,7 @@ const plugin: Plugin = {
 }
 ```
 
-### Available Properties
+### Available properties
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -97,22 +88,20 @@ const plugin: Plugin = {
 | `ctx.views` | `ViewsHost` | Host static files for your DevTools UI |
 | `ctx.rpc` | `RpcHost` | Register [RPC functions](./rpc) and broadcast to clients |
 | `ctx.viteConfig` | `ResolvedConfig` | The resolved Vite configuration |
-| `ctx.viteServer` | `ViteDevServer \| undefined` | Vite dev server instance (only in dev mode) |
+| `ctx.viteServer` | `ViteDevServer \| undefined` | Vite dev server instance, present in dev mode |
 | `ctx.mode` | `'dev' \| 'build'` | Current mode |
 | `ctx.cwd` | `string` | Current working directory |
 | `ctx.workspaceRoot` | `string` | Workspace root directory |
 
-### Example: Accessing Vite Config
+### Example: accessing Vite config
 
 ```ts
 const plugin: Plugin = {
   devtools: {
     setup(ctx) {
-      // Access Vite configuration
       console.log('Root:', ctx.viteConfig.root)
       console.log('Mode:', ctx.mode)
 
-      // Check if we're in dev mode
       if (ctx.viteServer) {
         console.log('Dev server is running')
       }
@@ -121,9 +110,9 @@ const plugin: Plugin = {
 }
 ```
 
-## Hosting Static Files
+## Hosting static files
 
-If you have a pre-built UI (e.g., a Vue/React SPA), use `ctx.views.hostStatic()` to serve it:
+For a pre-built UI (Vue/React SPA, etc.), serve it with `ctx.views.hostStatic()`:
 
 ```ts
 import { fileURLToPath } from 'node:url'
@@ -152,13 +141,11 @@ const plugin: Plugin = {
 }
 ```
 
-DevTools handles:
-- Dev server middleware to serve the static files
-- Copying static files to the output directory during production builds
+DevTools handles dev-server middleware and copies the static files into the output directory at build time.
 
-## Complete Example
+## Complete example
 
-Here's a complete example showing a DevTools plugin with dock entry, RPC function, and shared state:
+A plugin with a dock entry and an RPC function that exposes module data:
 
 ```ts
 /// <reference types="@vitejs/devtools-kit" />
@@ -219,7 +206,7 @@ export default function myAnalyzerPlugin(): Plugin {
 
 ## Debugging with Self Inspect
 
-When developing or debugging a DevTools plugin, you can install `@vitejs/devtools-self-inspect` to get a live view of all registered RPC functions, dock entries, client scripts, and DevTools-enabled plugins:
+`@vitejs/devtools-self-inspect` adds a "Self Inspect" panel to DevTools that shows registered RPC functions, dock entries, client scripts, and DevTools-enabled plugins — handy when verifying that everything you registered actually shows up:
 
 ```bash
 pnpm add -D @vitejs/devtools-self-inspect
@@ -237,10 +224,8 @@ export default defineConfig({
 })
 ```
 
-This adds a "Self Inspect" panel to DevTools that shows the internal state of the DevTools system — helpful for verifying that your plugin's RPC functions, docks, and client scripts are registered correctly.
+## Next steps
 
-## Next Steps
-
-- **[Dock System](./dock-system)** - Learn about different dock entry types (iframe, action, custom renderer)
-- **[RPC](./rpc)** - Set up bidirectional server-client communication
-- **[Shared State](./shared-state)** - Synchronize state between server and all clients
+- **[Dock System](./dock-system)** — iframe panels, action buttons, custom renderers, launchers, json-render specs.
+- **[RPC](./rpc)** — bidirectional server-client communication.
+- **[Shared State](./shared-state)** — patch-synced state across every connected client.

--- a/docs/kit/diagnostics.md
+++ b/docs/kit/diagnostics.md
@@ -1,15 +1,13 @@
 # Structured Diagnostics
 
-`ctx.diagnostics` is a thin layer over [`logs-sdk`](https://github.com/vercel-labs/logs-sdk) that lets DevTools plugins register their own coded errors and warnings into a shared logger — without taking a direct dependency on `logs-sdk`.
-
-Use it for *author-defined coded diagnostics* (errors, warnings, deprecations) that have a stable code, a documentation URL, and a structured payload. For free-form runtime output that should appear in the DevTools UI, use [`ctx.messages`](./messages) instead.
+`ctx.diagnostics` is a thin layer over [`logs-sdk`](https://github.com/vercel-labs/logs-sdk) that lets DevTools plugins register coded errors and warnings into a shared logger without depending on `logs-sdk` directly. Use it for author-defined coded diagnostics — errors, warnings, deprecations — that carry a stable code, a documentation URL, and a structured payload. For free-form runtime output that should appear in the DevTools UI, use [`ctx.messages`](./messages).
 
 | Surface | Purpose | Example |
 |---------|---------|---------|
 | `ctx.diagnostics` | Coded errors and warnings emitted from node-side plugin code | `MYP0001: Plugin foo not configured` |
 | [`ctx.messages`](./messages) | Free-form, user-facing notifications shown in the Messages panel | `'Audit complete — 3 issues found'` |
 
-## API Shape
+## API shape
 
 ```ts
 interface DevToolsDiagnosticsHost {
@@ -29,7 +27,7 @@ interface DevToolsDiagnosticsHost {
 
 The host ships pre-seeded with devframe's own `DF*` codes plus the Vite-specific `DTK*` codes registered by `@vitejs/devtools`. Call `register()` to fold your own definitions in.
 
-## Register Your Own Codes
+## Register your own codes
 
 ```ts
 import type { PluginWithDevTools } from '@vitejs/devtools-kit'
@@ -63,9 +61,9 @@ export function MyPlugin(): PluginWithDevTools {
 }
 ```
 
-## Code Prefix Conventions
+## Code prefix conventions
 
-Use a **4-letter prefix + 4-digit number** for your codes (e.g. `MYP0001`). Pick a prefix that's specific to your plugin — short enough to type, distinctive enough not to collide with other integrations.
+Codes are 4-letter prefix + 4-digit number (e.g. `MYP0001`). Pick a prefix specific to your plugin — short enough to type, distinctive enough to avoid collisions with other integrations.
 
 Prefixes used by the in-tree packages:
 
@@ -78,7 +76,7 @@ Prefixes used by the in-tree packages:
 
 Each definition supports `message` (string or function), optional `hint`, optional `level` (`'error'` / `'warn'` / `'suggestion'` / `'deprecation'` — defaults to `'error'`), and a `docsBase` for generating documentation URLs.
 
-## Emit a Diagnostic
+## Emit a diagnostic
 
 Each registered code becomes a callable factory on `ctx.diagnostics.logger`. The factory returns an object with `.throw()`, `.warn()`, `.error()`, `.log()`, and `.format()`.
 
@@ -102,9 +100,9 @@ ctx.diagnostics.logger.MYP0001({ name: 'foo' }, { cause: error }).log()
 throw ctx.diagnostics.logger.MYP0001({ name }).throw()
 ```
 
-## Typed Logger Reference
+## Typed logger reference
 
-`ctx.diagnostics.logger` is loosely typed — it covers an unbounded set of registered codes, so TypeScript can't narrow them. If you want autocompletion for your plugin's specific codes, keep your own typed reference returned from `createLogger`:
+`ctx.diagnostics.logger` is loosely typed — it covers an unbounded set of registered codes, beyond what TypeScript can narrow. For autocompletion on your plugin's specific codes, keep a typed reference returned from `createLogger`:
 
 ```ts
 const myDiagnostics = ctx.diagnostics.defineDiagnostics({
@@ -124,9 +122,9 @@ logger.MYP0001({ name: 'foo' }).warn()
 
 Both loggers share the formatter and reporter defaults set by the host (ANSI console output).
 
-## Don't Cache the Combined Logger
+## Don't cache the combined logger
 
-`ctx.diagnostics.logger` is a *getter* — it always returns the freshest combined logger, rebuilt each time `register()` is called. Don't cache it across registrations:
+`ctx.diagnostics.logger` is a getter — it returns the freshest combined logger, rebuilt each time `register()` is called. Don't cache it across registrations:
 
 ```ts
 // ❌ Stale after a later register() call
@@ -137,9 +135,9 @@ log.MYP0001({ name: 'foo' }).log()
 ctx.diagnostics.logger.MYP0001({ name: 'foo' }).log()
 ```
 
-If you want a stable reference, use the typed `createLogger` form above.
+For a stable reference, use the typed `createLogger` form above.
 
-## Document Your Codes
+## Document your codes
 
 Pair each code with a documentation page so emitted diagnostics carry a clickable URL back to a fix:
 
@@ -150,11 +148,11 @@ docs/errors/
   MYP0002.md
 ```
 
-Each page covers the message, cause, example, and fix. See any [DTK code page](/errors/) for the canonical template. Setting `docsBase` on `defineDiagnostics({...})` auto-attaches the URL to every emitted diagnostic.
+Each page covers the message, cause, example, and fix; see any [DTK code page](/errors/) for the canonical template. Setting `docsBase` on `defineDiagnostics({...})` auto-attaches the URL to every emitted diagnostic.
 
-## When to Use What
+## When to use what
 
-- **`ctx.diagnostics`** — Coded conditions you want users (or other tools) to be able to look up: misconfiguration, deprecations, validation failures, internal invariants. Always have a docs page. Often `.throw()`.
-- **[`ctx.messages`](./messages)** — User-facing activity surfaces in the DevTools UI: progress indicators, audit results, "URL copied" toasts. No code, no docs URL — just a message and a level.
+- **`ctx.diagnostics`** — coded conditions worth looking up: misconfiguration, deprecations, validation failures, internal invariants. Always docs-backed. Often `.throw()`.
+- **[`ctx.messages`](./messages)** — user-facing activity surfaces in the DevTools UI: progress indicators, audit results, "URL copied" toasts. Just a message and a level.
 
-The two systems are intentionally separate: diagnostics are for tool authors and CI; messages are for the human in front of the DevTools panel.
+Diagnostics target tool authors and CI; messages target the human in front of the DevTools panel.

--- a/docs/kit/dock-system.md
+++ b/docs/kit/dock-system.md
@@ -4,11 +4,11 @@ outline: deep
 
 # Dock System
 
-Dock entries are the primary way for users to interact with your DevTools integration. They appear as clickable items in the DevTools dock (similar to macOS Dock).
+Dock entries are how users open your DevTools integration — clickable items in the dock, similar to the macOS Dock.
 
-## Entry Types
+## Entry types
 
-DevTools Kit supports five types of dock entries:
+Kit supports five dock entry types:
 
 | Type | Description | Use Case |
 |------|-------------|----------|
@@ -18,11 +18,11 @@ DevTools Kit supports five types of dock entries:
 | `launcher` | Actionable setup card shown in panel | Run one-time setup tasks before showing other tools |
 | `json-render` | Renders UI from a JSON spec — no client code needed | Data panels, config viewers, simple interactive tools |
 
-## Iframe Panels
+## Iframe panels
 
-The most common approach—host your UI in an iframe. This keeps your DevTools isolated from the user's app and lets you use any framework.
+The default choice — host your UI in an iframe. The frame stays isolated from the user's app and works with any framework.
 
-### Basic Example
+### Basic example
 
 ```ts
 ctx.docks.register({
@@ -34,9 +34,9 @@ ctx.docks.register({
 })
 ```
 
-### Hosting Your Own UI
+### Hosting your own UI
 
-For most use cases, you'll build and host your own UI. DevTools can serve your static files:
+For most use cases, you build and host your own UI. DevTools serves the static files:
 
 ```ts
 import { fileURLToPath } from 'node:url'
@@ -57,11 +57,9 @@ ctx.docks.register({
 })
 ```
 
-DevTools handles:
-- Serving files via dev server middleware
-- Copying files to output during production builds
+DevTools serves the files via dev-server middleware and copies them into the build output for production.
 
-### Dock Entry Options
+### Dock entry options
 
 ```ts
 interface DockEntry {
@@ -94,7 +92,7 @@ interface DockEntry {
 
 ### Icons
 
-You can specify icons in several ways:
+Icons accept a URL, a data URI, or an [Iconify](https://icon-sets.iconify.design/) name. The `ph:` (Phosphor) set pairs well with DevTools UIs.
 
 ```ts
 // URL to an image
@@ -103,7 +101,7 @@ icon: 'https://example.com/logo.svg'
 // Data URI
 icon: 'data:image/svg+xml,...'
 
-// Iconify icon name (recommended)
+// Iconify icon name
 icon: 'ph:chart-bar-duotone' // Phosphor Icons
 icon: 'carbon:analytics' // Carbon Icons
 icon: 'mdi:view-dashboard' // Material Design Icons
@@ -115,22 +113,19 @@ icon: {
 }
 ```
 
-> [!TIP]
-> Browse available icons at [Iconify](https://icon-sets.iconify.design/). The `ph:` (Phosphor) icon set works well for DevTools UIs.
-
-> [!TIP]
-> See the [File Explorer example](/kit/examples#file-explorer) for a iframe dock plugin with RPC and static build support.
+The [File Explorer example](/kit/examples#file-explorer) is a complete iframe-dock plugin with RPC and static-build support.
 
 ### Remote-hosted UIs
 
-If you'd rather not bundle a dist with your plugin, an iframe dock can point at a **hosted website** that connects back to the local dev server over WebSocket. See [Remote Client](./remote-client) for the full guide.
+To skip bundling a dist with your plugin, an iframe dock can point at a hosted website that connects back to the local dev server over WebSocket. See [Remote Client](./remote-client).
 
-## Action Buttons
+## Action buttons
 
-Action buttons run client-side scripts when clicked. They're perfect for:
-- Temporary inspector tools (DOM inspector, component picker)
-- Feature toggles
-- One-time actions that don't need a panel
+Action buttons run a client-side script when clicked. They suit:
+
+- Temporary inspector tools (DOM inspector, component picker).
+- Feature toggles.
+- One-shot actions where a button is enough.
 
 ### Registration
 
@@ -147,9 +142,9 @@ ctx.docks.register({
 })
 ```
 
-### Client Script
+### Client script
 
-Create the action script that runs in the user's browser:
+The action script runs in the user's browser:
 
 ```ts
 // src/devtools-action.ts
@@ -191,7 +186,7 @@ export default function setupAction(ctx: DockClientScriptContext) {
 }
 ```
 
-### Package Export
+### Package export
 
 Export the action script from your package:
 
@@ -205,22 +200,18 @@ Export the action script from your package:
 }
 ```
 
-### Available Events
+### Available events
 
 | Event | Description |
 |-------|-------------|
-| `entry:activated` | Fired when the user clicks/activates this dock entry |
-| `entry:deactivated` | Fired when another entry is selected or the dock is closed |
+| `entry:activated` | Fires when the user activates this dock entry |
+| `entry:deactivated` | Fires when another entry is selected or the dock is closed |
 
-> [!TIP]
-> See the [A11y Checker example](/kit/examples#a11y-checker) for a real-world action dock that runs axe-core audits and reports violations as logs.
+For a real-world action dock, see the [A11y Checker example](/kit/examples#a11y-checker) — it runs axe-core audits and reports violations as logs.
 
-## Custom Renderers
+## Custom renderers
 
-Custom renderers let you render directly into the DevTools panel DOM. This gives you full control and is useful when:
-- You need direct DOM access
-- You want to mount a framework app into the panel
-- You need to avoid iframe isolation
+Custom renderers paint directly into the DevTools panel DOM. Use them when you want direct DOM access, want to mount a framework app into the panel, or want to skip iframe isolation.
 
 ### Registration
 
@@ -237,7 +228,7 @@ ctx.docks.register({
 })
 ```
 
-### Renderer Script
+### Renderer script
 
 ```ts
 // src/devtools-renderer.ts
@@ -275,7 +266,7 @@ export default function setupRenderer(ctx: DockClientScriptContext) {
 }
 ```
 
-### Available Events
+### Available events
 
 | Event | Payload | Description |
 |-------|---------|-------------|
@@ -283,12 +274,11 @@ export default function setupRenderer(ctx: DockClientScriptContext) {
 | `entry:activated` | — | Entry was activated |
 | `entry:deactivated` | — | Entry was deactivated |
 
-> [!NOTE]
-> The panel DOM is preserved when users switch between dock entries. Your UI persists, so you only need to set up once in `dom:panel:mounted`.
+The panel DOM is preserved across dock-entry switches, so your UI persists and the one-time setup belongs in `dom:panel:mounted`.
 
-## Launcher Entries
+## Launcher entries
 
-Launcher entries render a dedicated setup panel and trigger a server-side launch task. They are useful for integrations that need an explicit initialization step (for example starting a terminal task or generating artifacts).
+Launchers render a dedicated setup panel and run a server-side launch task. They suit integrations that need an explicit initialization step — starting a terminal task, generating artifacts, and so on.
 
 ```ts
 ctx.docks.register({
@@ -306,14 +296,11 @@ ctx.docks.register({
 })
 ```
 
-> [!NOTE]
-> Built-in messages panel (`~messages`) is currently reserved and hidden while the messages UI is under development.
+## JSON render panels
 
-## JSON Render Panels
+JSON render panels describe a UI as a JSON spec on the server — the client renders it from a built-in component library. This is the shortest path to a DevTools panel: server-side TypeScript only.
 
-JSON render panels let you describe your UI as a JSON spec on the server side — **no client code needed.** This is the simplest way to add a DevTools panel.
-
-Use `ctx.createJsonRenderer()` to create a renderer handle, then pass it as `ui` when registering a `json-render` dock entry:
+Create a renderer handle with `ctx.createJsonRenderer()` and pass it as `ui` when registering a `json-render` dock entry:
 
 ```ts
 const ui = ctx.createJsonRenderer({
@@ -349,9 +336,9 @@ ctx.docks.register({
 })
 ```
 
-See the [JSON Render](/kit/json-render) page for the full component reference, dynamic updates, actions, state bindings, and examples.
+See [JSON Render](/kit/json-render) for the full component reference, dynamic updates, actions, state bindings, and examples.
 
-## Common Options
+## Common options
 
 Every dock type accepts these base fields:
 
@@ -365,7 +352,7 @@ Every dock type accepts these base fields:
 | `when` | `string` | Visibility expression — see [When Clauses](/kit/when-clauses). |
 | `badge` | `string` | Short text badge (e.g. unread count). |
 
-## Update & Unregister
+## Update
 
 `register()` returns a handle with an `update(patch)` method:
 
@@ -376,11 +363,9 @@ const handle = ctx.docks.register({ /* ... */ })
 handle.update({ badge: '3' })
 ```
 
-The handle only supports `update`. Docks are not individually unregisterable today.
+## Communication with the server
 
-## Communication with Server
-
-All client scripts (actions and custom renderers) can communicate with the server using [RPC](./rpc):
+Action scripts and custom renderers talk to the server through [RPC](./rpc):
 
 ```ts
 import type { DockClientScriptContext } from '@vitejs/devtools-kit/client'

--- a/docs/kit/examples.md
+++ b/docs/kit/examples.md
@@ -4,58 +4,58 @@ outline: deep
 
 # Examples
 
-## Demo Examples
+## Demo plugins
 
-A collection of example plugins built with `@vitejs/devtools-kit` that demonstrate different features and patterns.
+Reference plugins built with `@vitejs/devtools-kit`, each focused on a different feature set.
 
 ### A11y Checker
 
-An accessibility auditing plugin powered by [axe-core](https://github.com/dequelabs/axe-core).
+Accessibility auditing powered by [axe-core](https://github.com/dequelabs/axe-core).
 
 **Features demonstrated:**
 
-- Registering an `action` dock entry with a client-side script
-- Running axe-core accessibility audits on the current page
-- Reporting violations as DevTools logs with severity levels
-- Using log handles to update a summary log in-place
+- An `action` dock entry with a client-side script.
+- Running axe-core audits on the current page.
+- Reporting violations as DevTools logs with severity levels.
+- Using log handles to update a summary log in place.
 
 **Source:** [`examples/plugin-a11y-checker`](https://github.com/vitejs/devtools/tree/main/examples/plugin-a11y-checker)
 
 ### File Explorer
 
-A file explorer dock that lists, reads, and writes files through RPC.
+A file-explorer dock that lists, reads, and writes files through RPC.
 
 **Features demonstrated:**
 
-- Creating and registering RPC functions (`static`, `query`, `action`)
-- Hosting a custom UI panel with `context.views.hostStatic(...)`
-- Registering an `iframe` dock entry
-- RPC dump support for static builds
-- Detecting backend mode (`websocket` vs `static`) on the client
+- `static`, `query`, and `action` RPC functions.
+- Custom UI panel hosted with `context.views.hostStatic(...)`.
+- An `iframe` dock entry.
+- RPC dump support for static builds.
+- Backend-mode detection (`websocket` vs `static`) on the client.
 
 **Source:** [`examples/plugin-file-explorer`](https://github.com/vitejs/devtools/tree/main/examples/plugin-file-explorer)
 
 ### Git UI
 
-An interactive Git panel built entirely with server-side JSON specs — no client code at all.
+An interactive Git panel built from server-side JSON specs — no client code.
 
 **Features demonstrated:**
 
-- Using the `json-render` dock type for zero-client-code panels
-- Building a `JsonRenderSpec` from server-side data (git branch, status, log)
-- Dynamic spec updates via shared state (`sharedStateKey`)
-- Button actions bridged to RPC functions (`git-ui:refresh`, `git-ui:commit`)
-- Text input with `$bindState` two-way binding and `$state` in action params
-- Updating dock badge text reactively
+- The `json-render` dock type for zero-client-code panels.
+- Building a `JsonRenderSpec` from server-side data (branch, status, log).
+- Dynamic spec updates via shared state (`sharedStateKey`).
+- Button actions bridged to RPC functions (`git-ui:refresh`, `git-ui:commit`).
+- Text input with `$bindState` two-way binding and `$state` in action params.
+- Reactively updating the dock badge.
 
 **Source:** [`examples/plugin-git-ui`](https://github.com/vitejs/devtools/tree/main/examples/plugin-git-ui)
 
-## Real-World Examples
+## Real-world examples
 
-The docs might not cover all the details—please help us improve them by submitting PRs. In the meantime, refer to these existing DevTools integrations:
+Existing DevTools integrations worth reading:
 
-- **[UnoCSS Inspector](https://github.com/unocss/unocss/blob/25c0dd737132dc20b257c276ee2bc3ccc05e2974/packages-integrations/inspector/src/index.ts#L140-L150)** - A simple iframe-based dock entry
-- **[vite-plugin-vue-tracer](https://github.com/antfu/vite-plugin-vue-tracer)** - An action button that triggers a DOM inspector
-  - [Plugin hook](https://github.com/antfu/vite-plugin-vue-tracer/blob/9f86fe723543405eea5d30588fe783796193bfd8/src/plugin.ts#L139-L157)
-  - [Client script](https://github.com/antfu/vite-plugin-vue-tracer/blob/main/src/client/vite-devtools.ts)
-- **[Oxc Inspector](https://github.com/yuyinws/oxc-inspector/blob/main/src/vite.ts)** - An iframe-based dock entry with custom RPC functions
+- **[UnoCSS Inspector](https://github.com/unocss/unocss/blob/25c0dd737132dc20b257c276ee2bc3ccc05e2974/packages-integrations/inspector/src/index.ts#L140-L150)** — a small iframe dock entry.
+- **[vite-plugin-vue-tracer](https://github.com/antfu/vite-plugin-vue-tracer)** — an action button that triggers a DOM inspector. See the [plugin hook](https://github.com/antfu/vite-plugin-vue-tracer/blob/9f86fe723543405eea5d30588fe783796193bfd8/src/plugin.ts#L139-L157) and the [client script](https://github.com/antfu/vite-plugin-vue-tracer/blob/main/src/client/vite-devtools.ts).
+- **[Oxc Inspector](https://github.com/yuyinws/oxc-inspector/blob/main/src/vite.ts)** — an iframe dock entry with custom RPC functions.
+
+PRs to improve coverage are welcome.

--- a/docs/kit/index.md
+++ b/docs/kit/index.md
@@ -5,23 +5,19 @@ outline: deep
 # DevTools Kit
 
 > [!WARNING] Experimental
-> The API is still in development and may change in any version. If you are building on top of it, please mind the version of packages you are using and warn your users about the experimental status.
+> The API is still in development and may change in any release. Pin the package version and let your users know they're on an experimental surface.
 
-DevTools Kit is **the hub that unites many DevTools integrations**. While [DevFrame](https://devfra.me/guide/) describes one tool — its RPC, its data, its SPA — Kit is the layer that takes many of those tools and gives them a single home: the dock, the command palette, terminal aggregation, cross-tool toasts, and the Vite plugin glue (`Plugin.devtools.setup`) that ties it all together.
+DevTools Kit is the integration hub for Vite DevTools. It owns the dock, the command palette, terminal aggregation, cross-tool toasts, and the `Plugin.devtools.setup` hook that any Vite plugin can implement to surface a UI inside DevTools.
 
-If you have a portable DevFrame app, drop it in via `createPluginFromDevframe(d)` from `@vitejs/devtools-kit/node` — the kit auto-derives an iframe dock entry from the definition's `id` / `name` / `icon` / `basePath`. If you're authoring a fresh Vite-specific integration that needs hub features (terminals, palette, custom-render docks), reach for the `Plugin.devtools.setup` hook directly. If you have a tool that doesn't need a hub at all, stay in [DevFrame](https://devfra.me/guide/).
-
-The vision of DevTools Kit is to provide a unified foundation for building custom developer tools that integrate seamlessly with Vite and frameworks built on top of it.
-
-We imagine a future where integrations can provide powerful tools for developers and agents to understand your application better, and be composable based on each specific use case:
+For a fresh Vite-specific integration, reach for `Plugin.devtools.setup` directly — that's where docks, terminals, the palette, and custom renderers live. Kit is built on [DevFrame](https://devfra.me/guide/), the framework-neutral foundation; tools that already have a portable DevFrame definition drop into the hub via `createPluginFromDevframe`, and standalone single-tool deployments can build on DevFrame directly.
 
 ![DevTools Kit Vision](/assets/vision-devtools-kit.jpg)
 
-If you are interested in more details, you can also check out [Anthony Fu's talk on ViteConf 2025](https://www.youtube.com/watch?v=tVd0JeSr8kg).
+For background, see [Anthony Fu's ViteConf 2025 talk](https://www.youtube.com/watch?v=tVd0JeSr8kg).
 
-## What DevTools Kit Provides
+## What DevTools Kit provides
 
-DevTools Kit owns the **hub-level surface** — the things that only make sense once you have multiple integrations sharing a UI:
+Kit owns the hub-level surface — the things that only matter once multiple integrations share a UI:
 
 | Feature | Description |
 |---------|-------------|
@@ -64,40 +60,9 @@ flowchart TB
   end
 ```
 
-## Why DevTools Kit?
+## Quick example
 
-Traditionally, each framework or tool has had to build its own isolated DevTools from scratch—resulting in duplicated effort, inconsistent user experiences, and maintenance overhead. DevTools Kit changes this by providing a **unified, extensible foundation** that allows plugin and framework authors to focus on what makes their tools unique, rather than rebuilding common infrastructure.
-
-Whether you're building a framework-specific inspector, a build analysis tool, or a custom debugging interface, DevTools Kit handles the heavy lifting of communication, UI hosting, and integration, so you can focus on delivering value to your users.
-
-## Quick Example
-
-Two paths into the hub.
-
-**Have a portable DevFrame app already?** Wrap it once. The kit auto-derives an iframe dock from the definition:
-
-```ts
-// vite.config.ts
-import { createPluginFromDevframe } from '@vitejs/devtools-kit/node'
-import devtool from './my-devtool'
-
-export default {
-  plugins: [
-    createPluginFromDevframe(devtool, {
-      // Optional kit-only setup for hub features:
-      setup(ctx) {
-        ctx.commands.register({
-          id: 'my-devtool:clear-cache',
-          title: 'Clear Cache',
-          handler: () => { /* ... */ },
-        })
-      },
-    }),
-  ],
-}
-```
-
-**Authoring a fresh Vite-specific integration?** Reach for the hook directly:
+Authoring a Vite plugin? Add a `devtools.setup` hook and register a dock entry:
 
 ```ts
 /// <reference types="@vitejs/devtools-kit" />
@@ -122,12 +87,34 @@ export default function myPlugin(): Plugin {
 }
 ```
 
-## Getting Started
+Already have a portable DevFrame app? Wrap it once and Kit synthesises the iframe dock entry from the definition's `id` / `name` / `icon` / `basePath`:
 
-1. **[DevTools Plugin](./devtools-plugin)** — Learn how to register a hub plugin and understand the kit-augmented context
-2. **[Dock System](./dock-system)** — Iframe panels, action buttons, custom renderers, launchers, json-render specs
-3. **[RPC](./rpc)** — Bidirectional, type-safe communication between server and client
-4. **[Shared State](./shared-state)** — Patch-synced cross-integration state
+```ts
+// vite.config.ts
+import { createPluginFromDevframe } from '@vitejs/devtools-kit/node'
+import devtool from './my-devtool'
 
-> [!TIP] Help Us Improve
-> If you are building something on top of Vite DevTools Kit, we invite you to label your repository with `vite-devtools` on GitHub to help us track usage and improve the project. Thank you!
+export default {
+  plugins: [
+    createPluginFromDevframe(devtool, {
+      // Optional kit-only setup for hub features:
+      setup(ctx) {
+        ctx.commands.register({
+          id: 'my-devtool:clear-cache',
+          title: 'Clear Cache',
+          handler: () => { /* ... */ },
+        })
+      },
+    }),
+  ],
+}
+```
+
+## Getting started
+
+1. **[DevTools Plugin](./devtools-plugin)** — register a hub plugin and walk the kit-augmented context.
+2. **[Dock System](./dock-system)** — iframe panels, action buttons, custom renderers, launchers, json-render specs.
+3. **[RPC](./rpc)** — bidirectional, type-safe communication between server and client.
+4. **[Shared State](./shared-state)** — patch-synced state that bridges every integration.
+
+If you're shipping something on Kit, tag the repo with `vite-devtools` on GitHub so we can see what folks are building.

--- a/docs/kit/json-render.md
+++ b/docs/kit/json-render.md
@@ -4,11 +4,11 @@ outline: deep
 
 # JSON Render
 
-JSON render panels let you build DevTools UIs entirely from server-side TypeScript — no client code needed. You describe your UI as a JSON spec, and the DevTools client renders it with the built-in component library.
+JSON render panels build DevTools UIs from server-side TypeScript alone. You describe the UI as a JSON spec; the DevTools client renders it with the built-in component library.
 
-## Getting Started
+## Getting started
 
-Use `ctx.createJsonRenderer()` to create a renderer handle from a spec, then pass it as `ui` when registering a `json-render` dock entry:
+Create a renderer handle with `ctx.createJsonRenderer()` and pass it as `ui` when registering a `json-render` dock entry:
 
 ```ts
 import type { PluginWithDevTools } from '@vitejs/devtools-kit'
@@ -55,7 +55,7 @@ export function MyPlugin(): PluginWithDevTools {
 }
 ```
 
-## Spec Structure
+## Spec structure
 
 A JSON render spec has three parts: a `root` element ID, an `elements` map, and an optional `state` object for two-way bindings.
 
@@ -85,9 +85,9 @@ ctx.createJsonRenderer({
 
 Every element has a `type` (component name), `props`, and optionally `children` (array of element IDs) or `on` (event handlers).
 
-## Dynamic Updates
+## Dynamic updates
 
-The `JsonRenderer` handle returned by `ctx.createJsonRenderer()` provides two methods for updating the UI reactively:
+The `JsonRenderer` handle returned by `ctx.createJsonRenderer()` exposes two methods for updating the UI reactively:
 
 ```ts
 const ui = ctx.createJsonRenderer(buildSpec(initialData))
@@ -112,9 +112,9 @@ ctx.docks.update({
 })
 ```
 
-## Handling Actions via RPC
+## Handling actions via RPC
 
-Buttons in the spec can trigger RPC functions on the server. Use the `on` property with an `action` key that matches a registered RPC function name:
+Buttons in the spec can trigger RPC functions on the server. The `on` property carries an `action` key that matches a registered RPC function name:
 
 ```ts
 // In the spec — Button with an action
@@ -164,9 +164,9 @@ const ui = ctx.createJsonRenderer({
 })
 ```
 
-## State and Two-Way Binding
+## State and two-way binding
 
-Use `$bindState` on TextInput `value` to create two-way binding with a state key. Use `$state` to read the bound value in action params:
+`$bindState` on a TextInput `value` creates a two-way binding with a state key; `$state` reads the bound value in action params:
 
 ```ts
 const ui = ctx.createJsonRenderer({
@@ -213,7 +213,7 @@ ctx.rpc.register(defineRpcFunction({
 }))
 ```
 
-## Built-in Components
+## Built-in components
 
 ### Layout
 
@@ -390,7 +390,7 @@ Text input field with optional two-way state binding.
 
 See [State and Two-Way Binding](#state-and-two-way-binding) for a full example.
 
-### Data Display
+### Data display
 
 #### KeyValueTable
 
@@ -513,7 +513,7 @@ Expandable tree view for inspecting nested objects.
 }
 ```
 
-## Full Example
+## Full example
 
 A complete panel combining layout, data display, inputs, and actions:
 
@@ -619,5 +619,4 @@ export function BuildReportPlugin(): PluginWithDevTools {
 }
 ```
 
-> [!TIP]
-> See the [Git UI example](/kit/examples#git-ui) for a more advanced plugin using json-render with per-file actions, text input with state binding, and dynamic badge updates.
+For a more advanced plugin using json-render with per-file actions, text input with state binding, and dynamic badge updates, see the [Git UI example](/kit/examples#git-ui).

--- a/docs/kit/messages.md
+++ b/docs/kit/messages.md
@@ -1,17 +1,15 @@
 # Messages & Notifications
 
-The Messages system allows plugins to emit structured message entries from both the server (Node.js) and client (browser) contexts. Messages are displayed in the built-in **Messages** panel in the DevTools dock, and can optionally appear as toast notifications.
+The Messages system lets plugins emit structured message entries from both the server (Node.js) and client (browser) contexts. Entries appear in the **Messages** panel in the DevTools dock and can optionally surface as toast notifications. For *coded* errors and warnings with stable codes and docs URLs, use [Structured Diagnostics](./diagnostics) (`ctx.diagnostics`) instead.
 
-> For *coded* errors and warnings with stable codes and docs URLs, see [Structured Diagnostics](./diagnostics) (`ctx.diagnostics`) instead.
+## Use cases
 
-## Use Cases
+- **Accessibility audits** — run a11y checks on the client and report warnings with element positions.
+- **Runtime errors** — capture and display errors with stack traces.
+- **Linting & testing** — run ESLint or test runners alongside the dev server and surface results with file positions.
+- **Notifications** — short-lived messages like "URL copied" that auto-dismiss.
 
-- **Accessibility audits** — Run a11y checks or similar tools on the client side, report warnings with element positions
-- **Runtime errors** — Capture and display errors with stack traces
-- **Linting & testing** — Run ESLint or test runners alongside the dev server and surface results with file positions
-- **Notifications** — Short-lived messages like "URL copied" that auto-dismiss
-
-## Message Entry Fields
+## Message entry fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -29,13 +27,13 @@ The Messages system allows plugins to emit structured message entries from both 
 | `status` | `'loading' \| 'idle'` | No | Status indicator (shows spinner when `'loading'`) |
 | `id` | `string` | No | Explicit id for deduplication — re-adding with the same id updates the existing entry |
 
-The `from` field is automatically set to `'server'` or `'browser'` depending on where the message was emitted.
+The `from` field is set to `'server'` or `'browser'` automatically, based on where the message was emitted.
 
 ## Usage
 
-Both server-side and client-side share the same `context.messages` API. All methods return Promises, but you don't need to `await` them for fire-and-forget usage.
+Server and client share the same `context.messages` API. Methods return Promises; for fire-and-forget usage, skip the `await`.
 
-### Fire-and-Forget
+### Fire-and-forget
 
 ```ts
 // No await needed — just emit the message
@@ -45,9 +43,9 @@ context.messages.add({
 })
 ```
 
-### With Handle
+### With handle
 
-`await` the `add()` call to get a `DevToolsMessageHandle` for subsequent updates:
+`await` the `add()` call for a `DevToolsMessageHandle` you can update later:
 
 ```ts
 // Await to get a handle for later updates
@@ -69,7 +67,7 @@ await handle.update({
 await handle.dismiss()
 ```
 
-### Server-Side Example
+### Server-side example
 
 ```ts
 export function myPlugin() {
@@ -88,7 +86,7 @@ export function myPlugin() {
 }
 ```
 
-### Client-Side Example
+### Client-side example
 
 ```ts
 import type { DockClientScriptContext } from '@vitejs/devtools-kit/client'
@@ -113,7 +111,7 @@ export default async function (context: DockClientScriptContext) {
 }
 ```
 
-## Message Handle
+## Message handle
 
 `context.messages.add()` returns a `Promise<DevToolsMessageHandle>` with:
 
@@ -124,11 +122,11 @@ export default async function (context: DockClientScriptContext) {
 | `handle.update(patch)` | Partially update the message entry (returns `Promise`) |
 | `handle.dismiss()` | Remove the message entry (returns `Promise`) |
 
-Both `handle.update()` and `handle.dismiss()` return Promises but can be used without `await` for fire-and-forget.
+Both `handle.update()` and `handle.dismiss()` return Promises; the `await` is optional.
 
 ## Deduplication
 
-When you call `add()` with an explicit `id` that already exists, the existing entry is **updated** instead of duplicated. This is useful for messages that represent ongoing operations:
+Calling `add()` with an explicit `id` that already exists updates the existing entry rather than creating a duplicate — useful for ongoing operations:
 
 ```ts
 // First call creates the entry
@@ -138,9 +136,9 @@ context.messages.add({ id: 'my-scan', message: 'Scanning...', level: 'info', sta
 context.messages.add({ id: 'my-scan', message: 'Scan complete', level: 'success', status: 'idle' })
 ```
 
-## Toast Notifications
+## Toast notifications
 
-Set `notify: true` to show the message entry as a toast notification overlay. Toasts appear regardless of whether the Messages panel is open.
+Set `notify: true` to surface the message entry as a toast overlay. Toasts appear whether or not the Messages panel is open.
 
 ```ts
 context.messages.add({
@@ -151,9 +149,9 @@ context.messages.add({
 })
 ```
 
-The default auto-dismiss time for toasts is 5 seconds.
+Toast auto-dismiss defaults to 5 seconds.
 
-## Managing Messages
+## Managing messages
 
 ```ts
 // Remove a specific message by id
@@ -163,18 +161,17 @@ context.messages.remove(entryId)
 context.messages.clear()
 ```
 
-Messages have a maximum capacity of 1000 entries. When the limit is reached, the oldest entries are automatically removed.
+Capacity tops out at 1000 entries; the oldest are dropped automatically when the limit is hit.
 
-> [!TIP]
-> See the [A11y Checker example](/kit/examples#a11y-checker) for a plugin that uses messages to report accessibility violations with severity levels, element positions, and WCAG labels.
+The [A11y Checker example](/kit/examples#a11y-checker) is a plugin that uses messages to report accessibility violations with severity levels, element positions, and WCAG labels.
 
-## Dock Badge
+## Dock badge
 
-The Messages dock icon automatically shows a badge with the total message count. The icon is hidden when there are no messages.
+The Messages dock icon shows a badge with the total message count and hides itself when there are no messages.
 
 ## Events
 
-The host emits events for anyone who wants to observe the message stream:
+The host emits events for observers of the message stream:
 
 ```ts
 ctx.messages.events.on('message:added', (entry) => { /* ... */ })
@@ -183,7 +180,7 @@ ctx.messages.events.on('message:removed', (id) => { /* ... */ })
 ctx.messages.events.on('message:cleared', () => { /* ... */ })
 ```
 
-Use this to bridge messages into external tools — e.g. mirror them into a structured log file or forward certain categories to your own reporter:
+Use the events to bridge messages into external tools — mirror them into a structured log, forward certain categories to your own reporter, etc.:
 
 ```ts
 ctx.messages.events.on('message:added', (entry) => {
@@ -192,7 +189,7 @@ ctx.messages.events.on('message:added', (entry) => {
 })
 ```
 
-## Long-Running Operation Pattern
+## Long-running operation pattern
 
 Combine `id`-based deduplication with `status: 'loading'` to drive a single message through a multi-step lifecycle:
 

--- a/docs/kit/remote-client.md
+++ b/docs/kit/remote-client.md
@@ -4,18 +4,15 @@ outline: deep
 
 # Remote Client
 
-Remote client mode lets a dock point at a **hosted website** — e.g. `https://example.com/devtools` — instead of bundling a SPA dist with your plugin. The hosted page opens a WebSocket connection back to the local Vite dev server and talks to your plugin using the same RPC and shared-state APIs as an embedded client.
+Remote client mode points a dock at a hosted website (e.g. `https://example.com/devtools`) instead of bundling a SPA dist with your plugin. The hosted page opens a WebSocket back to the local Vite dev server and uses the same RPC and shared-state APIs as an embedded client. A live demo lives at [Remote Connection Demo](./remote-demo) — register a dock pointing at that URL to see the flow end-to-end.
 
-> [!TIP]
-> A live demo is hosted on this site at [Remote Connection Demo](./remote-demo). Register a dock pointing at that URL and open it to see the flow end-to-end.
+Compared to the bundled approach in [Dock System → Iframe Panels](./dock-system#iframe-panels), remote mode:
 
-Compared to the bundled approach described in [Dock System → Iframe Panels](./dock-system#iframe-panels), remote mode means:
+- **Keeps your npm package small.** Ship node-side code only.
+- **Decouples release cadences.** Update the hosted UI without republishing the plugin.
+- **Surfaces existing dashboards.** Drop in a production URL your team already runs.
 
-- **No client dist shipped with your plugin.** Your npm package stays small; you ship only node-side code.
-- **Iterate on the hosted app independently.** Deploy updates to the UI without republishing the plugin.
-- **Use the production URL of an existing dashboard.** If your team already hosts something, surface it directly inside DevTools.
-
-The tradeoff: users must be online to load the hosted page, and you trust the hosted origin to faithfully render local data.
+The tradeoff: users need to be online to load the hosted page, and the hosted origin gets trusted access to render local data.
 
 ## How it works
 
@@ -25,7 +22,7 @@ When you register an iframe dock with `remote: true`, DevTools:
 2. Injects a connection descriptor — the WS URL, the token, and the user's dev-server origin — into the iframe's `src` attribute.
 3. Accepts the token on WebSocket handshake (after verifying the `Origin` header, if origin-lock is on).
 
-On the hosted page, `connectRemoteDevTools()` parses the descriptor out of the URL and hands back a fully connected [`DevToolsRpcClient`](./rpc) — the same client you'd get from `getDevToolsRpcClient()` in an embedded page.
+On the hosted page, `connectRemoteDevTools()` parses the descriptor out of the URL and returns a fully connected [`DevToolsRpcClient`](./rpc) — the same client you'd get from `getDevToolsRpcClient()` in an embedded page.
 
 ```mermaid
 sequenceDiagram
@@ -44,7 +41,7 @@ sequenceDiagram
   Hosted->>Core: rpc.call('my-plugin:…')
 ```
 
-## Register a remote dock
+## Registering a remote dock
 
 ```ts
 import type { Plugin } from 'vite'
@@ -68,7 +65,7 @@ export function myPlugin(): Plugin {
 }
 ```
 
-That's the whole node-side change. The dock renders exactly like a normal iframe panel — with the connection descriptor invisibly appended to the URL.
+That's the whole node-side change. The dock renders like a regular iframe panel, with the connection descriptor appended invisibly to the URL.
 
 ### Options
 
@@ -88,18 +85,17 @@ interface RemoteDockOptions {
 
 #### `transport`
 
-- **`'fragment'` (default)** — the descriptor is appended as a URL fragment (`#vite-devtools-kit-connection=...`). Fragments are **not** sent to servers, **not** written to access logs, and **stripped from `Referer`** on outbound sub-resource requests. This is the safest place to carry an auth token.
-- **`'query'`** — the descriptor is appended as a query parameter (`?vite-devtools-kit-connection=...`). Use this when:
-  - Your SPA router uses the fragment for navigation (and strips unknown fragments).
-  - Your hosting platform or CDN rewrites URLs in a way that drops fragments.
+- **`'fragment'` (default)** — the descriptor rides as a URL fragment (`#vite-devtools-kit-connection=...`). Fragments stay client-side: they don't reach servers, don't enter access logs, and get stripped from `Referer` on sub-resource requests. The safest place to carry an auth token.
+- **`'query'`** — the descriptor rides as a query parameter (`?vite-devtools-kit-connection=...`). Pick this when your SPA router uses the fragment for navigation, or when your hosting platform / CDN rewrites URLs in a way that drops fragments.
 
-  The token **will** appear in server access logs and outbound `Referer` headers when transport is `'query'`. Only opt in if you control the analytics / log pipeline for the hosted origin.
+> [!WARNING]
+> With `'query'` transport, the auth token appears in server access logs and outbound `Referer` headers. Use it only when you control the analytics / log pipeline on the hosted origin.
 
 #### `originLock`
 
-When on (default), the WebSocket handshake is rejected if the browser's `Origin` header doesn't match the origin of the dock URL you registered. If the token leaks (e.g. logged to an external analytics tool that ingests URLs), a different origin can't use it to talk to the local dev server.
+When on (default), the WebSocket handshake is rejected if the browser's `Origin` header doesn't match the origin of the registered dock URL. If the token leaks (for example to an external analytics tool that ingests URLs), the wrong origin can't reuse it.
 
-Turn off only when the same hosted app is served from multiple origins (e.g. preview deploys on `pr-123.preview.example.com`):
+Turn it off only when the same hosted app is served from multiple origins (e.g. preview deploys on `pr-123.preview.example.com`):
 
 ```ts
 ctx.docks.register({
@@ -112,9 +108,9 @@ ctx.docks.register({
 })
 ```
 
-## Connect from the hosted page
+## Connecting from the hosted page
 
-Install `@vitejs/devtools-kit` as a dependency of your hosted page — it's browser-safe for this entrypoint:
+Install `@vitejs/devtools-kit` as a dependency of your hosted page — the client entrypoint is browser-safe:
 
 ```sh
 pnpm add @vitejs/devtools-kit
@@ -133,7 +129,7 @@ const data = await rpc.call('my-plugin:get-data')
 
 `connectRemoteDevTools()` reads the descriptor from the current URL, opens the WebSocket, and resolves to a `DevToolsRpcClient` with `.call`, `.callEvent`, `.callOptional`, `.sharedState`, and the rest of the standard API documented in [RPC](./rpc).
 
-If the page is loaded without a descriptor in the URL (someone opening `https://example.com/devtools` directly), the call throws. That's a useful signal — render a friendly "Open me through Vite DevTools" placeholder in that case:
+When someone opens the page directly (no descriptor in the URL), the call throws. Use that as a cue to render a friendly "Open me through Vite DevTools" placeholder:
 
 ```ts
 import { connectRemoteDevTools, parseRemoteConnection } from '@vitejs/devtools-kit/client'
@@ -149,7 +145,7 @@ else {
 
 ### Advanced: custom URL / options
 
-`connectRemoteDevTools` forwards any [`DevToolsRpcClientOptions`](./rpc) except `connectionMeta` and `authToken` (those come from the descriptor). Use this for RPC caching, custom `rpcOptions`, etc.
+`connectRemoteDevTools` forwards any [`DevToolsRpcClientOptions`](./rpc) — RPC caching, custom `rpcOptions`, and so on — while keeping `connectionMeta` and `authToken` sourced from the descriptor.
 
 ```ts
 const rpc = await connectRemoteDevTools({
@@ -157,7 +153,7 @@ const rpc = await connectRemoteDevTools({
 })
 ```
 
-For testing or non-browser environments you can pass an explicit URL or raw fragment/query string to `parseRemoteConnection`:
+For testing or non-browser environments, pass an explicit URL or raw fragment/query string to `parseRemoteConnection`:
 
 ```ts
 parseRemoteConnection('https://example.com/p#vite-devtools-kit-connection=...')
@@ -184,24 +180,25 @@ It's JSON-encoded and base64url-encoded, then appended to the iframe URL under t
 
 ## Trust boundary
 
-Enabling remote mode extends the following trust chain:
+Remote mode extends the following trust chain:
 
-1. The user **installs your plugin** and opts into DevTools.
-2. Your plugin **declares a remote URL**.
-3. DevTools **hands the hosted origin a session token** scoped to that URL.
+1. The user installs your plugin and opts into DevTools.
+2. Your plugin declares a remote URL.
+3. DevTools hands the hosted origin a session token scoped to that URL.
 
-The session token is:
+Properties of the session token:
 
-- **Pre-approved** — no interactive "trust this browser?" prompt fires. The user already agreed to the integration when they installed your plugin.
-- **Session-scoped** — stored in memory only, regenerated on every dev-server restart.
-- **Re-register-scoped** — calling `ctx.docks.register(..., true)` again for the same id revokes the previous token before allocating a new one. Any live WS clients using the old token receive `devframe:auth:revoked` and become untrusted.
-- **Origin-locked by default** — only connections whose `Origin` header matches the dock URL's origin are accepted.
+- **Pre-approved.** No interactive "trust this browser?" prompt fires; the user agreed to the integration when they installed the plugin.
+- **Session-scoped.** Stored in memory only and regenerated on every dev-server restart.
+- **Re-register-scoped.** Calling `ctx.docks.register(...)` again for the same id revokes the previous token; live WS clients on the old token receive `devframe:auth:revoked` and become untrusted.
+- **Origin-locked by default.** Only connections whose `Origin` matches the dock URL are accepted.
 
-Because the token rides in the URL (fragment or query), it should be treated as a session secret: don't log URLs to external services on the hosted page, and prefer `transport: 'fragment'` unless you have a specific reason not to.
+> [!WARNING]
+> The token rides in the URL — treat it as a session secret. Avoid logging URLs to external services on the hosted page, and prefer `transport: 'fragment'` unless you have a specific reason to use `'query'`.
 
 ## Build mode
 
-The WebSocket server exists only in dev mode (`vite`), not in build mode (`vite build`). Remote-iframe docks are skipped automatically in static-dump output, so you don't need to gate them with a [`when` clause](./when-clauses) — but you can add one if you want different visibility rules in embedded vs. standalone clients:
+The WebSocket server runs in dev mode (`vite`); remote-iframe docks skip themselves in static-dump output, so no [`when` clause](./when-clauses) is needed. Add one if you want different visibility in embedded vs. standalone clients:
 
 ```ts
 ctx.docks.register({

--- a/docs/kit/rpc.md
+++ b/docs/kit/rpc.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Remote Procedure Calls (RPC)
 
-DevTools Kit provides a built-in RPC layer for type-safe bidirectional communication between your Node.js server and browser clients.
+DevTools Kit's RPC layer is type-safe, bidirectional, and works between your Node.js server and any connected browser client.
 
 ## Overview
 
@@ -18,11 +18,11 @@ sequenceDiagram
   Server->>Client: { id, data: '...' }
 ```
 
-## Server-Side Functions
+## Server-side functions
 
-### Defining RPC Functions
+### Defining RPC functions
 
-Use `defineRpcFunction` to create type-safe server functions:
+Use `defineRpcFunction` for type-safe server functions:
 
 ```ts
 import { defineRpcFunction } from '@vitejs/devtools-kit'
@@ -44,31 +44,22 @@ const getModules = defineRpcFunction({
 })
 ```
 
-### Naming Convention
+### Naming convention
 
-Recommended RPC function naming:
+Scope each function with your package prefix and use kebab-case for the function part: `my-plugin:get-modules`, `my-plugin:read-file`.
 
-1. Scope functions with your package prefix: `<package-name>:...`
-2. Use kebab-case for the function part after `:`
+### Function types
 
-Examples:
-- `my-plugin:get-modules`
-- `my-plugin:read-file`
+| Type | Use for | Cached | Dump support |
+|------|---------|--------|--------------|
+| `query` | Fetch data, read operations | Yes | Manual |
+| `static` | Constant data | Indefinitely | Automatic |
+| `action` | Side effects, mutations | No | — |
+| `event` | Notifications without a response | No | — |
 
-### Function Types
+For chunk-style data (LLM deltas, log lines, build progress, file uploads), reach for [streaming channels](./streaming) — they handle stream IDs, cancellation, replay, and Web Streams interop for you.
 
-| Type | Description | Caching | Dump Support |
-|------|-------------|---------|--------------|
-| `query` | Fetch data, read operations | Can be cached | ✓ (manual) |
-| `static` | Constant data that never changes | Cached indefinitely | ✓ (automatic) |
-| `action` | Side effects, mutations | Not cached | ✗ |
-| `event` | Emit events, no response | Not cached | ✗ |
-
-::: tip Streaming chunks instead of single responses
-For chunk-style data (LLM deltas, log lines, build progress, file uploads), reach for [streaming channels](./streaming) rather than hand-rolling `action + delta/end events`. The streaming API gives you stream IDs, cancellation, replay, and Web Streams interop for free.
-:::
-
-### Handler Arguments
+### Handler arguments
 
 Handlers can accept any serializable arguments:
 
@@ -85,7 +76,7 @@ const getModule = defineRpcFunction({
 })
 ```
 
-### Context in Setup
+### Context in setup
 
 The `setup` function receives the full `DevToolsNodeContext`:
 
@@ -106,12 +97,11 @@ setup: (ctx) => {
 }
 ```
 
-> [!IMPORTANT]
-> For build mode compatibility, compute data in the setup function using the context rather than relying on runtime global state. This allows the dump feature to pre-compute results at build time.
+For build-mode compatibility, compute data in `setup` using the context and let the handler use it. The dump feature then pre-computes results at build time using values that already exist in `setup`'s closure.
 
-### Registering Functions
+### Registering functions
 
-Register your RPC function in the `devtools.setup`:
+Register the RPC function from `devtools.setup`:
 
 ```ts
 const plugin: Plugin = {
@@ -123,22 +113,21 @@ const plugin: Plugin = {
 }
 ```
 
-### Dump Feature for Build Mode
+### Dump feature for build mode
 
-When creating a static DevTools build (via `vite devtools build` CLI or the [`build.withApp`](/guide/#building-with-the-app) plugin option), the server cannot execute functions at runtime. The **dump feature** solves this by pre-computing RPC results at build time.
+A static DevTools build (via `vite devtools build` or the [`build.withApp`](/guide/#building-with-the-app) plugin option) has no live server. The dump feature pre-computes RPC results at build time and bakes them into the static output.
 
-#### How It Works
+#### How it works
 
-1. At build time, `dumpFunctions()` executes your RPC handlers with predefined arguments
-2. Results are stored in `__rpc-dump/index.json` in the build output
-3. The static client reads from this JSON file instead of making live RPC calls
+1. At build time, `dumpFunctions()` runs each RPC handler with predefined arguments.
+2. Results land in `__rpc-dump/index.json` (and sharded `__rpc-dump/*.json` files) in the build output.
+3. The static client reads from those files instead of making live RPC calls.
 
-Dump shard files are written to `__rpc-dump/*.json`. Function names in shard file keys replace `:` with `~` (for example `my-plugin:get-data` -> `my-plugin~get-data`).
-Query record maps are embedded directly in `__rpc-dump/index.json`; no per-function index files are generated.
+Function names in shard file keys replace `:` with `~` (e.g. `my-plugin:get-data` → `my-plugin~get-data`). Query record maps are embedded directly in `__rpc-dump/index.json`.
 
-#### Static Functions (Recommended)
+#### Static functions
 
-Functions with `type: 'static'` are **automatically dumped** with no arguments:
+Functions with `type: 'static'` are dumped automatically with no arguments — the recommended default for constant data:
 
 ```ts
 const getConfig = defineRpcFunction({
@@ -153,9 +142,9 @@ const getConfig = defineRpcFunction({
 })
 ```
 
-This works in both dev mode (live) and build mode (pre-computed).
+Works in both dev mode (live) and build mode (pre-computed).
 
-#### Query Functions with Dumps
+#### Query functions with dumps
 
 For `query` functions that need arguments, define `dump` in the setup:
 
@@ -181,17 +170,17 @@ const getModule = defineRpcFunction({
 })
 ```
 
-#### Recommendations for Plugin Authors
+#### Recommendations for plugin authors
 
-To ensure your DevTools work in build mode:
+For DevTools that work in both dev and build:
 
-1. **Prefer `type: 'static'`** for functions that return constant data
-2. **Return context-based data in setup** rather than accessing global state in handlers
-3. **Define dumps in setup function** for query functions that need pre-computation
-4. **Use fallback values** for graceful degradation when arguments don't match
+1. Prefer `type: 'static'` for functions that return constant data.
+2. Compute context-based data in `setup` rather than accessing global state in handlers.
+3. Define `dump` in `setup` for query functions that need pre-computation.
+4. Provide fallback values so unmatched arguments degrade gracefully.
 
 ```ts
-// ✓ Good: Returns static data, works in build mode
+// ✓ Good: returns static data, works in build mode
 const getPluginInfo = defineRpcFunction({
   name: 'my-plugin:info',
   type: 'static',
@@ -203,29 +192,26 @@ const getPluginInfo = defineRpcFunction({
   }),
 })
 
-// ✗ Avoid: Depends on runtime server state
+// ✗ Avoid: depends on runtime server state, dev-mode only
 const getLiveMetrics = defineRpcFunction({
   name: 'my-plugin:metrics',
-  type: 'query', // No dump - won't work in build mode
+  type: 'query',
   handler: async () => {
-    return getCurrentMetrics() // Requires live server
+    return getCurrentMetrics() // requires live server
   },
 })
 ```
 
-> [!TIP]
-> If your data genuinely needs live server state, use `type: 'query'` without dumps. The function will work in dev mode but gracefully fail in build mode.
+`type: 'query'` without a dump still works in dev mode — use it when the data genuinely needs live server state.
 
-### Organization Convention
+### Organization convention
 
-For plugin-scale RPC modules, we recommend this structure:
+For plugin-scale RPC modules, we recommend:
 
-General guidelines:
-
-1. Keep function definitions small and focused: one RPC function per file.
-2. Use `src/node/rpc/index.ts` as the single composition point for registration and type augmentation.
-3. Store plugin-specific runtime options in `src/node/rpc/context.ts` (instead of mutating the base DevTools context object).
-4. Use `context.rpc.invokeLocal(...)` for server-side cross-function composition.
+1. One RPC function per file — small and focused.
+2. `src/node/rpc/index.ts` as the single composition point for registration and type augmentation.
+3. Plugin-specific runtime options stored in `src/node/rpc/context.ts` rather than mutated onto the base DevTools context.
+4. `context.rpc.invokeLocal(...)` for server-side cross-function composition.
 
 Rough file tree:
 
@@ -319,12 +305,11 @@ export const readFile = defineRpcFunction({
 })
 ```
 
-> [!TIP]
-> See the [File Explorer example](/kit/examples#file-explorer) for a plugin using RPC functions with dump support, organized following the conventions above.
+The [File Explorer example](/kit/examples#file-explorer) follows these conventions for a plugin with RPC functions and dump support.
 
-## Schema Validation (Optional)
+## Schema validation
 
-The RPC system has built-in support for runtime schema validation using [Valibot](https://valibot.dev). When you provide schemas, TypeScript types are automatically inferred and validation happens at runtime.
+The RPC system supports runtime schema validation through [Valibot](https://valibot.dev). When you provide schemas, TypeScript types are inferred and validation runs at the call site. Schemas are optional — without them, RPC works on plain TypeScript types.
 
 ```ts
 import { defineRpcFunction } from '@vitejs/devtools-kit'
@@ -357,12 +342,9 @@ const getModule = defineRpcFunction({
 })
 ```
 
-> [!NOTE]
-> Schema validation is optional. If you don't provide `args` or `returns` schemas, the RPC system will work without validation and you can use regular TypeScript types instead.
+## Client-side calls
 
-## Client-Side Calls
-
-### In Iframe Pages
+### In iframe pages
 
 Use `getDevToolsRpcClient()` to get the RPC client:
 
@@ -382,7 +364,7 @@ async function loadData() {
 }
 ```
 
-### In Action/Renderer Scripts
+### In action/renderer scripts
 
 Use `ctx.rpc` from the script context:
 
@@ -397,9 +379,9 @@ export default function setup(ctx: DockClientScriptContext) {
 }
 ```
 
-### Sharing State Across RPC Functions
+### Sharing state across RPC functions
 
-When multiple RPC functions need access to the same plugin-specific state (a manager instance, plugin options, cached data, etc.), use a `WeakMap` keyed by `DevToolsNodeContext` to store and retrieve that state. This avoids mutating the base context object and keeps your plugin state scoped and garbage-collectable.
+When multiple RPC functions need the same plugin-specific state (a manager instance, plugin options, cached data), key a `WeakMap` by `DevToolsNodeContext`. This keeps the plugin state scoped, garbage-collectable, and out of the base context.
 
 Create a helper file with get/set functions:
 
@@ -465,9 +447,9 @@ export const getData = defineRpcFunction({
 
 :::
 
-### Global Client Context
+### Global client context
 
-Use `getDevToolsClientContext()` to access the client context (`DevToolsClientContext`) from anywhere on the client side. This is set automatically when DevTools initializes in embedded or standalone mode.
+`getDevToolsClientContext()` returns the `DevToolsClientContext` from anywhere on the client side. DevTools sets it automatically in embedded or standalone mode, and the function returns `undefined` until initialization completes.
 
 ```ts
 import { getDevToolsClientContext } from '@vitejs/devtools-kit/client'
@@ -478,14 +460,11 @@ if (ctx) {
 }
 ```
 
-Returns `undefined` if the context has not been initialized yet.
-```
+## Client-side functions
 
-## Client-Side Functions
+The client can also expose functions that the server calls.
 
-You can also define functions on the client that the server can call.
-
-### Registering Client Functions
+### Registering client functions
 
 ```ts
 import type { DockClientScriptContext } from '@vitejs/devtools-kit/client'
@@ -507,9 +486,9 @@ export default function setup(ctx: DockClientScriptContext) {
 }
 ```
 
-### Broadcasting from Server
+### Broadcasting from server
 
-Use `ctx.rpc.broadcast()` to call client functions from the server:
+`ctx.rpc.broadcast()` sends an event-style call to every connected client and resolves once dispatch completes:
 
 ```ts
 const plugin: Plugin = {
@@ -525,14 +504,11 @@ const plugin: Plugin = {
 }
 ```
 
-> [!NOTE]
-> `broadcast` sends an event-style call to all connected clients and resolves when dispatch completes.
+## Type safety
 
-## Type Safety
+Extend the DevTools Kit interfaces for end-to-end type checking.
 
-For full type safety, extend the DevTools Kit interfaces.
-
-### Server Functions
+### Server functions
 
 ```ts
 // src/types.ts
@@ -555,7 +531,7 @@ interface Module {
 }
 ```
 
-### Client Functions
+### Client functions
 
 ```ts
 // src/types.ts
@@ -580,9 +556,9 @@ const module = await rpc.call('my-plugin:get-module', '/src/main.ts')
 const data = await rpc.call('my-plugin:unknown')
 ```
 
-## Complete Example
+## Complete example
 
-Here's a complete example with both server and client RPC functions:
+A plugin with both server and client RPC functions:
 
 ::: code-group
 

--- a/docs/kit/shared-state.md
+++ b/docs/kit/shared-state.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Shared State
 
-DevTools Kit provides a built-in shared state system for synchronizing data between server and clients. Changes made on either side are automatically propagated to all connected parties.
+DevTools Kit's shared-state system synchronizes data between server and clients. Changes on either side propagate to every connected party.
 
 ## Overview
 
@@ -26,11 +26,11 @@ flowchart LR
   S_Mutate <-->|RPC sync| B_Value
 ```
 
-## Server-Side Usage
+## Server-side usage
 
-### Creating Shared State
+### Creating shared state
 
-Use `ctx.rpc.sharedState.get()` to create or access shared state:
+`ctx.rpc.sharedState.get()` creates or returns shared state:
 
 ```ts
 const plugin: Plugin = {
@@ -52,7 +52,7 @@ const plugin: Plugin = {
 }
 ```
 
-### Reading State
+### Reading state
 
 ```ts
 const state = await ctx.rpc.sharedState.get('my-plugin:state', {
@@ -64,9 +64,9 @@ const current = state.value()
 console.log(current.count) // 0
 ```
 
-### Mutating State
+### Mutating state
 
-Use `state.mutate()` to update the state. Changes are automatically synced to all clients:
+`state.mutate()` updates the state and syncs the change to every connected client:
 
 ```ts
 // Mutate with a function (recommended)
@@ -74,12 +74,11 @@ state.mutate((draft) => {
   draft.count += 1
   draft.items.push({ id: 1, name: 'New item' })
 })
-
-// The mutation function receives a mutable draft
-// Changes are batched and synced automatically
 ```
 
-### Example: Real-Time Updates
+The mutation function receives a mutable draft; changes are batched and synced automatically.
+
+### Example: real-time updates
 
 ```ts
 const plugin: Plugin = {
@@ -101,11 +100,11 @@ const plugin: Plugin = {
 }
 ```
 
-## Client-Side Usage
+## Client-side usage
 
-### Accessing Shared State
+### Accessing shared state
 
-Use `client.sharedState.get()` to access the shared state:
+`client.sharedState.get()` returns the shared state from the client:
 
 ```ts
 import { getDevToolsRpcClient } from '@vitejs/devtools-kit/client'
@@ -118,7 +117,7 @@ const state = await client.sharedState.get('my-plugin:state')
 console.log(state.value())
 ```
 
-You can also access shared state through the global client context:
+The global client context exposes shared state too:
 
 ```ts
 import { getDevToolsClientContext } from '@vitejs/devtools-kit/client'
@@ -129,9 +128,9 @@ if (ctx) {
 }
 ```
 
-### Subscribing to Changes
+### Subscribing to changes
 
-Use `state.on('updated', ...)` to react to state changes:
+`state.on('updated', ...)` reacts to state changes:
 
 ```ts
 const state = await client.sharedState.get('my-plugin:state')
@@ -146,11 +145,11 @@ state.on('updated', (newState) => {
 })
 ```
 
-## Framework Integration
+## Framework integration
 
 ### Vue
 
-Create a reactive ref that syncs with shared state:
+A reactive ref that syncs with shared state:
 
 ```ts
 import { getDevToolsRpcClient } from '@vitejs/devtools-kit/client'
@@ -174,7 +173,7 @@ const state = await useSharedState('my-plugin:state')
 // `state` is now reactive and auto-updates
 ```
 
-### Vue Composable (Full Example)
+### Vue composable (full example)
 
 ```vue
 <script setup lang="ts">
@@ -291,7 +290,7 @@ function MyComponent() {
 <p>Count: {$state.count}</p>
 ```
 
-## Type Safety
+## Type safety
 
 Extend `DevToolsRpcSharedStates` for type-safe shared state:
 
@@ -338,59 +337,59 @@ state.mutate((draft) => {
 })
 ```
 
-## Best Practices
+## Best practices
 
-### Use Namespaced Keys
+### Namespaced keys
 
 Prefix state keys with your plugin name to avoid collisions:
 
 ```ts
-// Good
+// ✓ Good
 'my-plugin:state'
 'my-plugin:settings'
 
-// Bad - may conflict with other plugins
+// ✗ Bad — may conflict with other plugins
 'state'
 'settings'
 ```
 
-### Keep State Serializable
+### Keep state serializable
 
-Shared state must be JSON-serializable. Avoid:
+Shared state travels over JSON. Stick to plain data — no functions, no circular references:
 
 <!-- eslint-skip -->
 
 ```ts
-// ✗ Bad - functions can't be serialized
+// ✗ Bad — functions don't serialize
 {
   count: 0,
   increment: () => this.count++
 }
 
-// ✗ Bad - circular references
+// ✗ Bad — circular references
 const obj = { child: null }
 obj.child = obj
 
-// ✓ Good - plain data
+// ✓ Good — plain data
 {
   count: 0,
   items: [{ id: 1, name: 'Item' }]
 }
 ```
 
-### Batch Updates
+### Batch updates
 
-When making multiple changes, use a single `mutate` call:
+Group multiple changes into a single `mutate` call to broadcast one sync event:
 
 ```ts
-// ✓ Good - single sync event
+// ✓ Good — single sync event
 state.mutate((draft) => {
   draft.count += 1
   draft.lastUpdate = Date.now()
   draft.items.push(newItem)
 })
 
-// ✗ Bad - multiple sync events
+// ✗ Bad — three sync events
 state.mutate((d) => {
   d.count += 1
 })
@@ -402,24 +401,18 @@ state.mutate((d) => {
 })
 ```
 
-### Consider State Size
+### Mind state size
 
-Large state objects may impact performance. For large datasets, consider:
+Large state objects can drag on sync performance. For large datasets, keep IDs in shared state and fetch the full records via RPC on demand:
 
 <!-- eslint-skip -->
 
 ```ts
-// Instead of storing all data in shared state
-{
-  allModules: [...thousands of modules...]
-}
-
-// Store just IDs and fetch details via RPC
+// ✓ Store just IDs and fetch details via RPC
 {
   moduleIds: ['a', 'b', 'c'],
   selectedModule: 'a'
 }
 
-// Use RPC to fetch full module data
 const module = await rpc.call('my-plugin:get-module', state.selectedModule)
 ```

--- a/docs/kit/streaming.md
+++ b/docs/kit/streaming.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Streaming
 
-DevTools Kit ships a first-class streaming-channel API for chunk-style data flowing in either direction between server and client — chat deltas, log lines, build progress, file uploads, mic / screen-share frames. It's the same primitive as DevFrame's [streaming guide](/devframe/guide/streaming), surfaced through the Kit's Vite plugin idioms.
+DevTools Kit ships a streaming-channel API for chunk-style data flowing in either direction between server and client — chat deltas, log lines, build progress, file uploads, mic / screen-share frames.
 
 Reach for streaming when you need:
 
@@ -13,7 +13,7 @@ Reach for streaming when you need:
 - Replay on reconnect — a panel reopened mid-stream picks up where it left off.
 - Client-to-server uploads without inventing a multipart protocol.
 
-For *snapshot* state that survives reconnect and syncs across panels, prefer [shared state](./shared-state) instead.
+For *snapshot* state that survives reconnect and syncs across panels, use [shared state](./shared-state) instead.
 
 ## Overview
 
@@ -32,11 +32,11 @@ sequenceDiagram
 
 A **channel** owns a wire namespace. Each call to `channel.start()` produces an individual **stream** keyed by an id (auto-generated unless you pass one). Subscribers join by `(channelName, id)`.
 
-## Server-to-Client (the common case)
+## Server-to-client (the common case)
 
-### Defining a Channel
+### Defining a channel
 
-In your `devtools.setup`, create the channel once. Channels are framework-neutral, so the same code works whether you ship via `@vitejs/devtools-kit` (Vite) or DevFrame's other adapters:
+Create the channel once in `devtools.setup`:
 
 ```ts
 /// <reference types="@vitejs/devtools-kit" />
@@ -78,9 +78,9 @@ export default function chatPlugin(): Plugin {
 }
 ```
 
-The channel name follows the same `<plugin-id>:<name>` convention as RPC functions and shared-state keys.
+Channel names follow the `<plugin-id>:<name>` convention used by RPC functions and shared-state keys.
 
-### Producing — Three Surfaces, One Stream
+### Producing — three surfaces, one stream
 
 The handle returned by `channel.start({ id? })` is both an imperative producer and a Web Streams `WritableStream<T>`:
 
@@ -112,9 +112,9 @@ for (const token of source) {
 stream.close()
 ```
 
-#### Node.js Stream Interop
+#### Node.js stream interop
 
-Web Streams are the canonical surface, but Node 17+ ships free converters that bridge to `node:stream`:
+Web Streams are the canonical surface. Node 17+ ships standard-library converters for bridging to `node:stream`:
 
 ```ts
 import { Readable, Writable } from 'node:stream'
@@ -125,8 +125,6 @@ sourceNodeReadable.pipe(Writable.fromWeb(stream.writable))
 // Pipe the channel out to a Node Writable
 Readable.fromWeb(reader.readable).pipe(targetNodeWritable)
 ```
-
-DevTools Kit doesn't wrap these — they're standard library, and the surface stays small.
 
 ### Consuming — `for await` or `pipeTo`
 
@@ -152,11 +150,11 @@ await reader.readable.pipeTo(downloadWritable)
 reader.cancel() // sends cancel upstream; server stream.signal flips
 ```
 
-Pick one surface per reader — they share a single internal queue, so concurrent draining will race.
+Use one surface per reader — they share a single internal queue, so concurrent draining races.
 
-## Client-to-Server Uploads
+## Client-to-server uploads
 
-The same channel works in reverse for chunk-style uploads — file content, mic / screen-share frames, browser-side logs forwarded to disk, anything you'd otherwise hand-roll as `multipart` over HTTP. The pattern uses one normal RPC call to allocate the id, then dedicated streaming events for the chunks:
+The same channel works in reverse for chunk-style uploads — file content, mic / screen-share frames, browser-side logs forwarded to disk, anything that would otherwise need a hand-rolled multipart-over-HTTP. The pattern: one regular RPC call allocates the id, then dedicated streaming events carry the chunks.
 
 ```ts
 // Server — typically inside an action handler
@@ -204,9 +202,9 @@ Lifecycle mirrors the outbound case:
 - `upload.error(err)` propagates as a thrown error inside the server's `for await`.
 - If the client disconnects mid-upload, the server's `for await` exits with an `UploadDisconnected` error so consumers can clean up.
 
-Each `openInbound()` allocates a fresh server-allocated id and is owned by exactly one uploading session — there's no fan-in, no shared subscribers, and no replay (the producer is the client, so reconnect means restart).
+Each `openInbound()` allocates a fresh server-side id owned by exactly one uploading session. Uploads are point-to-point: one producer, no fan-in, no shared subscribers, no replay (reconnect means the client restarts).
 
-## Lifecycle and Cancellation
+## Lifecycle and cancellation
 
 | Event | Server side | Client side |
 |-------|-------------|-------------|
@@ -215,11 +213,11 @@ Each `openInbound()` allocates a fresh server-allocated id and is owned by exact
 | WS disconnects | When the **last** subscriber drops, server aborts `stream.signal` | Reader stays alive; resubscribes automatically when trust is re-established |
 | Panel closes mid-stream | Reader cancel cascades upstream | — |
 
-A stream with multiple subscribers stays alive until the last one cancels or disconnects. Producers should always make `stream.signal.aborted` part of their inner loop.
+A stream with multiple subscribers stays alive until the last one cancels or disconnects. Producers should make `stream.signal.aborted` part of their inner loop.
 
-## Replay on Reconnect
+## Replay on reconnect
 
-When the channel is created with `replayWindow: N`, the server keeps a rolling buffer of the last `N` chunks per stream. On (re)subscribe, the client passes the highest sequence number it has seen, and the server replays anything newer before resuming live.
+With `replayWindow: N`, the server keeps a rolling buffer of the last `N` chunks per stream. On (re)subscribe, the client passes the highest sequence number it has seen, and the server replays anything newer before resuming live.
 
 ```ts
 ctx.rpc.streaming.create<string>('my-plugin:chat', {
@@ -228,11 +226,11 @@ ctx.rpc.streaming.create<string>('my-plugin:chat', {
 })
 ```
 
-`closedStreamRetention` defaults to 30 seconds when `replayWindow > 0` (so a panel re-opened a few seconds after a chat finishes still gets the full transcript), or 0 when replay is disabled. Set it explicitly to opt in or out.
+`closedStreamRetention` defaults to 30 seconds when `replayWindow > 0` (so a panel re-opened seconds after a chat finishes still gets the full transcript). Set it explicitly to tune retention.
 
 ## Backpressure
 
-The client maintains a bounded queue per subscription (`highWaterMark`, default 256). When the consumer can't keep up, the **oldest** queued chunk is dropped and a [`DF0029`](/devframe/errors/DF0029) warning is logged. This is best-effort — proper transport-level backpressure isn't worth threading through the RPC layer for the streaming use cases that exist today.
+The client maintains a bounded queue per subscription (`highWaterMark`, default 256). When the consumer falls behind, the oldest queued chunk drops and a [`DF0029`](/devframe/errors/DF0029) warning is logged. This is best-effort — sufficient for current streaming use cases without threading transport-level backpressure through the RPC layer.
 
 ```ts
 const reader = rpc.streaming.subscribe('my-plugin:chat', id, {
@@ -240,9 +238,9 @@ const reader = rpc.streaming.subscribe('my-plugin:chat', id, {
 })
 ```
 
-If you need authoritative state rather than every intermediate value, prefer [shared state](./shared-state) — it carries Immer patches with delivery guarantees, at the cost of being structured rather than streaming.
+When you need authoritative state rather than every intermediate value, [shared state](./shared-state) carries Immer patches with delivery guarantees — structured rather than streaming.
 
-## Combining Streaming with Shared State
+## Combining streaming with shared state
 
 Token-level streaming and shared-state snapshots compose naturally for chat-style UIs:
 
@@ -308,7 +306,7 @@ ctx.rpc.register(defineRpcFunction({
 
 A working version of this pattern lives in [`devframe/examples/devframe-streaming-chat`](https://github.com/vitejs/devtools/tree/main/devframe/examples/devframe-streaming-chat).
 
-## When to Use Streaming vs Events vs Shared State
+## When to use streaming vs events vs shared state
 
 | Use streaming for | Use `event`-typed RPC for | Use shared state for |
 |-------------------|---------------------------|----------------------|
@@ -319,6 +317,4 @@ A working version of this pattern lives in [`devframe/examples/devframe-streamin
 
 ## Reference
 
-- API surface: `RpcStreamingHost`, `RpcStreamingChannel<T>`, `StreamSink<T>`, `StreamReader<T>` — re-exported from `@vitejs/devtools-kit`.
-- Working example: [`devframe/examples/devframe-streaming-chat`](https://github.com/vitejs/devtools/tree/main/devframe/examples/devframe-streaming-chat).
-- Errors: [`DF0029`](/devframe/errors/DF0029) (overflow), [`DF0030`](/devframe/errors/DF0030) (unknown stream id), [`DF0031`](/devframe/errors/DF0031) (write to closed stream), [`DF0032`](/devframe/errors/DF0032) (channel name collision).
+The API surface — `RpcStreamingHost`, `RpcStreamingChannel<T>`, `StreamSink<T>`, `StreamReader<T>` — is re-exported from `@vitejs/devtools-kit`. Streaming is built on the same primitive as DevFrame's [streaming guide](/devframe/guide/streaming); error codes for backpressure and lifecycle live there: [`DF0029`](/devframe/errors/DF0029), [`DF0030`](/devframe/errors/DF0030), [`DF0031`](/devframe/errors/DF0031), [`DF0032`](/devframe/errors/DF0032).

--- a/docs/kit/terminals.md
+++ b/docs/kit/terminals.md
@@ -4,9 +4,9 @@ outline: deep
 
 # Terminals & Subprocesses
 
-DevTools Kit includes a built-in terminal host that lets your plugin spawn and manage child processes. Output is streamed in real-time to an xterm.js UI inside DevTools.
+DevTools Kit's terminal host lets a plugin spawn and manage child processes. Output streams in real time to an xterm.js panel inside DevTools.
 
-## Starting a Child Process
+## Starting a child process
 
 The primary API is `ctx.terminals.startChildProcess()`:
 
@@ -39,7 +39,7 @@ interface DevToolsChildProcessExecuteOptions {
 
 The second argument provides terminal metadata (id, title, and optional description/icon).
 
-### Returned Session
+### Returned session
 
 `startChildProcess()` returns a `DevToolsChildProcessTerminalSession` with lifecycle controls:
 
@@ -54,12 +54,11 @@ await session.restart()
 const cp = session.getChildProcess()
 ```
 
-> [!NOTE]
-> Color output is enabled automatically — `FORCE_COLOR` and `COLORS` environment variables are set to `'true'` by default.
+The spawned process gets `FORCE_COLOR=true` and `COLORS=true` so terminal output stays coloured by default.
 
-## Combining with Launcher Docks
+## Combining with launcher docks
 
-A common pattern is pairing a [launcher dock entry](/kit/dock-system#launcher-entries) with a terminal session. The launcher gives the user a button to start the process on demand:
+Pair a [launcher dock entry](/kit/dock-system#launcher-entries) with a terminal session for a one-button start:
 
 ```ts
 ctx.docks.register({
@@ -87,9 +86,9 @@ ctx.docks.register({
 })
 ```
 
-## Custom Terminal Sessions
+## Custom terminal sessions
 
-For scenarios that don't involve spawning a child process (e.g. streaming logs from an external source), you can register a session directly with a custom `ReadableStream`:
+To stream from any source — external logs, custom protocols, anything yielding strings — register a session with a `ReadableStream`:
 
 ```ts
 let controller: ReadableStreamDefaultController<string>
@@ -111,7 +110,7 @@ ctx.terminals.register({
 controller.enqueue('Hello from custom stream!\n')
 ```
 
-## Session Lifecycle
+## Session lifecycle
 
 Each terminal session has a `status` field:
 
@@ -141,7 +140,7 @@ ctx.terminals.events.on('terminal:session:updated', (session) => {
 })
 ```
 
-Output chunks aren't delivered as host events — terminals stream via the [streaming channel](/kit/streaming) `devframe:terminals`, keyed by session id. From the browser:
+Output chunks travel through the [streaming channel](/kit/streaming) `devframe:terminals`, keyed by session id. The kit's `DevToolsTerminalHost` already pipes each session's `ReadableStream<string>` into the channel; this matters only when building a custom terminal renderer:
 
 ```ts
 const reader = rpc.streaming.subscribe<string>(
@@ -151,8 +150,6 @@ const reader = rpc.streaming.subscribe<string>(
 for await (const chunk of reader) writeToTerminal(chunk)
 ```
 
-A server-side bridge inside the kit's `DevToolsTerminalHost` pipes each session's `ReadableStream<string>` straight into the channel — you don't need to wire anything yourself unless you're building a custom terminal renderer.
-
 ## Inspection
 
 ```ts
@@ -161,4 +158,4 @@ for (const session of ctx.terminals.sessions.values()) {
 }
 ```
 
-`ctx.terminals.sessions` is a live `Map<string, DevToolsTerminalSession>` — handy for diagnostics, testing, and for building custom terminal UIs that mirror the built-in panel.
+`ctx.terminals.sessions` is a live `Map<string, DevToolsTerminalSession>` — useful for diagnostics, testing, and custom terminal UIs that mirror the built-in panel.

--- a/docs/kit/when-clauses.md
+++ b/docs/kit/when-clauses.md
@@ -4,13 +4,13 @@ outline: deep
 
 # When Clauses
 
-When clauses are conditional expressions that control visibility and activation of commands and dock entries. They use a simple expression language — the same one used by [VS Code's when-clause contexts](https://code.visualstudio.com/api/references/when-clause-contexts) — evaluated against a reactive context object.
+When clauses are conditional expressions that control visibility and activation of commands and dock entries. The expression language matches [VS Code's when-clause contexts](https://code.visualstudio.com/api/references/when-clause-contexts), evaluated against a reactive context object.
 
-The evaluator is powered by [`whenexpr`](https://github.com/antfu/whenexpr), which also provides the `WhenExpression<Ctx, S>` type helper used by `defineCommand` / `defineDockEntry` for compile-time validation (see [Type-safe `when` clauses](#type-safe-when-clauses)).
+The evaluator is [`whenexpr`](https://github.com/antfu/whenexpr), which also provides the `WhenExpression<Ctx, S>` type helper used by `defineCommand` / `defineDockEntry` for compile-time validation — see [Type-safe `when` clauses](#type-safe-when-clauses).
 
 ## Usage
 
-### On Commands
+### On commands
 
 Controls whether the command appears in the palette and whether it can be triggered via shortcuts:
 
@@ -23,7 +23,7 @@ ctx.commands.register(defineCommand({
 }))
 ```
 
-### On Dock Entries
+### On dock entries
 
 Controls whether a dock entry is visible in the dock bar:
 
@@ -38,9 +38,9 @@ ctx.docks.register(defineDockEntry({
 }))
 ```
 
-Set `when: 'false'` to unconditionally hide a dock entry.
+`when: 'false'` hides a dock entry unconditionally.
 
-## Expression Syntax
+## Expression syntax
 
 ### Operators
 
@@ -93,7 +93,7 @@ when: '(clientType == embedded && dockOpen) || clientType == standalone'
 when: 'vite.mode == development'
 ```
 
-## Built-in Context Variables
+## Built-in context variables
 
 | Variable | Type | Description |
 |----------|------|-------------|
@@ -102,9 +102,9 @@ when: 'vite.mode == development'
 | `paletteOpen` | `boolean` | Whether the command palette is currently open |
 | `dockSelectedId` | `string` | ID of the currently selected dock entry. Empty string `''` (falsy) when no dock is selected. |
 
-## Namespaced Context Keys
+## Namespaced context keys
 
-Plugins can register context variables using namespaced keys with `.` or `:` separators to avoid collisions:
+Plugins register context variables under namespaced keys (`.` or `:` separators) to avoid collisions. Use your plugin id as the prefix — `my-plugin.featureEnabled`, `rolldown:buildStep`.
 
 ```ts
 // Flat key (recommended)
@@ -123,22 +123,18 @@ when: 'vite:buildMode == lib'
 when: 'vite.ssr'
 ```
 
-### Lookup Order
+### Lookup order
 
 When resolving a namespaced key like `vite.mode`:
 
-1. **Exact match** — looks for `ctx['vite.mode']` first
-2. **Nested path** — falls back to `ctx.vite?.mode`
+1. **Exact match** — `ctx['vite.mode']` is checked first.
+2. **Nested path** — `ctx.vite?.mode` is the fallback.
 
-Flat keys take priority over nested objects if both exist.
-
-::: tip Naming Convention
-Use your plugin name as a namespace prefix: `my-plugin.featureEnabled`, `rolldown:buildStep`, etc. This prevents collisions between unrelated plugins.
-:::
+Flat keys take priority over nested objects when both exist.
 
 ## Type-safe `when` clauses
 
-`defineCommand` and `defineDockEntry` capture the `when:` string as a TypeScript literal and validate it against `WhenContext` through [`whenexpr`](https://github.com/antfu/whenexpr)'s `WhenExpression<Ctx, S>` helper. Syntax errors surface as compile-time errors at the call site — no runtime check needed.
+`defineCommand` and `defineDockEntry` capture the `when:` string as a TypeScript literal and validate it against `WhenContext` through [`whenexpr`](https://github.com/antfu/whenexpr)'s `WhenExpression<Ctx, S>` helper. Syntax errors surface as compile-time errors at the call site.
 
 ```ts
 import { defineCommand } from '@vitejs/devtools-kit'
@@ -161,9 +157,7 @@ defineCommand({
 
 ### Key validation with plugin-specific contexts
 
-The default `WhenContext` uses `[key: string]: unknown` so that plugins can add any namespaced key. A consequence is that the type checker only validates **syntax** — it cannot flag a typo like `'dockOpn == embedded'`.
-
-If you want key validation for your own plugin, define a narrower context shape and build a plugin-specific `define*` wrapper:
+The default `WhenContext` uses `[key: string]: unknown` to keep namespaced plugin keys open-ended; that means built-in syntax validation alone won't catch typos like `'dockOpn == embedded'`. For key-name validation in your plugin, define a narrower context shape and build a plugin-specific `define*` wrapper:
 
 ```ts
 import type { WhenContext, WhenExpression } from '@vitejs/devtools-kit'
@@ -201,7 +195,7 @@ defineMyCommand({
 })
 ```
 
-## API Reference
+## API reference
 
 The when-clause evaluator is provided by `devframe`:
 
@@ -226,7 +220,7 @@ resolveContextValue('dockOpen', ctx) // true
 
 ### `evaluateWhen(expression, ctx, options?)`
 
-Evaluates a when-clause expression string against a context object. Returns `boolean`. Pass `{ strict: true }` in `options` to throw when an unknown context key is encountered (useful for catching typos during development).
+Evaluates a when-clause expression string against a context object. Returns `boolean`. Pass `{ strict: true }` to throw on unknown context keys — useful for catching typos during development.
 
 ### `resolveContextValue(key, ctx)`
 

--- a/docs/rolldown/index.md
+++ b/docs/rolldown/index.md
@@ -4,24 +4,20 @@ outline: deep
 
 # DevTools for Rolldown
 
-DevTools for Rolldown (`@vitejs/devtools-rolldown`) is a built-in integration that provides comprehensive build analysis for Vite projects using Rolldown. It comes included with Vite DevTools out of the box.
+DevTools for Rolldown (`@vitejs/devtools-rolldown`) is a built-in integration that analyses Rolldown production builds in Vite 8+. It ships with Vite DevTools.
 
-> [!WARNING]
-> DevTools for Rolldown currently only supports build mode of Vite 8+.
-> Dev mode and Vite versions under 8 are not supported yet.
+## What it does
 
-## What It Does
+Insights into a Rolldown-powered build:
 
-DevTools for Rolldown gives you deep insights into your Rolldown-powered build process:
+- **Module analysis** — visualise module graphs, dependencies, and transformation flows.
+- **Plugin insights** — inspect plugin hook costs and processed modules.
+- **Chunk & asset analysis** — explore build output through list, graph, treemap, and flamegraph views.
+- **Package detection** — surface duplicated packages and dependency sizes.
+- **Session compare** — diff bundle changes across builds.
 
-- **Module Analysis** — Visualize module graphs, dependencies, and transformation flows
-- **Plugin Insights** — Inspect plugin hook costs and processed modules
-- **Chunk & Asset Analysis** — Explore build output with list, graph, treemap, and flamegraph views
-- **Package Detection** — Detect duplicated packages and analyze dependency sizes
-- **Session Compare** — Compare bundle changes across builds
+See [Features](/rolldown/features) for a detailed walkthrough with screenshots.
 
-See the [Features](/rolldown/features) page for a detailed walkthrough with screenshots.
+## Getting started
 
-## Getting Started
-
-DevTools for Rolldown is automatically available when you set up Vite DevTools. Follow the [Getting Started](/guide/) guide to install and configure Vite DevTools, then the Rolldown build analysis panels will appear in the dock.
+DevTools for Rolldown is enabled automatically once Vite DevTools is set up. Follow [Getting Started](/guide/) to install and configure Vite DevTools, then run a build — the Rolldown panels appear in the dock.


### PR DESCRIPTION
### Description

Sweeping editorial pass over `docs/` and `devframe/docs/` (29 files; -808/+690 lines):

- **Positive framing.** Drop "X is for Y, not Z" constructions and roadmap phrases ("not yet implemented", "dev mode planned") in favour of present-tense scope.
- **Sparing callouts.** Reserve `[!WARNING]` for genuinely critical material — kept on experimental APIs, added one to remote-client URL token leakage. Folded `[!NOTE]` / `[!TIP]` content into prose.
- **Kit-first in `/docs/`.** Lead examples with the Vite-plugin / Kit path; treat DevFrame as the underlying foundation referenced where relevant.
- **Concise and precise.** Tightened intros, trimmed redundant cross-links, shortened section headings.

`AGENTS.md` records the four guidelines so future doc edits follow the same conventions.

### Linked Issues

None.

### Additional context

`pnpm -C devframe/docs run docs:build` passes cleanly. The main `pnpm -C docs run docs:build` fails on a pre-existing config issue (the import in `docs/.vitepress/config.ts` references `devframe/docs/.vitepress/sidebar`, which was removed in #316; the corresponding fix was inadvertently reverted in #317). Out of scope for this PR — flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)