### PR TITLE
docs(devframe): add netlify config, enrich landing page, clean up READMEs

### DIFF
--- a/devframe/README.md
+++ b/devframe/README.md
@@ -1,17 +1,8 @@
 # Devframe
 
-Framework-neutral foundation for building generic DevTools — an RPC layer (birpc + valibot + WS presets), runtime hosts (RPC / docks / views / terminals / logs / commands / agent), and adapters that deploy a single devtool definition to seven targets: `cli`, `build`, `vite`, `kit`, `embedded`, `mcp`, plus the `spa` mode.
+Framework-neutral foundation for building generic DevTools. Describe one devtool — its RPC, its data, its SPA, its CLI shape — and deploy the same definition through any of seven adapters.
 
-## Layout
-
-This directory is staged for extraction into a standalone repository. Until then it lives inside the [`vitejs/devtools`](https://github.com/vitejs/devtools) monorepo.
-
-| Path | Description |
-|------|-------------|
-| [`packages/devframe`](./packages/devframe) | The published [`devframe`](https://www.npmjs.com/package/devframe) npm package. |
-| [`docs`](./docs) | VitePress documentation site, deployed at https://devfra.me/. |
-| [`examples`](./examples) | End-to-end demos: [`devframe-counter`](./examples/devframe-counter) (smallest cross-adapter demo) and [`devframe-files-inspector`](./examples/devframe-files-inspector) (CLI dev/build/spa + Vite DevTools dock). |
-| [`tests`](./tests) | Public-API snapshot tests via [`tsnapi`](https://github.com/posva/tsnapi). |
+Documentation: [https://devfra.me/](https://devfra.me/).
 
 ## Install
 
@@ -19,9 +10,29 @@ This directory is staged for extraction into a standalone repository. Until then
 pnpm add devframe
 ```
 
-## Documentation
+## Hello, Devframe
 
-See [https://devfra.me/](https://devfra.me/) for the full guide and API reference.
+```ts
+import { defineDevtool, defineRpcFunction } from 'devframe'
+import { createCli } from 'devframe/adapters/cli'
+
+const devtool = defineDevtool({
+  id: 'my-devtool',
+  name: 'My Devtool',
+  setup(ctx) {
+    ctx.rpc.register(defineRpcFunction({
+      name: 'my-devtool:hello',
+      type: 'static',
+      jsonSerializable: true,
+      handler: () => ({ message: 'hello' }),
+    }))
+  },
+})
+
+await createCli(devtool).parse()
+```
+
+Drop the same definition into Vite DevTools via `createPluginFromDevframe` from `@vitejs/devtools-kit`. The dock entry is auto-derived from the definition.
 
 ## Adapters
 
@@ -30,9 +41,20 @@ See [https://devfra.me/](https://devfra.me/) for the full guide and API referenc
 | `cli` | Standalone CLI tool with `dev` / `build` / `mcp` subcommands. |
 | `build` | Generates a static, self-contained SPA snapshot. |
 | `vite` | Runs as a Vite plugin alongside the host app's dev server. |
-| `kit` | Plugs into the DevTools Kit aggregator. |
-| `embedded` | Mounts as an overlay inside another devtool's UI. |
-| `mcp` | Exposes the devtool's RPC surface to coding agents over MCP. |
+| `kit` | Mounts into the DevTools Kit aggregator. |
+| `embedded` | Overlays inside another devtool's UI. |
+| `mcp` | Surfaces the devtool's RPC to coding agents over MCP. |
+
+## Repo layout
+
+This directory is staged for extraction into a standalone repository. Until then it lives inside the [`vitejs/devtools`](https://github.com/vitejs/devtools) monorepo.
+
+| Path | Description |
+|------|-------------|
+| [`packages/devframe`](./packages/devframe) | The published [`devframe`](https://www.npmjs.com/package/devframe) npm package. |
+| [`docs`](./docs) | VitePress documentation site, deployed at https://devfra.me/. |
+| [`examples`](./examples) | End-to-end demos: [`devframe-counter`](./examples/devframe-counter) (smallest cross-adapter demo), [`devframe-files-inspector`](./examples/devframe-files-inspector) (CLI dev/build/spa + Vite DevTools dock), and [`devframe-streaming-chat`](./examples/devframe-streaming-chat) (streaming channels demo). |
+| [`tests`](./tests) | Public-API snapshot tests via [`tsnapi`](https://github.com/posva/tsnapi). |
 
 ## License
 

--- a/devframe/docs/index.md
+++ b/devframe/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Devframe
   text: Framework-neutral foundation for DevTools
-  tagline: One devtool definition. Seven adapters. RPC, hosts, shared state, agent-native — without depending on Vite or any framework.
+  tagline: One devtool definition. Seven adapters. RPC, hosts, shared state, and agent-native — independent of Vite and any UI framework.
   actions:
     - theme: brand
       text: Get Started
@@ -14,16 +14,28 @@ hero:
       link: https://github.com/vitejs/devtools
 
 features:
-  - title: One Definition, Many Deployments
+  - icon: 🧱
+    title: One Definition, Many Deployments
     details: A single `defineDevtool` call deploys to CLI, static build, SPA, Vite plugin, embedded overlay, kit host, or MCP server.
     link: /guide/devtool-definition
-  - title: Type-safe RPC
+  - icon: 🔌
+    title: Type-safe RPC
     details: Bidirectional, schema-validated calls built on birpc + valibot. Query, static, action, and event function types.
     link: /guide/rpc
-  - title: Headless by Default
-    details: No banners, no logging, no opinionated styling. Hooks let your app own the UX while Devframe owns the plumbing.
+  - icon: 🔄
+    title: Shared State
+    details: Observable, patch-synced state that survives reconnects and bridges server and browser with structured updates.
+    link: /guide/shared-state
+  - icon: 🌊
+    title: Streaming Channels
+    details: One-way RPC streams and two-way upload channels for long-running data, progress reporting, and live feeds.
+    link: /guide/streaming
+  - icon: 🎨
+    title: Bring Your Own UX
+    details: Hooks like `onReady` and `cli.configure` let your app own banners, logging, and styling while Devframe owns the plumbing.
     link: /guide/
-  - title: Agent-Native (experimental)
-    details: Surface your devtool's RPC functions, tools, and resources to coding agents over MCP with a single field.
+  - icon: 🤖
+    title: Agent-Native (experimental)
+    details: Surface RPC functions, tools, and resources to coding agents over MCP with a single `agent` field on each function.
     link: /guide/agent-native
 ---

--- a/devframe/netlify.toml
+++ b/devframe/netlify.toml
@@ -1,9 +1,7 @@
 [build]
 publish = "devframe/docs/.vitepress/dist"
 command = "pnpm -C devframe/docs run docs:build"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ./devframe ./pnpm-lock.yaml ./pnpm-workspace.yaml"
 
 [build.environment]
 NODE_VERSION = "24"
-
-[build.ignore]
-command = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ./devframe ./pnpm-lock.yaml ./pnpm-workspace.yaml"

--- a/devframe/netlify.toml
+++ b/devframe/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+publish = "devframe/docs/.vitepress/dist"
+command = "pnpm -C devframe/docs run docs:build"
+
+[build.environment]
+NODE_VERSION = "24"
+
+[build.ignore]
+command = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ./devframe ./pnpm-lock.yaml ./pnpm-workspace.yaml"

--- a/devframe/netlify.toml
+++ b/devframe/netlify.toml
@@ -1,7 +1,6 @@
 [build]
-publish = "devframe/docs/.vitepress/dist"
-command = "pnpm -C devframe/docs run docs:build"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ./devframe ./pnpm-lock.yaml ./pnpm-workspace.yaml"
+publish = "docs/.vitepress/dist"
+command = "pnpm -C docs run docs:build"
 
 [build.environment]
 NODE_VERSION = "24"

--- a/devframe/packages/devframe/README.md
+++ b/devframe/packages/devframe/README.md
@@ -1,6 +1,8 @@
 # devframe
 
-Framework-neutral foundation for building generic DevTools — RPC layer (birpc + valibot + WS presets), six hosts (RPC / docks / views / terminals / logs / commands / agent), and adapters under `devframe/adapters/*` (cli / build / spa / vite / kit / embedded / mcp). Part of the [Vite DevTools](https://devtools.vite.dev) monorepo.
+Framework-neutral foundation for building generic DevTools. Describe one devtool — its RPC, its data, its SPA, its CLI shape — and deploy the same definition through any of seven adapters.
+
+Part of the [Vite DevTools](https://devtools.vite.dev) monorepo. Full documentation: [https://devfra.me/](https://devfra.me/).
 
 ## Install
 
@@ -8,15 +10,45 @@ Framework-neutral foundation for building generic DevTools — RPC layer (birpc 
 pnpm add devframe
 ```
 
-## Docs
+## Hello, Devframe
 
-See the [Devframe documentation](https://devfra.me/) for the full guide and API reference.
+```ts
+import { defineDevtool, defineRpcFunction } from 'devframe'
+import { createCli } from 'devframe/adapters/cli'
+
+const devtool = defineDevtool({
+  id: 'my-devtool',
+  name: 'My Devtool',
+  setup(ctx) {
+    ctx.rpc.register(defineRpcFunction({
+      name: 'my-devtool:hello',
+      type: 'static',
+      jsonSerializable: true,
+      handler: () => ({ message: 'hello' }),
+    }))
+  },
+})
+
+await createCli(devtool).parse()
+```
+
+## Adapters
+
+| Adapter | Use case |
+|---------|----------|
+| `cli` | Standalone CLI tool with `dev` / `build` / `mcp` subcommands. |
+| `build` | Generates a static, self-contained SPA snapshot. |
+| `vite` | Runs as a Vite plugin alongside the host app's dev server. |
+| `kit` | Mounts into the DevTools Kit aggregator. |
+| `embedded` | Overlays inside another devtool's UI. |
+| `mcp` | Surfaces the devtool's RPC to coding agents over MCP. |
 
 ## Agent-Native (experimental)
 
-> ⚠️ **Experimental.** The agent-native surface — the `agent` field on `defineRpcFunction`, `DevToolsAgentHost`, and the `devframe/adapters/mcp` adapter — is experimental and may change without a major version bump until it stabilizes.
+> [!WARNING]
+> The agent-native surface — the `agent` field on `defineRpcFunction`, `DevToolsAgentHost`, and the `devframe/adapters/mcp` adapter — may change without a major version bump until it stabilizes.
 
-Devframe can expose a devtool's RPC functions, tools, and resources to coding agents over [MCP](https://modelcontextprotocol.io). Flag an RPC function with `agent: { description }` to surface it, then spin up an MCP server:
+Devframe surfaces a devtool's RPC functions, tools, and resources to coding agents over [MCP](https://modelcontextprotocol.io). Flag an RPC function with `agent: { description }` to expose it, then spin up an MCP server:
 
 ```ts
 import { defineDevtool, defineRpcFunction } from 'devframe'
@@ -35,7 +67,6 @@ const devtool = defineDevtool({
   id: 'my-plugin',
   setup(ctx) {
     ctx.rpc.register(getSummary)
-    // Optional: register tools or resources directly.
     ctx.agent.registerResource({
       id: 'latest-build',
       name: 'Latest build',
@@ -47,15 +78,7 @@ const devtool = defineDevtool({
 await createMcpServer(devtool, { transport: 'stdio' })
 ```
 
-Or via the CLI:
-
-```sh
-devframe mcp
-```
-
-`@modelcontextprotocol/sdk` is a peer dependency — add it to your package when you want to ship MCP support.
-
-See the [Agent-Native guide](https://devfra.me/agent-native) for the full API, safety model, and Claude Desktop integration example.
+Or via the CLI: `devframe mcp`. `@modelcontextprotocol/sdk` is a peer dependency — add it when you want MCP support. See the [Agent-Native guide](https://devfra.me/guide/agent-native) for the full API and Claude Desktop integration example.
 
 ## License
 


### PR DESCRIPTION
### Description

Adds `devframe/netlify.toml` so the devfra.me deploy is reproducible from the repo — builds only the devframe docs and skips builds when devframe-related files haven't changed. Enriches the docs landing page from 4 plain feature tiles to 6 with emoji icons, reframing the "Headless: no banners…" tile positively per the docs style guide. Tightens both the directory and npm package READMEs by replacing the run-on opening sentence with a focused tagline + a "Hello, Devframe" quick-start, and fixes a broken `/agent-native` link to `/guide/agent-native`.

### Linked Issues

### Additional context

Verified locally: `pnpm -C devframe/docs run docs:build` succeeds (~2.3s) and the new feature tiles render in the built `index.html`. To activate the netlify config, point a separate Netlify site at this repo with the configuration file path set to `devframe/netlify.toml` (or migrate the existing devfra.me site's UI-configured build to use it).