### PR TITLE
fix(ui): isolate dark mode localStorage key to prevent theme leaking from iframe panels

### DIFF
--- a/packages/ui/src/composables/dark.ts
+++ b/packages/ui/src/composables/dark.ts
@@ -1,6 +1,7 @@
 import { useDark } from '@vueuse/core'
 
 export const isDark = useDark({
+  storageKey: 'vite-devtools-color-scheme',
   valueLight: 'light',
 })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Enabling light mode in the UnoCSS panel causes CSS styling issues in the DevTools Debug Dashboard. Additionally,the Self Inspect panel's dark/light mode state is shared with the UnoCSS panel.

I believe there should be a unified setting in the DevTools settings to control this.

<img width="1743" height="985" alt="屏幕截图_11-5-2026_16582_localhost" src="https://github.com/user-attachments/assets/a0edf6be-2e32-4ce2-893d-1831210a43c6" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
