### PR TITLE
fix(core): use reactive settings ref in SettingsDocks

### DIFF
--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
@@ -21,14 +21,14 @@ const settings = sharedStateToRef(props.settingsStore)
 // group button. A group's members live in their own reorderable container
 // (`grp:<id>`); category containers are keyed `cat:<name>`.
 const categories = computed<DevToolsDockEntriesGrouped>(() => {
-  return docksGroupByCategories(props.context.docks.entries, props.settingsStore.value(), {
+  return docksGroupByCategories(props.context.docks.entries, settings.value, {
     includeHidden: true,
     collapseGroups: true,
   })
 })
 
 function membersOf(groupId: string): DevToolsDockEntry[] {
-  return getGroupMembers(props.context.docks.entries, groupId, props.settingsStore.value(), {
+  return getGroupMembers(props.context.docks.entries, groupId, settings.value, {
     includeHidden: true,
   })
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed a bug where changing dock order did not update in real time, and the new order only appeared after reopening the panel.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
