### PR TITLE
 fix(core): fix devtools asset routing under `/__devtools`

### DIFF
--- a/packages/core/src/node/cli-commands.ts
+++ b/packages/core/src/node/cli-commands.ts
@@ -2,6 +2,7 @@
 
 import {
   DEVTOOLS_MOUNT_PATH,
+  DEVTOOLS_MOUNT_PATH_NO_TRAILING_SLASH,
 } from '@vitejs/devtools-kit/constants'
 import { normalizeHttpServerUrl } from 'devframe/node'
 import { colors as c } from 'devframe/utils/colors'
@@ -51,7 +52,7 @@ export async function start(options: StartOptions) {
   for (const { baseUrl, distDir } of devtools.context.views.buildStaticDirs)
     mountStaticHandler(app, baseUrl, distDir)
 
-  app.use(DEVTOOLS_MOUNT_PATH, h3)
+  app.use(DEVTOOLS_MOUNT_PATH_NO_TRAILING_SLASH, h3)
   app.use('/', defineHandler(event => sendRedirect(event, DEVTOOLS_MOUNT_PATH, 302)))
 
   const server = createServer(toNodeHandler(app))


### PR DESCRIPTION
## Summary

After running `vite-devtools` (e.g. `pnpm -F @vitejs/devtools play:build`), opening `/__devtools/` loads the SPA shell but every asset under `/__devtools/assets/*` returns 404.

## Cause

PR #346 (h3 v1 → v2 migration) changed the sub-app mount from `app.use(DEVTOOLS_MOUNT_PATH, h3.handler)` to `app.use(DEVTOOLS_MOUNT_PATH, h3)`. With an `H3` instance, `app.use` routes through `H3.mount(base, subApp)`, whose
internal matcher assumes `base` has **no trailing slash**:


## Additional context
https://github.com/h3js/h3/blob/84244b49b84e6ce6260d6b3a3590409e0d525fab/src/h3.ts#L129-L140
