### PR TITLE
fix: fall back to structured-clone for RPC error envelopes

### DIFF
--- a/devframe/packages/devframe/src/rpc/transports/ws-client.ts
+++ b/devframe/packages/devframe/src/rpc/transports/ws-client.ts
@@ -84,7 +84,12 @@ export function createWsRpcChannel(options: WsRpcChannelOptions): ChannelOptions
         method = pendingRequestMethods.get(msg.i)
         pendingRequestMethods.delete(msg.i)
       }
-      const useJson = !!method && definitions.get(method)?.jsonSerializable === true
+      // `jsonSerializable` constrains the return-value path (args + return).
+      // Error envelopes (`{ t: 's', i, e }`) carry a thrown value — fall back
+      // to structured-clone so they round-trip instead of crashing the serializer.
+      // Detect via `'e' in msg` so `throw undefined` still routes through SC.
+      const isErrorResponse = msg.t === 's' && 'e' in msg
+      const useJson = !isErrorResponse && !!method && definitions.get(method)?.jsonSerializable === true
       if (useJson)
         return strictJsonStringify(msg, method ?? '')
       return `${STRUCTURED_CLONE_PREFIX}${structuredCloneStringify(msg)}`

--- a/devframe/packages/devframe/src/rpc/transports/ws-server.ts
+++ b/devframe/packages/devframe/src/rpc/transports/ws-server.ts
@@ -127,7 +127,12 @@ export function attachWsRpcTransport<
           method = pendingRequestMethods.get(msg.i)
           pendingRequestMethods.delete(msg.i)
         }
-        const useJson = !!method && definitions.get(method)?.jsonSerializable === true
+        // `jsonSerializable` constrains the return-value path (args + return).
+        // Error envelopes (`{ t: 's', i, e }`) carry a thrown value — fall back
+        // to structured-clone so they round-trip instead of crashing the serializer.
+        // Detect via `'e' in msg` so `throw undefined` still routes through SC.
+        const isErrorResponse = msg.t === 's' && 'e' in msg
+        const useJson = !isErrorResponse && !!method && definitions.get(method)?.jsonSerializable === true
         if (useJson)
           return strictJsonStringify(msg, method ?? '')
         return `${STRUCTURED_CLONE_PREFIX}${structuredCloneStringify(msg)}`

--- a/devframe/packages/devframe/src/rpc/transports/ws.test.ts
+++ b/devframe/packages/devframe/src/rpc/transports/ws.test.ts
@@ -52,4 +52,38 @@ describe('devtools rpc', () => {
 
     expect(await server.broadcast.$call('hey', 'server')).toEqual(expect.arrayContaining(['hey server, I\'m client 1', 'hey server, I\'m client 2']))
   })
+
+  // Regression: a `jsonSerializable: true` RPC that throws used to crash the
+  // WS serializer with DF0020 because the error envelope was strict-JSON-encoded
+  // alongside the result path.
+  it('returns a rejection (not a serialization crash) when a jsonSerializable RPC throws', async () => {
+    const PORT = 3334
+    const HOST = '127.0.0.1'
+    const WS_URL = `ws://${HOST}:${PORT}`
+
+    const serverFunctions = {
+      explode: async () => {
+        throw new Error('boom')
+      },
+    }
+
+    const definitions = new Map<string, { jsonSerializable?: boolean }>([
+      ['explode', { jsonSerializable: true }],
+    ])
+
+    const server = createRpcServer<Record<string, never>, typeof serverFunctions>(serverFunctions)
+    const { wss } = attachWsRpcTransport(server, { port: PORT, host: HOST, definitions: definitions as any })
+
+    try {
+      const client = createRpcClient<typeof serverFunctions, Record<string, never>>({}, {
+        channel: createWsRpcChannel({ url: WS_URL, definitions: definitions as any }),
+      })
+
+      await expect(client.$call('explode')).rejects.toThrow(/boom/)
+    }
+    finally {
+      for (const c of wss.clients) c.terminate()
+      await new Promise<void>(resolve => wss.close(() => resolve()))
+    }
+  })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`jsonSerializable: true` declares the *result* shape of an RPC function, but the WS transport applied `strictJsonStringify` to every outgoing message routed to such a method — including the error envelope (`{ t: 's', i, e }`) emitted when the handler throws. Because `Error` instances aren't JSON-serializable, this crashed the serializer with DF0020 and masked the original DTK0011 entirely, taking the dev server down with it (reproducible on StackBlitz / WebContainer).

Skip the strict-JSON path for error envelopes on both ws-server and ws-client transports so thrown values round-trip via structured-clone, and the underlying failure surfaces on the caller instead.

### Linked Issues

close: https://github.com/vitejs/devtools/issues/335

### Additional context

N/A
<!-- e.g. is there anything you'd like reviewers to focus on? -->
