### PR TITLE
fix(core): bind draggable to owner document window in SettingsDocks

### DIFF
--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
@@ -94,6 +94,7 @@ function applyOrder(container: string, items: DevToolsDockEntry[]) {
 }
 
 useDraggable(sortContainerEl, {
+  draggingElement: () => sortContainerEl.value?.ownerDocument?.defaultView ?? window,
   onStart(_, event) {
     if (event.button !== 0)
       return false


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix drag-and-drop reordering not working in popup mode.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
