### PR TITLE
feat(core): add Switch component to json-render catalog

### DIFF
--- a/examples/plugin-git-ui/src/node/plugin.ts
+++ b/examples/plugin-git-ui/src/node/plugin.ts
@@ -89,14 +89,17 @@ function createRpcFunctions(gitRoot: string, getUi: () => JsonRenderer, interact
       name: 'git-ui:commit',
       type: 'action',
       setup: ctx => ({
-        handler: async (params: { message?: string }) => {
+        handler: async (params: { message?: string, amend?: boolean }) => {
           const message = params?.message
           if (!message) {
             ctx.messages.add({ message: 'Commit message is empty', level: 'warn', category: 'git-ui', notify: true })
             return
           }
 
-          const result = await git(['commit', '-m', message], gitRoot)
+          const args = ['commit', '-m', message]
+          if (params?.amend)
+            args.push('--amend')
+          const result = await git(args, gitRoot)
           if (result.ok) {
             ctx.messages.add({ message: `Committed: ${message}`, level: 'info', category: 'git-ui', notify: true })
           }

--- a/examples/plugin-git-ui/src/node/spec.ts
+++ b/examples/plugin-git-ui/src/node/spec.ts
@@ -80,13 +80,14 @@ export function buildSpec(gitState: GitState, options?: { interactive?: boolean 
 
   const rootChildren = ['header', 'branch-info']
   if (interactive)
-    rootChildren.push('commit-section')
+    rootChildren.push('commit-section', 'amend-switch')
   rootChildren.push('divider1', 'staged-card', 'unstaged-card', 'commits-card')
 
   return {
     root: 'root',
     state: {
       commitMessage: '',
+      amend: false,
     },
     elements: {
       'root': {
@@ -133,6 +134,13 @@ export function buildSpec(gitState: GitState, options?: { interactive?: boolean 
         props: { direction: 'horizontal', gap: 8 },
         children: ['commit-input', 'commit-btn'],
       },
+      'amend-switch': {
+        type: 'Switch',
+        props: {
+          label: 'Amend last commit',
+          value: { $bindState: '/amend' },
+        },
+      },
       'commit-input': {
         type: 'TextInput',
         props: {
@@ -146,7 +154,10 @@ export function buildSpec(gitState: GitState, options?: { interactive?: boolean 
         on: {
           press: {
             action: 'git-ui:commit',
-            params: { message: { $state: '/commitMessage' } },
+            params: {
+              message: { $state: '/commitMessage' },
+              amend: { $state: '/amend' },
+            },
           },
         },
       },

--- a/packages/core/src/client/webcomponents/json-render/catalog.ts
+++ b/packages/core/src/client/webcomponents/json-render/catalog.ts
@@ -94,6 +94,14 @@ export const devtoolsCatalog = defineCatalog(devtoolsSchema, {
       }),
       description: 'Text input field. Use $bindState on the value prop for two-way binding.',
     },
+    Switch: {
+      props: z.object({
+        value: z.boolean().default(false),
+        label: z.string().optional(),
+        disabled: z.boolean().default(false),
+      }),
+      description: 'Toggle switch. Use $bindState on the value prop for two-way binding. Bind "change" event to react to toggles.',
+    },
     KeyValueTable: {
       props: z.object({
         title: z.string().optional(),

--- a/packages/core/src/client/webcomponents/json-render/components/Switch.ts
+++ b/packages/core/src/client/webcomponents/json-render/components/Switch.ts
@@ -1,0 +1,71 @@
+import type { RegistryComponentProps } from './types'
+import { useBoundProp } from '@json-render/vue'
+import { defineComponent, h } from 'vue'
+import { primary, surfaceSubtle } from './tokens'
+
+export const Switch = defineComponent({
+  name: 'JrSwitch',
+  props: ['element', 'emit', 'on', 'bindings', 'loading'],
+  setup(ctx: RegistryComponentProps) {
+    return () => {
+      const { label, disabled } = ctx.element.props
+      const [value, setValue] = useBoundProp<boolean>(ctx.element.props.value, ctx.bindings?.value)
+      const change = ctx.on('change')
+      const checked = !!value
+
+      const track = h('button', {
+        'type': 'button',
+        'role': 'switch',
+        'aria-checked': checked ? 'true' : 'false',
+        disabled,
+        'class': 'jr-switch',
+        'style': {
+          position: 'relative',
+          flexShrink: '0',
+          width: '36px',
+          height: '20px',
+          padding: '0',
+          border: 'none',
+          borderRadius: '10px',
+          cursor: disabled ? 'not-allowed' : 'pointer',
+          opacity: disabled ? '0.5' : '1',
+          backgroundColor: checked ? primary : surfaceSubtle,
+          transition: 'background-color 0.15s ease',
+        },
+        'onClick': () => {
+          setValue(!checked)
+          change.emit()
+        },
+      }, [
+        h('span', {
+          style: {
+            position: 'absolute',
+            top: '2px',
+            left: '2px',
+            width: '16px',
+            height: '16px',
+            borderRadius: '50%',
+            backgroundColor: '#fff',
+            transform: checked ? 'translateX(16px)' : 'translateX(0)',
+            transition: 'transform 0.15s ease',
+          },
+        }),
+      ])
+
+      if (label) {
+        return h('label', {
+          style: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '8px',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+          },
+        }, [
+          track,
+          h('span', { style: { fontSize: '12px' } }, label),
+        ])
+      }
+      return track
+    }
+  },
+})

--- a/packages/core/src/client/webcomponents/json-render/registry.ts
+++ b/packages/core/src/client/webcomponents/json-render/registry.ts
@@ -9,6 +9,7 @@ import { Icon } from './components/Icon'
 import { KeyValueTable } from './components/KeyValueTable'
 import { Progress } from './components/Progress'
 import { Stack } from './components/Stack'
+import { Switch } from './components/Switch'
 import { Text } from './components/Text'
 import { TextInput } from './components/TextInput'
 import { Tree } from './components/Tree'
@@ -22,6 +23,7 @@ export const devtoolsRegistry: Record<string, Component> = {
   Icon,
   Divider,
   TextInput,
+  Switch,
   KeyValueTable,
   DataTable,
   CodeBlock,


### PR DESCRIPTION
### Description

Adds a new `Switch` component to the DevTools json-render catalog, so plugins can render boolean toggles in their specs.

### Example
<img width="1479" height="921" alt="image" src="https://github.com/user-attachments/assets/252f1f79-0cbc-4f68-af7f-dc9f4bf232d4" />



