### PR TITLE
fix(core): include group members when checking/resetting docks custom order

### DIFF
--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
@@ -228,17 +228,37 @@ function moveOrder(container: string, id: string, delta: number) {
   applyOrder(container, array)
 }
 
+function customOrderIdsForContainer(container: string): string[] {
+  const items = itemsOfContainer(container)
+  const ids = items.map(item => item.id)
+  if (container.startsWith('cat:')) {
+    for (const item of items) {
+      if (item.type === 'group')
+        ids.push(...membersOf(item.id).map(member => member.id))
+    }
+  }
+  return ids
+}
+
 function doesContainerHaveCustomOrder(container: string): boolean {
   const current = itemsOfContainer(container).map(i => i.id)
   const def = defaultItemsOfContainer(container).map(i => i.id)
-  return current.length !== def.length || current.some((id, i) => id !== def[i])
+  if (current.length !== def.length || current.some((id, i) => id !== def[i]))
+    return true
+  // Also account for custom ordering inside groups of a category
+  if (container.startsWith('cat:')) {
+    return itemsOfContainer(container).some(item =>
+      item.type === 'group' && doesContainerHaveCustomOrder(GROUP_CONTAINER(item.id)),
+    )
+  }
+  return false
 }
 
 function resetCustomOrderForContainer(container: string) {
-  const items = itemsOfContainer(container)
+  const ids = customOrderIdsForContainer(container)
   props.settingsStore.mutate((state) => {
-    items.forEach((item) => {
-      delete state.docksCustomOrder[item.id]
+    ids.forEach((id) => {
+      delete state.docksCustomOrder[id]
     })
   })
 }


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed a bug where changes to the order of group members did not trigger reset for the group. Only the category reset was modified, we could also add a reset for group level.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
