### PR TITLE
chore(playground): add cross-package import to exercise vue-tracer

### DIFF
--- a/packages/core/playground/src/pages/index.vue
+++ b/packages/core/playground/src/pages/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import DisplayBadge from '@vitejs/devtools-ui/components/DisplayBadge.vue'
 import HelloWorld from '../components/HelloWorld.vue'
 </script>
 
@@ -12,6 +13,7 @@ import HelloWorld from '../components/HelloWorld.vue'
     </a>
   </div>
   <HelloWorld msg="Vite + Vue" />
+  <DisplayBadge text="<DisplayBadge />" />
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Import `DisplayBadge` from `@vitejs/devtools-ui` in the playground so vue-tracer's click-to-source can be verified across monorepo package boundaries.
