### PR TITLE
fix(dock): remove redundant native title on dock entry

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockEntry.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntry.vue
@@ -77,7 +77,6 @@ useEventListener('pointerdown', () => {
   >
     <button
       ref="button"
-      :title="dock.title"
       :class="[
         isVertical ? 'rotate-270' : '',
         isDimmed ? 'op50 saturate-0' : '',
@@ -86,7 +85,7 @@ useEventListener('pointerdown', () => {
       ]"
       class="flex items-center justify-center p1.5 hover:bg-[#8881] hover:scale-110 transition-all duration-300 relative outline-none"
     >
-      <DockIcon :icon="dock.icon" :title="dock.title" class="w-5 h-5 select-none" />
+      <DockIcon :icon="dock.icon" class="w-5 h-5 select-none" />
       <div v-if="badge" class="absolute top-0.5 right-0 bg-gray-6 text-white text-0.6em px-1 rounded-full shadow">
         {{ badge }}
       </div>


### PR DESCRIPTION
## Before
Hovering a dock entry shows both the custom floating tooltip and the browser's native title tooltip.
<img width="435" height="625" alt="2026-05-29 160014" src="https://github.com/user-attachments/assets/54f18322-7d04-454b-9643-8fa77c53276c" />


## After:
Only the custom floating tooltip is shown.
<img width="358" height="544" alt="2026-05-29 155957" src="https://github.com/user-attachments/assets/7298ff3e-4ec6-4d97-af06-279350d9cc75" />
