### PR TITLE
fix: isolate typecheck for nuxt apps

### DIFF
--- a/packages/rolldown/src/nuxt.config.ts
+++ b/packages/rolldown/src/nuxt.config.ts
@@ -139,6 +139,10 @@ export default defineNuxtConfig({
       compilerOptions: {
         types: ['chrome'], // for devtools-webext package
       },
+      exclude: [
+        '../../../vite/**/*',
+        '../../../self-inspect/**/*',
+      ],
     },
     // Temporary disable type check for nuxt, rely on CI for now
     // typeCheck: true,

--- a/packages/self-inspect/src/nuxt.config.ts
+++ b/packages/self-inspect/src/nuxt.config.ts
@@ -102,10 +102,6 @@ export default defineNuxtConfig({
     enabled: false,
   },
 
-  typescript: {
-    includeWorkspace: true,
-  },
-
   workspaceDir: '../../',
 
   compatibilityDate: '2024-07-17',

--- a/packages/self-inspect/src/tsconfig.json
+++ b/packages/self-inspect/src/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "references": [
+    { "path": "./.nuxt/tsconfig.app.json" },
+    { "path": "./.nuxt/tsconfig.server.json" },
+    { "path": "./.nuxt/tsconfig.shared.json" },
+    { "path": "./.nuxt/tsconfig.node.json" }
+  ],
+  "files": []
 }

--- a/packages/vite/src/nuxt.config.ts
+++ b/packages/vite/src/nuxt.config.ts
@@ -106,10 +106,6 @@ export default defineNuxtConfig({
     enabled: false,
   },
 
-  typescript: {
-    includeWorkspace: true,
-  },
-
   workspaceDir: '../../',
 
   compatibilityDate: '2024-07-17',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "./tsconfig.base.json",
   "references": [
-    { "path": "./packages/rolldown/src/.nuxt/tsconfig.app.json" },
-    { "path": "./packages/rolldown/src/.nuxt/tsconfig.server.json" },
-    { "path": "./packages/rolldown/src/.nuxt/tsconfig.shared.json" },
-    { "path": "./packages/rolldown/src/.nuxt/tsconfig.node.json" }
+    { "path": "./packages/rolldown/src/tsconfig.json" },
+    { "path": "./packages/vite/src/tsconfig.json" },
+    { "path": "./packages/self-inspect/src/tsconfig.json" }
   ],
   "files": []
 }


### PR DESCRIPTION
## Summary

Make the Vite and self-inspect Nuxt apps typecheck against their own generated Nuxt tsconfigs instead of relying on the Rolldown app's workspace-wide typecheck.

## Problem

The root `tsconfig.json` only referenced Rolldown's generated Nuxt tsconfigs. Since Rolldown uses `includeWorkspace`, its generated `tsconfig.app.json` includes the parent workspace and can end up checking files from other packages, including `vite` and `self-inspect`.

That means Vite and self-inspect were not being checked in their own Nuxt type environments. This can hide app-specific type errors, especially around generated Nuxt aliases, imports, components, and app/server/shared/node tsconfig boundaries. It can also report errors through the wrong Nuxt app context.

  ## Solution

  - Reference the Rolldown, Vite, and self-inspect package tsconfig wrappers from the root `tsconfig.json`.
  - Keep Rolldown's existing workspace coverage for the other packages.
  - Exclude the Vite and self-inspect packages from Rolldown's workspace-wide Nuxt typecheck.
  - Update self-inspect to use the same Nuxt project-reference tsconfig shape as the other Nuxt apps.

  This keeps the change minimal while giving the Vite and self-inspect Nuxt apps their own typecheck coverage. Longer
  term, we can move toward explicit tsconfig and typecheck scripts for every package.