### PR TITLE
docs(errors): fix DTK0013 clientAuthTokens config example

### DIFF
--- a/docs/errors/DTK0013.md
+++ b/docs/errors/DTK0013.md
@@ -16,7 +16,7 @@ A client becomes trusted through one of these mechanisms:
 
 1. **Client auth is disabled** (build mode, `clientAuth: false`, or `VITE_DEVTOOLS_DISABLE_CLIENT_AUTH=true`) -- all clients are auto-trusted.
 2. **Auth token in storage** -- the client provides a `devframe_auth_token` query parameter that matches a token stored in `node_modules/.vite/devtools/auth.json`.
-3. **Static auth tokens** -- the token matches one of the tokens listed in `devtools.config.clientAuthTokens`.
+3. **Static auth tokens** -- the token matches one of the tokens listed in the top-level `devtools.clientAuthTokens` Vite config option.
 
 If none of these conditions are met, the client is untrusted and any call to a non-anonymous method triggers this error.
 
@@ -45,7 +45,7 @@ const ws = new WebSocket(
 )
 ```
 
-Or configure static trusted tokens in your Vite config:
+Or configure static trusted tokens via the top-level `devtools` option in your Vite config:
 
 ```ts
 import devtools from '@vitejs/devtools'
@@ -54,12 +54,12 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [
-    devtools({
-      config: {
-        clientAuthTokens: ['your-trusted-token'],
-      },
-    }),
+    devtools(),
   ],
+  devtools: {
+    enabled: true,
+    clientAuthTokens: ['your-trusted-token'],
+  },
 })
 ```
 

--- a/docs/errors/DTK0013.md
+++ b/docs/errors/DTK0013.md
@@ -16,7 +16,7 @@ A client becomes trusted through one of these mechanisms:
 
 1. **Client auth is disabled** (build mode, `clientAuth: false`, or `VITE_DEVTOOLS_DISABLE_CLIENT_AUTH=true`) -- all clients are auto-trusted.
 2. **Auth token in storage** -- the client provides a `devframe_auth_token` query parameter that matches a token stored in `node_modules/.vite/devtools/auth.json`.
-3. **Static auth tokens** -- the token matches one of the tokens listed in the top-level `devtools.clientAuthTokens` Vite config option.
+3. **Static auth tokens** -- the token matches one of the tokens listed in `devtools.clientAuthTokens` in your Vite config.
 
 If none of these conditions are met, the client is untrusted and any call to a non-anonymous method triggers this error.
 
@@ -45,7 +45,7 @@ const ws = new WebSocket(
 )
 ```
 
-Or configure static trusted tokens via the top-level `devtools` option in your Vite config:
+Or configure static trusted tokens in your Vite config:
 
 ```ts
 import devtools from '@vitejs/devtools'


### PR DESCRIPTION
`clientAuthTokens` belongs to `DevToolsConfig`, which is consumed by Vite core, not the plugin. The plugin option type (`DevToolsOptions`) doesn't accept it, so the documented `devtools({ config: { clientAuthTokens } })` form doesn't work.