### PR TITLE
feat(rolldown): add session cleanup to prevent unbounded disk growth

### DIFF
--- a/packages/rolldown/src/node/plugin.ts
+++ b/packages/rolldown/src/node/plugin.ts
@@ -1,15 +1,37 @@
 import type { PluginWithDevTools } from '@vitejs/devtools-kit'
+import { existsSync } from 'node:fs'
 import { DEVTOOLS_VITEPLUS_GROUP_ID } from '@vitejs/devtools-kit/constants'
+import { join } from 'pathe'
 import { clientPublicDir } from '../dirs'
+import { DEFAULT_MAX_SESSIONS, RolldownLogsManager } from './rolldown/logs-manager'
 import { rpcFunctions } from './rpc/index'
 
-export function DevToolsRolldownUI(): PluginWithDevTools {
+export interface DevToolsRolldownOptions {
+  /**
+   * Maximum number of build sessions to retain on disk.
+   * Older sessions are removed when the limit is exceeded.
+   * Set to 0 to disable automatic cleanup.
+   * @default 10
+   */
+  maxSessions?: number
+}
+
+export function DevToolsRolldownUI(options: DevToolsRolldownOptions = {}): PluginWithDevTools {
   return {
     name: 'vite:devtools:rolldown-ui',
     devtools: {
       setup(ctx) {
         for (const fn of rpcFunctions) {
           ctx.rpc.register(fn as any)
+        }
+
+        const maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS
+        if (maxSessions > 0) {
+          const rolldownDir = join(ctx.cwd, 'node_modules', '.rolldown')
+          if (existsSync(rolldownDir)) {
+            const manager = new RolldownLogsManager(rolldownDir)
+            manager.cleanup(maxSessions).catch(() => {})
+          }
         }
 
         ctx.views.hostStatic(

--- a/packages/rolldown/src/node/rolldown/logs-manager.ts
+++ b/packages/rolldown/src/node/rolldown/logs-manager.ts
@@ -78,6 +78,17 @@ export class RolldownLogsManager {
     if (!existsSync(this.dir)) {
       return
     }
+
+    const allDirs = (await fs.readdir(this.dir, { withFileTypes: true }))
+      .filter(d => d.isDirectory())
+
+    const invalidDirs = allDirs.filter(
+      d => !existsSync(join(this.dir, d.name, 'meta.json')),
+    )
+    await Promise.all(
+      invalidDirs.map(d => fs.rm(join(this.dir, d.name), { recursive: true, force: true })),
+    )
+
     const sessions = await this.list()
     if (sessions.length <= maxSessions) {
       return

--- a/packages/rolldown/src/node/rolldown/logs-manager.ts
+++ b/packages/rolldown/src/node/rolldown/logs-manager.ts
@@ -4,6 +4,8 @@ import fs from 'node:fs/promises'
 import { join } from 'pathe'
 import { RolldownEventsReader } from './events-reader'
 
+export const DEFAULT_MAX_SESSIONS = 10
+
 export interface BuildInfo {
   id: string
   timestamp: number
@@ -70,6 +72,22 @@ export class RolldownLogsManager {
     const reader = await this.loadSession(session)
     await reader.readAssets()
     return reader
+  }
+
+  async cleanup(maxSessions: number = DEFAULT_MAX_SESSIONS): Promise<void> {
+    if (!existsSync(this.dir)) {
+      return
+    }
+    const sessions = await this.list()
+    if (sessions.length <= maxSessions) {
+      return
+    }
+    const toDelete = sessions
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .slice(0, sessions.length - maxSessions)
+    await Promise.all(
+      toDelete.map(session => fs.rm(join(this.dir, session.id), { recursive: true, force: true })),
+    )
   }
 
   async loadPackageSession(session: string) {


### PR DESCRIPTION
### Description

When `devtools` is enabled in Vite 8 (Rolldown), a new session folder is written to `node_modules/.rolldown/sid_*/` on every dev server start. Each session contains a `logs.json` file that can reach ~500MB+ for medium-sized projects.

**There is no cleanup mechanism.** After weeks of normal development, sessions accumulate silently — a real-world example:

```
node_modules/.rolldown/   →  17 GB total
└── sid_* × 113 sessions  →  ~568 MB each
```

**Reproduction**: a single `vite build --mode development` run already creates multiple sessions:

```
node_modules/.rolldown/
├── sid_1_1781751596708/   531 MB
├── sid_1_1781751958185/   531 MB   ← 1 build run → 2 sessions, 1 GB
└── unknown-session/       136 KB   ← see below
```

Sessions accumulate from multiple sources:

| Source | Notes |
|---|---|
| `vite dev` restart | ~500 MB per start |
| `vite build --mode development` | ~500 MB per run, often 2 sessions (client + optimizer env) |
| Multiple Vite environments (SSR + client) | each environment gets its own session |
| CI/CD pipelines with devtools enabled | new sessions on every pipeline run |
| `unknown-session` (bug) | `session_id` logged as literal `"${session_id}"`, `meta.json` is empty — previously invisible to `list()` and never cleaned up |

---

**Changes**

`RolldownLogsManager.cleanup(maxSessions)` — new method in `logs-manager.ts`:

1. **Invalid session sweep**: removes any subdirectory that lacks a valid `meta.json` (covers the `unknown-session` case above)
2. **Max-session enforcement**: sorts valid sessions by `timestamp` (oldest first) and deletes those beyond `maxSessions`
3. No-ops if the `.rolldown` directory does not exist yet (fresh installs)

`DevToolsRolldownUI(options?)` — new `maxSessions` option in `plugin.ts`:
- Calls `cleanup()` on devtools startup (fire-and-forget, never throws)
- Default: `10` — keeps enough history for the Session Compare panel (see #371)
- Set `maxSessions: 0` to opt out of automatic cleanup entirely

```ts
// opt out
DevToolsRolldownUI({ maxSessions: 0 })

// keep last 5 sessions
DevToolsRolldownUI({ maxSessions: 5 })
```

---

**Why `maxSessions` and not "always keep only the latest"?**

PR #371 added a Session Compare panel where users compare two builds side-by-side. Keeping only 1 session would break this workflow. A configurable limit with a sensible default preserves the compare experience while bounding disk growth.

### Linked Issues

closes #383

### Additional context

**Open design question for maintainers**: the `maxSessions` option is currently placed on `DevToolsRolldownUI()`. However, since most users don't call this function directly (it's registered internally), a better API surface might be:

- A top-level `devtools: { rolldown: { maxSessions } }` Vite config option, or
- Simply hardcoding the default (e.g. `10`) with no user-facing knob at all

Happy to move the option to whichever layer makes more sense. The `cleanup()` logic itself is stable regardless of where the config lives.

The cleanup runs once at devtools startup (inside `setup(ctx)`). It is intentionally fire-and-forget — a cleanup failure never blocks the devtools from initializing.