### PR TITLE
fix(core): set `open` state false when switching to no entry

### DIFF
--- a/packages/core/src/client/webcomponents/state/context.ts
+++ b/packages/core/src/client/webcomponents/state/context.ts
@@ -51,6 +51,7 @@ export async function createDocksContext(
   const switchEntry = async (id: string | null = null) => {
     if (id == null) {
       selectedId.value = null
+      panelStore.value.open = false
       return true
     }
     if (id === '~client-auth-notice') {


### PR DESCRIPTION
### Description
#### Before

After opening any dock entry once, the dock stayed fully expanded forever — moving the mouse away or waiting past `inactiveTimeout` no longer collapsed it to the small minimized dot. Only pressing ESC could restore the auto-minimize behavior. The stuck state also persisted across page reloads.

#### After

Closing a panel via toggle re-click, click-outside, or ESC all behave the same: the dock collapses to the minimized dot after `inactiveTimeout` once the mouse leaves.

### Test plan

- [ ] Toggle-close an entry → dock minimizes after 3s
- [ ] Click outside to close → dock minimizes after 3s
- [ ] ESC to close → dock minimizes after 3s
