### PR TITLE
 fix(core): resolve vite `server.https` for websocket server

### DIFF
--- a/packages/core/src/node/https.ts
+++ b/packages/core/src/node/https.ts
@@ -1,0 +1,33 @@
+// Port from https://github.com/vitejs/vite/blob/main/packages/vite/src/node/http.ts#L146
+
+import type { Buffer } from 'node:buffer'
+import type { ServerOptions as HttpsServerOptions } from 'node:https'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export async function resolveHttpsConfig(https: HttpsServerOptions | undefined): Promise<HttpsServerOptions | undefined> {
+  if (!https)
+    return undefined
+
+  const [ca, cert, key, pfx] = await Promise.all([
+    readFileIfExists(https.ca),
+    readFileIfExists(https.cert),
+    readFileIfExists(https.key),
+    readFileIfExists(https.pfx),
+  ])
+
+  return {
+    ...https,
+    ca,
+    cert,
+    key,
+    pfx,
+  }
+}
+
+async function readFileIfExists<T>(value: T): Promise<T | Buffer> {
+  if (typeof value === 'string')
+    return readFile(resolve(value)).catch(() => value)
+
+  return value
+}

--- a/packages/core/src/node/ws.ts
+++ b/packages/core/src/node/ws.ts
@@ -12,6 +12,7 @@ import { getPort } from 'get-port-please'
 import { createDebug } from 'obug'
 import { MARK_INFO } from './constants'
 import { diagnostics } from './diagnostics'
+import { resolveHttpsConfig } from './https'
 
 const debugInvoked = createDebug('vite:devtools:rpc:invoked')
 
@@ -40,7 +41,7 @@ function buildWsUrl({ host, port, https }: { host: string, port: number, https: 
 export async function createWsServer(options: CreateWsServerOptions) {
   const rpcHost = options.context.rpc as unknown as RpcFunctionsHost
   const host = options.websocket.host
-  const https = options.websocket.https === false ? undefined : (options.websocket.https ?? options.context.viteConfig.server.https)
+  const https = await resolveHttpsConfig(options.websocket.https === false ? undefined : (options.websocket.https ?? options.context.viteConfig.server.https))
   const port = options.websocket.port ?? await getPort({ port: 7812, host, random: true })!
 
   const wsClients = new Set<WebSocket>()


### PR DESCRIPTION
   Fixes an HTTPS startup failure when Vite DevTools is used with a Vite server.https config whose TLS fields are file paths, such as the config produced by laravel-vite-plugin with Valet/Herd TLS detection.   (Closes #345)

   Vite normalizes server.https before creating its HTTP and HMR WebSocket servers by attempting to read ca, cert, key, and pfx string values as files. Vite DevTools creates its own WebSocket server from the resolved Vite config, but previously passed  viteConfig.server.https directly to `devframe / node:https.createServer()`. Node treats string key and cert values as PEM content, not file paths, which caused `ERR_OSSL_PEM_NO_START_LINE`.

  This PR ports Vite's HTTPS config resolution into `packages/core/src/node/https.ts` and applies it before creating the DevTools WebSocket server.