### PR TITLE
feat(devframe): dev-time RPC bridge via `createVitePlugin({ devMiddleware })` and Nuxt module

### DIFF
--- a/devframe/docs/errors/DF0033.md
+++ b/devframe/docs/errors/DF0033.md
@@ -1,0 +1,29 @@
+---
+outline: deep
+---
+
+# DF0033: Dev RPC Bridge Failed to Start
+
+## Message
+
+> Failed to start dev RPC bridge for "`{id}`": `{reason}`
+
+## Cause
+
+`createVitePlugin({ devMiddleware })` could not bring up the bridge dev server that pairs a host-served SPA (Vite, Nuxt, Astro, etc.) with devframe's RPC backend. Common reasons:
+
+- The preferred port is in use and no fallback range was configured.
+- Calling `def.setup(ctx)` threw — the devframe's own setup logic surfaced an error.
+- A required peer (e.g. `get-port-please` or `h3`) is missing or mismatched.
+
+This is a soft warning — the surrounding Vite dev server keeps running, but the host-served SPA will fail its `__connection.json` lookup until the bridge starts.
+
+## Fix
+
+- Pin a port via `cli.port` / `cli.portRange` on the devframe definition, or via `devMiddleware.port` on `createVitePlugin`.
+- Inspect the `reason` (or the attached `cause`) for the underlying error — fix the setup function or free the port.
+- For Nuxt: pass `devMiddleware: { port: <free-port> }` to the `@devframes/nuxt` module.
+
+## Source
+
+- [`packages/devframe/src/adapters/vite.ts`](https://github.com/vitejs/devtools/blob/main/devframe/packages/devframe/src/adapters/vite.ts) — `createVitePlugin({ devMiddleware })` logs `DF0033` when port resolution or `createDevServer` throws during `configureServer`.

--- a/devframe/docs/errors/index.md
+++ b/devframe/docs/errors/index.md
@@ -41,3 +41,4 @@ Emitted by `devframe` — framework-neutral host / shared-state / auth surface.
 | [DF0030](./DF0030) | error | Unknown Stream ID |
 | [DF0031](./DF0031) | error | Write to Closed Stream |
 | [DF0032](./DF0032) | error | Streaming Channel Already Registered |
+| [DF0033](./DF0033) | warn | Dev RPC Bridge Failed to Start |

--- a/devframe/docs/guide/nuxt.md
+++ b/devframe/docs/guide/nuxt.md
@@ -4,13 +4,14 @@ outline: deep
 
 # Nuxt Helper
 
-The `@devframes/nuxt` module wires a Nuxt-built SPA as a devframe client. It runs inside the Nuxt app that consumes your devframe — separate from the CLI that serves it.
+The `@devframes/nuxt` module wires a Nuxt-built SPA as a devframe client, and optionally serves the dev-time RPC bridge alongside `nuxt dev`. It runs inside the Nuxt app that consumes your devframe.
 
-It handles the three things every Nuxt-powered standalone devtool needs:
+It handles the four things every Nuxt-powered standalone devtool needs:
 
 1. **Base-agnostic assets.** Sets `app.baseURL: './'` and `vite.base: './'` so the same production build works at `/`, `/tool/`, and any other deployment path without build-time URL rewriting.
 2. **Runtime RPC connection.** Adds a client plugin that calls [`connectDevframe()`](./client) once on page load and provides the result as `$rpc` on the Nuxt app.
-3. **TypeScript augmentation.** `useNuxtApp().$rpc` is typed as `DevToolsRpcClient` out of the box.
+3. **Dev-time RPC bridge.** When you pass `devframe`, `nuxt dev` spins up a separate WebSocket RPC server and serves `__connection.json` so the SPA can reach it — no hand-rolled Vite plugin required.
+4. **TypeScript augmentation.** `useNuxtApp().$rpc` is typed as `DevToolsRpcClient` out of the box.
 
 ## Install
 
@@ -55,6 +56,63 @@ export default defineNuxtConfig({
 - **`baseURL`** defaults to `'./'`, which resolves against `document.baseURI` at runtime. The connection meta and dump shards sit next to `index.html`, so the same build works at any deployment path.
 - **`skipAppDefaults: true`** disables the `app.baseURL: './'` / `vite.base: './'` defaults. Use this when you're shipping with absolute asset paths and have your own base-URL story.
 
+## Dev-time RPC bridge
+
+Pass your devframe definition to wire `nuxt dev` up to the RPC backend:
+
+```ts [nuxt.config.ts]
+import devframe from './src/devframe' // defineDevframe(...) export
+
+export default defineNuxtConfig({
+  modules: [['@devframes/nuxt', { devframe }]],
+})
+```
+
+That's the full setup. Behind the scenes, `nuxt dev` now:
+
+- Starts a separate WebSocket RPC server on a port resolved via [`get-port-please`](https://github.com/unjs/get-port-please) (respects `devframe.cli.port` / `portRange` / `random`).
+- Registers Vite middleware at `${baseURL}__connection.json` so the SPA reads it on load.
+- Runs `devframe.setup(ctx, { flags })` once the bridge is up, registering your RPC functions.
+- Cleans up the bridge on Vite restart, `nuxt dev` shutdown, and bundle close.
+
+The bridge is **on by default** whenever `devframe` is set. Skip it (back to client-only) with `devMiddleware: false`.
+
+### Customizing the bridge
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: [['@devframes/nuxt', {
+    devframe,
+    devMiddleware: {
+      port: 7777,
+      host: '0.0.0.0',
+      flags: { config: process.env.MY_CONFIG },
+    },
+  }]],
+})
+```
+
+- **`port`** pins the bridge port. Skip it to let `get-port-please` pick a free port.
+- **`host`** controls the bridge bind host. Defaults to `nuxt.options.devServer.host ?? devframe.cli?.host ?? 'localhost'`, so `nuxt dev --host` propagates automatically. Set this manually when your Nuxt server config doesn't surface `host` (e.g. custom listen options).
+- **`flags`** is forwarded to `devframe.setup(ctx, { flags })`. Use it to pass env-derived configuration into the RPC layer.
+
+### Relationship to `createCli`
+
+The bridge handles the **dev workflow**. Production deploys still go through `createCli` (or `createBuild`), which produces a static `__connection.json` + `__rpc-dump/` snapshot from `cli.distDir`:
+
+```
+my-tool/
+├── bin.mjs               # createCli(devframe).parse()
+├── src/
+│   ├── devframe.ts       # defineDevframe + setup(ctx) { ctx.rpc.register(...) }
+│   └── app/              # Nuxt SPA — uses `@devframes/nuxt`
+└── dist/
+    ├── cli.mjs           # bundled Node entry
+    └── public/           # Nuxt build output, pointed at by cli.distDir
+```
+
+In dev (`nuxt dev`) the bridge is live. In production (`<your-cli> build` then `<your-cli> spa`) the SPA loads the static dump.
+
 ## How it works
 
 At build time the module:
@@ -69,26 +127,6 @@ At build time the module:
   ```
 
 At runtime the built SPA fetches `./__connection.json` (resolved against `document.baseURI`) and branches on the `backend` field — `websocket` in dev, `static` from a `createBuild` snapshot.
-
-## Relationship to `createCli`
-
-The Nuxt helper is a client-side integration — `createCli` runs the server side. The typical shape is:
-
-```
-my-tool/
-├── bin.mjs               # createCli(devtool).parse()
-├── src/
-│   ├── cli.ts            # defineDevframe + setup(ctx) { ctx.rpc.register(...) }
-│   └── app/              # Nuxt SPA — uses `@devframes/nuxt`
-└── dist/
-    ├── cli.mjs           # bundled Node entry
-    └── public/           # Nuxt build output, pointed at by cli.distDir
-```
-
-- `createCli` (from `devframe/adapters/cli`) runs the Node side — HTTP + WS + static build + MCP.
-- `@devframes/nuxt` handles the client side — RPC connection + base-URL plumbing.
-
-They're decoupled: swap Nuxt for any other SPA framework that calls `connectDevframe()` in the browser.
 
 ## See also
 

--- a/devframe/packages/devframe/src/adapters/__tests__/dev.test.ts
+++ b/devframe/packages/devframe/src/adapters/__tests__/dev.test.ts
@@ -44,15 +44,36 @@ describe('adapters/dev', () => {
     }
   })
 
-  it('createDevServer throws when no distDir is configured', async () => {
+  it('createDevServer runs in bridge mode when no distDir is configured', async () => {
     const devframe = defineDevframe({
       id: 'devframe-test-nodist',
       name: 'No Dist',
       setup: () => {},
     })
-    await expect(createDevServer(devframe, { openBrowser: false }))
-      .rejects
-      .toThrow(/no distDir/)
+    const host = '127.0.0.1'
+    const port = await getPort({ port: 19990, host })
+    const handle = await createDevServer(devframe, {
+      host,
+      port,
+      openBrowser: false,
+    })
+
+    try {
+      // Connection meta is still served — the bridge endpoint that lets
+      // a host-served SPA discover the WS backend.
+      const res = await fetch(`http://${host}:${port}/__connection.json`)
+      expect(res.ok).toBe(true)
+      const meta = await res.json()
+      expect(meta).toEqual({ backend: 'websocket', websocket: port })
+
+      // The SPA mount is absent — without a distDir, sirv isn't wired,
+      // so the basePath returns a 404 from h3 instead of an index.html.
+      const spa = await fetch(`http://${host}:${port}/`)
+      expect(spa.status).toBe(404)
+    }
+    finally {
+      await handle.close()
+    }
   })
 
   it('resolveDevServerPort honors def.cli.port as the preferred default', async () => {

--- a/devframe/packages/devframe/src/adapters/dev.ts
+++ b/devframe/packages/devframe/src/adapters/dev.ts
@@ -30,8 +30,11 @@ export interface CreateDevServerOptions {
    */
   flags?: Record<string, unknown>
   /**
-   * Override `def.cli?.distDir`. Throws when neither is set — the dev
-   * server has nothing to mount otherwise.
+   * Override `def.cli?.distDir`. When neither this option nor
+   * `def.cli?.distDir` is set, the dev server runs in **bridge mode** —
+   * only `__connection.json` and the WS endpoint are mounted; the SPA
+   * is expected to be hosted elsewhere (e.g. by a parent Vite/Nuxt
+   * dev server via `createVitePlugin({ devMiddleware })`).
    */
   distDir?: string
   /**
@@ -93,8 +96,14 @@ export async function resolveDevServerPort(
 
 /**
  * Start a devframe dev server for a {@link DevframeDefinition} —
- * h3 + WebSocket RPC + the author's SPA mounted at the resolved base
- * path.
+ * h3 + WebSocket RPC + (optionally) the author's SPA mounted at the
+ * resolved base path.
+ *
+ * When `distDir` is omitted (and `def.cli?.distDir` is unset) the
+ * server runs in **bridge mode**: only `__connection.json` and the WS
+ * endpoint are mounted, with no sirv-served SPA. The SPA is expected to
+ * be hosted elsewhere (e.g. by a parent Vite/Nuxt dev server) — see
+ * `createVitePlugin({ devMiddleware })`.
  *
  * Returns the underlying {@link StartedServer} handle so callers can
  * close it gracefully (SIGINT, hot-reload, test teardown).
@@ -108,8 +117,6 @@ export async function createDevServer(
   options: CreateDevServerOptions = {},
 ): Promise<StartedServer> {
   const distDir = options.distDir ?? def.cli?.distDir
-  if (!distDir)
-    throw new Error(`[devframe] createDevServer: no distDir for "${def.id}". Set \`cli.distDir\` on the definition or pass it as an option.`)
 
   const host = options.host ?? def.cli?.host ?? 'localhost'
   const port = options.port ?? await resolveDevServerPort(def, { host })
@@ -145,7 +152,8 @@ export async function createDevServer(
     return event.node.res.end(JSON.stringify({ backend: 'websocket', websocket: port }))
   }))
 
-  app.use(basePath, fromNodeMiddleware(sirv(resolve(distDir), { dev: true, single: true })))
+  if (distDir)
+    app.use(basePath, fromNodeMiddleware(sirv(resolve(distDir), { dev: true, single: true })))
 
   return startHttpAndWs({
     context: ctx,

--- a/devframe/packages/devframe/src/adapters/vite.ts
+++ b/devframe/packages/devframe/src/adapters/vite.ts
@@ -1,14 +1,41 @@
 import type { DevframeDefinition } from '../types/devframe'
 import { resolve } from 'pathe'
 import sirv from 'sirv'
+import { DEVTOOLS_CONNECTION_META_FILENAME } from '../constants'
+import { logger } from '../node/diagnostics'
 import { resolveBasePath } from './_shared'
+import { createDevServer, resolveDevServerPort } from './dev'
 
 export interface CreateVitePluginOptions {
   /**
    * Mount base. Defaults to `def.basePath ?? '/__<id>/'` for this hosted
    * adapter — the devframe shares the origin with the host Vite app.
+   *
+   * Relative spellings like `'./'` (common for base-agnostic Nuxt builds)
+   * are normalized to absolute paths so they compose with Vite's connect
+   * router.
    */
   base?: string
+  /**
+   * Dev-time middleware mode. When set, the host app owns the SPA and
+   * devframe spins up a separate RPC + WS server on a resolved port,
+   * registering Vite middleware at `<base>__connection.json` so the
+   * host-served SPA can discover the WS endpoint.
+   *
+   *  - `false` (default) — sirv-mount the SPA at `base` (today's
+   *    behavior). No RPC server is started.
+   *  - `true` — bridge mode with all defaults (port from
+   *    {@link resolveDevServerPort}, host from `def.cli?.host`).
+   *  - object — bridge mode with explicit overrides.
+   */
+  devMiddleware?: boolean | {
+    /** Override the bridge port. Default: {@link resolveDevServerPort}. */
+    port?: number
+    /** Override the bridge bind host. Default: `def.cli?.host ?? 'localhost'`. */
+    host?: string
+    /** Flag bag forwarded to `def.setup(ctx, { flags })`. */
+    flags?: Record<string, unknown>
+  }
 }
 
 export interface DevframeVitePlugin {
@@ -16,30 +43,103 @@ export interface DevframeVitePlugin {
   apply: 'serve'
   configureServer: (server: {
     middlewares: { use: (path: string, handler: any) => void }
-  }) => void
+    httpServer?: { once: (event: 'close', cb: () => void) => void } | null
+  }) => void | Promise<void>
+  closeBundle?: () => void | Promise<void>
 }
 
 /**
- * Plain Vite plugin — mounts a devframe's SPA into a user's
- * Vite dev server at `options.base` (default: `def.basePath ?? '/__<id>/'`).
- * Use this for tools that want the Vite dev experience without
- * pulling the full Vite DevTools Kit.
+ * Vite plugin for hosting a devframe inside a Vite dev server.
  *
- * Note: this does not yet spin up the RPC WS server — for the full
- * RPC path, use `createPluginFromDevframe` from
- * `@vitejs/devtools-kit/node` alongside `@vitejs/devtools`, or the
- * standalone `createCli`.
+ * Two modes, picked via `options.devMiddleware`:
+ *
+ *   - **sirv mode** (default) — mounts `def.cli.distDir` at `options.base`
+ *     via sirv. Single-page fallback enabled. No RPC server is started.
+ *
+ *   - **bridge mode** (`devMiddleware: true | {…}`) — skips the sirv
+ *     mount; the host app owns the SPA. Devframe starts a separate
+ *     RPC + WS dev server (via {@link createDevServer} in bridge mode,
+ *     i.e. without sirv) and registers Vite middleware at
+ *     `<base>__connection.json` so the host-served SPA can discover
+ *     the WS endpoint via {@link connectDevframe}.
+ *
+ * Use bridge mode when integrating with frameworks that own the SPA
+ * (Nuxt, Astro, SolidStart, plain Vite apps). For the all-in-one
+ * `dev` / `build` / `mcp` shell, reach for {@link createCli} instead.
  */
 export function createVitePlugin(d: DevframeDefinition, options: CreateVitePluginOptions = {}): DevframeVitePlugin {
-  const base = options.base ?? resolveBasePath(d, 'hosted')
-  const distDir = d.cli?.distDir
+  const base = normalizeMountBase(options.base ?? resolveBasePath(d, 'hosted'))
+
+  if (!options.devMiddleware) {
+    const distDir = d.cli?.distDir
+    return {
+      name: `devframe:${d.id}`,
+      apply: 'serve',
+      configureServer(server) {
+        if (!distDir)
+          return
+        server.middlewares.use(base, sirv(resolve(distDir), { dev: true, single: true }))
+      },
+    }
+  }
+
+  const mw = options.devMiddleware === true ? {} : options.devMiddleware
+  let started: Awaited<ReturnType<typeof createDevServer>> | undefined
+
   return {
     name: `devframe:${d.id}`,
     apply: 'serve',
-    configureServer(server) {
-      if (!distDir)
+    async configureServer(server) {
+      // Vite re-invokes `configureServer` on each restart cycle; close
+      // the prior handle so we don't leak the WS server. Silent catch —
+      // a stale handle's close failure shouldn't block a fresh start.
+      await started?.close().catch(() => {})
+      started = undefined
+
+      let port: number
+      try {
+        port = mw.port ?? await resolveDevServerPort(d, { host: mw.host })
+        started = await createDevServer(d, {
+          host: mw.host,
+          port,
+          flags: mw.flags,
+          openBrowser: false,
+        })
+      }
+      catch (e) {
+        logger.DF0033({ id: d.id, reason: String(e) }, { cause: e as Error }).log()
         return
-      server.middlewares.use(base, sirv(resolve(distDir), { dev: true, single: true }))
+      }
+
+      const metaPath = `${base}${DEVTOOLS_CONNECTION_META_FILENAME}`
+      server.middlewares.use(metaPath, (_req: unknown, res: any) => {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ backend: 'websocket', websocket: port }))
+      })
+
+      server.httpServer?.once('close', () => {
+        void started?.close().catch(() => {})
+      })
+    },
+
+    async closeBundle() {
+      await started?.close().catch(() => {})
+      started = undefined
     },
   }
+}
+
+/**
+ * Make `base` safe for `server.middlewares.use(path, …)`. Vite's connect
+ * router matches by absolute URL prefix, so relative spellings like
+ * `'./'` (commonly used for base-agnostic Nuxt builds) need to be
+ * converted to `/` first.
+ */
+function normalizeMountBase(base: string): string {
+  let out = base.replace(/^\.\/?/, '/')
+  if (!out.startsWith('/'))
+    out = `/${out}`
+  if (!out.endsWith('/'))
+    out = `${out}/`
+  return out.replace(/\/+/g, '/')
 }

--- a/devframe/packages/devframe/src/node/diagnostics.ts
+++ b/devframe/packages/devframe/src/node/diagnostics.ts
@@ -56,6 +56,12 @@ export const diagnostics = defineDiagnostics({
         `Streaming channel "${p.channel}" is already registered.`,
       hint: 'Each channel name must be unique within a context. Pick a different name or reuse the existing channel handle.',
     },
+    DF0033: {
+      message: (p: { id: string, reason: string }) =>
+        `Failed to start dev RPC bridge for "${p.id}": ${p.reason}`,
+      hint: 'Verify the bridge port is free and the devframe setup function does not throw. Pin a port via `cli.port` / `cli.portRange` on the definition, or via `devMiddleware.port` on `createVitePlugin`.',
+      level: 'warn',
+    },
   },
 })
 

--- a/devframe/packages/nuxt/src/index.ts
+++ b/devframe/packages/nuxt/src/index.ts
@@ -1,4 +1,6 @@
-import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+import type { DevframeDefinition } from 'devframe/types'
+import { addPlugin, addVitePlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+import { createVitePlugin } from 'devframe/adapters/vite'
 
 export interface DevframeNuxtModuleOptions {
   /**
@@ -15,20 +17,57 @@ export interface DevframeNuxtModuleOptions {
    * Defaults to `false` — devframe sets sensible base-agnostic defaults.
    */
   skipAppDefaults?: boolean
+  /**
+   * Devframe definition that powers the dev-time RPC bridge. When set
+   * (and Nuxt is in dev mode), the module starts a separate RPC + WS
+   * server alongside `nuxt dev` and registers Vite middleware at
+   * `${baseURL}__connection.json` so the client SPA can discover the
+   * WS endpoint. Without it the module stays client-only.
+   */
+  devframe?: DevframeDefinition
+  /**
+   * Dev-time middleware mode. Mirrors `createVitePlugin`'s option of the
+   * same name.
+   *
+   *  - `true` (default) — when `devframe` is set and Nuxt is in dev
+   *    mode, start the RPC bridge with all defaults.
+   *  - `false` — skip the bridge entirely. The module remains
+   *    client-only.
+   *  - object — enable with explicit overrides.
+   */
+  devMiddleware?: boolean | {
+    /** Override the bridge port. Default: resolved via `get-port-please`. */
+    port?: number
+    /**
+     * Override the bridge bind host. Defaults to
+     * `nuxt.options.devServer.host ?? devframe.cli?.host ?? 'localhost'`,
+     * so `nuxt dev --host` propagates automatically.
+     */
+    host?: string
+    /** Flag bag forwarded to `devframe.setup(ctx, { flags })`. */
+    flags?: Record<string, unknown>
+  }
 }
 
 /**
- * Nuxt module that wires a Nuxt-built SPA up as a devframe client:
+ * Nuxt module that wires a Nuxt-built SPA up as a devframe client, and
+ * (optionally) serves the dev-time RPC bridge alongside `nuxt dev`.
  *
  *   - Sets `app.baseURL: './'` + `vite.base: './'` so the production
  *     build is base-agnostic (works at any deployment path without
  *     build-time rewriting).
  *   - Injects a client plugin that calls {@link connectDevframe} once on
  *     page load and exposes the RPC client via `useNuxtApp().$rpc`.
+ *   - When `devframe` is provided and Nuxt is in dev mode, registers a
+ *     Vite plugin (via `addVitePlugin(createVitePlugin(devframe, {
+ *     devMiddleware: ... }))`) that starts the RPC + WS bridge and
+ *     serves `${baseURL}__connection.json`.
  *
  * ```ts [nuxt.config.ts]
+ * import devframe from './src/devframe' // defineDevframe(...) export
+ *
  * export default defineNuxtConfig({
- *   modules: ['@devframes/nuxt'],
+ *   modules: [['@devframes/nuxt', { devframe }]],
  * })
  * ```
  *
@@ -49,6 +88,7 @@ export default defineNuxtModule<DevframeNuxtModuleOptions>({
   defaults: {
     baseURL: './',
     skipAppDefaults: false,
+    devMiddleware: true,
   },
   setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
@@ -77,5 +117,26 @@ export default defineNuxtModule<DevframeNuxtModuleOptions>({
       src: resolve('./runtime/plugin.client'),
       mode: 'client',
     })
+
+    // Dev-time RPC bridge. Skipped without a definition or when the
+    // user opts out; `apply: 'serve'` on the inner Vite plugin is a
+    // second guard against accidental activation during build.
+    if (options.devframe && options.devMiddleware !== false && nuxt.options.dev) {
+      const mw = options.devMiddleware === true || options.devMiddleware === undefined
+        ? {}
+        : options.devMiddleware
+      const host = mw.host
+        ?? (nuxt.options.devServer as any)?.host
+        ?? options.devframe.cli?.host
+
+      addVitePlugin(createVitePlugin(options.devframe, {
+        base: options.baseURL ?? './',
+        devMiddleware: {
+          port: mw.port,
+          host,
+          flags: mw.flags,
+        },
+      }) as any)
+    }
   },
 })

--- a/devframe/tests/__snapshots__/tsnapi/@devframes/nuxt/index.snapshot.d.ts
+++ b/devframe/tests/__snapshots__/tsnapi/@devframes/nuxt/index.snapshot.d.ts
@@ -5,6 +5,12 @@
 export interface DevframeNuxtModuleOptions {
   baseURL?: string;
   skipAppDefaults?: boolean;
+  devframe?: DevframeDefinition;
+  devMiddleware?: boolean | {
+    port?: number;
+    host?: string;
+    flags?: Record<string, unknown>;
+  };
 }
 // #endregion
 

--- a/devframe/tests/__snapshots__/tsnapi/devframe/adapters/vite.snapshot.d.ts
+++ b/devframe/tests/__snapshots__/tsnapi/devframe/adapters/vite.snapshot.d.ts
@@ -4,6 +4,11 @@
 // #region Interfaces
 export interface CreateVitePluginOptions {
   base?: string;
+  devMiddleware?: boolean | {
+    port?: number;
+    host?: string;
+    flags?: Record<string, unknown>;
+  };
 }
 export interface DevframeVitePlugin {
   name: string;
@@ -12,7 +17,11 @@ export interface DevframeVitePlugin {
     middlewares: {
       use: (_: string, _: any) => void;
     };
-  }) => void;
+    httpServer?: {
+      once: (_: 'close', _: () => void) => void;
+    } | null;
+  }) => void | Promise<void>;
+  closeBundle?: () => void | Promise<void>;
 }
 // #endregion
 


### PR DESCRIPTION
### Description

Adds a `devMiddleware` option to `createVitePlugin` so any Vite-based host (Nuxt, Astro, SolidStart, plain Vite) can own the SPA while devframe owns the RPC + WS backend — the plugin starts `createDevServer` in bridge mode on a resolved port and serves `<base>__connection.json` via Vite middleware. The `@devframes/nuxt` module gains a matching `devframe` + `devMiddleware` pair (default-on whenever `devframe` is set, auto-reads `nuxt.options.devServer.host` so `nuxt dev --host` propagates, clean teardown on Vite restart / Nuxt close). `createDevServer`'s `distDir` is now truly optional — bridge mode skips the sirv SPA mount. New `DF0033` (warn) covers bridge startup failures, with docs added under `docs/errors/` and a new "Dev-time RPC bridge" section in the Nuxt guide.

### Linked Issues

### Additional context

This unblocks Nuxt-based devtools (e.g. `eslint-config-inspector`) running `nuxt dev` without hand-rolling a ~40-line Vite plugin per project. Backwards compatible: `createVitePlugin` defaults `devMiddleware: false`, and the Nuxt module's bridge is gated on a `devframe` being provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)