### PR TITLE
fix(dock): open position dropdown inward based on dock edge

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockEdge.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEdge.vue
@@ -45,6 +45,12 @@ const positionLabels: Record<string, string> = {
   bottom: 'Bottom',
   left: 'Left',
 }
+const positionDropdownPlacement: Record<string, 'top' | 'bottom' | 'left' | 'right'> = {
+  top: 'bottom',
+  bottom: 'top',
+  left: 'right',
+  right: 'left',
+}
 
 function switchPosition(pos: 'top' | 'right' | 'bottom' | 'left') {
   store.position = pos
@@ -74,6 +80,7 @@ function togglePositionDropdown() {
   setEdgePositionDropdown({
     el: positionButton.value,
     gap: 6,
+    placement: positionDropdownPlacement[store.position],
     content: () => h('div', { class: 'flex flex-col gap-0.5 min-w-28' }, positions.map(pos =>
       h('button', {
         class: [

--- a/packages/core/src/client/webcomponents/components/floating/FloatingPopover.ts
+++ b/packages/core/src/client/webcomponents/components/floating/FloatingPopover.ts
@@ -87,7 +87,9 @@ const FloatingPopoverComponent = defineComponent({
 
       const vw = window.innerWidth
       const vh = window.innerHeight
-      if (rect.left < DETECT_MARGIN)
+      if (props.item?.placement)
+        align = props.item.placement
+      else if (rect.left < DETECT_MARGIN)
         align = 'right'
       else if (rect.left + rect.width > vw - DETECT_MARGIN)
         align = 'left'

--- a/packages/core/src/client/webcomponents/state/floating-tooltip.ts
+++ b/packages/core/src/client/webcomponents/state/floating-tooltip.ts
@@ -5,6 +5,7 @@ export interface FloatingPopoverProps {
   el: HTMLElement
   content: string | (() => VNode | undefined)
   gap?: number
+  placement?: 'top' | 'bottom' | 'left' | 'right'
 }
 
 const tooltip = shallowRef<FloatingPopoverProps | null>(null)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Change the opening direction based on the dock's edge.

The main changes are to the top and bottom directions.

before:
<img width="2502" height="1344" alt="屏幕截图_3-7-2026_213218_localhost" src="https://github.com/user-attachments/assets/daaf3c7b-88d0-4c0e-a40b-c433e5b69ed5" />

now:
<img width="2507" height="1347" alt="屏幕截图_3-7-2026_213148_localhost" src="https://github.com/user-attachments/assets/3b872ae7-db75-463c-a28f-1acbc2f24453" />



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
