### PR TITLE
fix(docs): build workspace packages before docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:rolldown": "pnpm -C packages/rolldown run dev",
     "dev:vite": "pnpm -C packages/vite run dev",
     "docs": "pnpm -C docs run docs",
-    "docs:build": "pnpm -C docs run docs:build",
+    "docs:build": "pnpm build && pnpm -C docs run docs:build",
     "docs:serve": "pnpm -C docs run docs:serve",
     "play": "pnpm -C packages/core run play",
     "play:debug": "pnpm -C packages/core run play:debug",


### PR DESCRIPTION
### Description

`pnpm docs:build` was failing with `TS2307: Cannot find module '@vitejs/devtools'` because twoslash resolves the package's `types` field (`dist/index.d.ts`) — which doesn't exist until the workspace packages have been built. Chaining `pnpm build` (turbo-cached, so it's a no-op when nothing changed) before the docs build makes `pnpm docs:build` self-sufficient from a fresh clone or after cleaning `dist/`.

### Linked Issues

### Additional context