### PR TITLE
fix(core): pass null to avoid serialization error

### DIFF
--- a/packages/core/src/client/webcomponents/state/messages.ts
+++ b/packages/core/src/client/webcomponents/state/messages.ts
@@ -24,7 +24,7 @@ export function useMessages(context: DocksContext): Reactive<MessagesState> {
 
   const entryMap = new Map<string, DevToolsMessageEntry>()
   let isInitialFetch = true
-  let lastVersion: number | undefined
+  let lastVersion: number | null = null
 
   async function updateMessages() {
     const result = await context.rpc.call('devtoolskit:internal:messages:list', lastVersion)

--- a/packages/core/src/node/rpc/internal/messages-list.ts
+++ b/packages/core/src/node/rpc/internal/messages-list.ts
@@ -15,7 +15,7 @@ export const messagesList = defineRpcFunction({
   setup: (context) => {
     const host = context.messages as unknown as DevToolsMessagesHost
     return {
-      async handler(since?: number): Promise<MessagesListResult> {
+      async handler(since?: number | null): Promise<MessagesListResult> {
         const currentVersion = (host as any)._clock as number
 
         if (since == null) {


### PR DESCRIPTION
### Summary
Caused by #301. First call to `devtoolskit:internal:messages:list` passed `undefined` as the cursor, which the strict JSON wire format rejects. Pass `null` instead.

### Reproduction
1. `pnpm play`
2. Open browser console — see `[DF0020] ... value at "[0]" is a undefined` on load.

### Additional context

https://github.com/vitejs/devtools/blob/dc4f9253e60ebc4cb65ea49d5a48dbb8c336638a/devframe/packages/devframe/src/rpc/serialization.ts#L66-L70
