### PR TITLE
perf(vite): use disk logs with in-memory metadata

### DIFF
--- a/docs/errors/VDT0003.md
+++ b/docs/errors/VDT0003.md
@@ -1,0 +1,27 @@
+---
+outline: deep
+---
+
+# VDT0003: Inspect Storage Error
+
+## Message
+
+> Vite inspect storage failed while `{operation}`.
+
+## Cause
+
+The Vite inspect collector encountered a payload or plugin-call archive initialization, batched write, read, or shutdown failure.
+
+## Example
+
+Starting the Vite DevTools Vite UI plugin with an unwritable Vite cache directory can trigger this error.
+
+## Fix
+
+Restart the Vite dev server. If the error persists, clear the Vite cache directory and reinstall dependencies.
+
+## Source
+
+- [`packages/vite/src/node/inspect/store/index.ts`](https://github.com/vitejs/devtools/blob/main/packages/vite/src/node/inspect/store/index.ts) — the inspect store emits this when archive setup, batched writes, reads, or shutdown fail.
+- [`packages/vite/src/node/inspect/store/payload.ts`](https://github.com/vitejs/devtools/blob/main/packages/vite/src/node/inspect/store/payload.ts) — the payload archive emits this when an in-memory or file-backed payload cannot be read or written completely.
+- [`packages/vite/src/node/inspect/store/plugin-calls.ts`](https://github.com/vitejs/devtools/blob/main/packages/vite/src/node/inspect/store/plugin-calls.ts) — the plugin-call archive emits this when a binary event cannot be encoded, read, or written completely.

--- a/docs/errors/index.md
+++ b/docs/errors/index.md
@@ -51,3 +51,4 @@ Emitted by `@vitejs/devtools-vite`.
 |------|-------|-------|
 | [VDT0001](./VDT0001) | error | Inspect Context Unavailable |
 | [VDT0002](./VDT0002) | error | Inspect Target Not Found |
+| [VDT0003](./VDT0003) | error | Inspect Storage Error |

--- a/packages/core/playground/vite.config.ts
+++ b/packages/core/playground/vite.config.ts
@@ -17,6 +17,7 @@ import { hideDockWhenEmpty } from '../../core/src/node/plugins/auto-hide'
 // eslint-disable-next-line ts/ban-ts-comment
 // @ts-ignore ignore the type error
 import { DevToolsRolldownUI } from '../../rolldown/src/node'
+import { DevToolsViteUI } from '../../vite/src/node'
 
 declare module '@vitejs/devtools-kit' {
   interface DevToolsRpcSharedStates {
@@ -74,6 +75,7 @@ export default defineConfig({
       builtinDevTools: false,
     }),
     DevToolsRolldownUI(),
+    DevToolsViteUI(),
     UnoCSS(),
     Tracer({
       viteDevtools: true,

--- a/packages/vite/src/app/components/data/PluginDetailsLoader.vue
+++ b/packages/vite/src/app/components/data/PluginDetailsLoader.vue
@@ -91,6 +91,12 @@ const parsedPaths = computed(() => props.modules.map((mod) => {
 }))
 const moduleTypes = computed(() => ModuleTypeRules.filter(rule => parsedPaths.value.some(mod => rule.match.test(mod.mod.id))))
 
+function getModuleGraphLink(moduleId: string | undefined): string | false {
+  return moduleId
+    ? `/graph?module=${encodeURIComponent(moduleId)}`
+    : false
+}
+
 const _tree = computed(() => {
   const map = new Map<string, TreeNodeInput<PluginChartInfo | undefined>>()
   const maxDepth = 3
@@ -338,7 +344,7 @@ watch(() => settings.value.pluginDetailsViewType, () => {
             :id="child.text!"
             w-full border-none ws-nowrap
             :cwd="root"
-            :link="`/graph?module=${encodeURIComponent(child.text!)}`"
+            :link="getModuleGraphLink(child.meta?.graphModuleId)"
             hover="bg-active"
             border="~ base rounded" block px2 py1
           />

--- a/packages/vite/src/app/components/data/PluginDetailsTable.vue
+++ b/packages/vite/src/app/components/data/PluginDetailsTable.vue
@@ -41,7 +41,6 @@ const moduleTypeNameMap = computed(() => {
 
   return map
 })
-
 const filterModuleTypes = ref<string[]>(settings.value.pluginDetailsModuleTypes ?? searchFilterTypes.value.map(item => item.name))
 const selectedModuleTypes = computed(() => new Set(filterModuleTypes.value))
 const { state: durationSortType, next } = useCycleList(['', 'desc', 'asc'], {
@@ -96,6 +95,12 @@ function toggleModuleType(rule: FilterMatchRule) {
 function toggleDurationSortType() {
   next()
   settings.value.pluginDetailsDurationSortType = durationSortType.value
+}
+
+function getModuleGraphLink(moduleId: string | undefined): string | false {
+  return moduleId
+    ? `/graph?module=${encodeURIComponent(moduleId)}`
+    : false
 }
 </script>
 
@@ -181,7 +186,7 @@ function toggleDurationSortType() {
             :id="item.module"
             w-full border-none ws-nowrap
             :cwd="root"
-            :link="`/graph?module=${encodeURIComponent(item.module)}`"
+            :link="getModuleGraphLink(item.graphModuleId)"
             hover="bg-active"
             border="~ base rounded" block px2 py1
           />

--- a/packages/vite/src/node/__tests__/inspect-context.test.ts
+++ b/packages/vite/src/node/__tests__/inspect-context.test.ts
@@ -1,13 +1,28 @@
 import type { Environment, Plugin, ResolvedConfig } from 'vite'
-import { describe, expect, it } from 'vitest'
+import type { ViteInspectStoreOptions } from '../inspect/store'
+import type { ViteInspectPluginCallInfo } from '../inspect/types'
+import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ViteInspectContext } from '../inspect/context'
 import { hijackPlugin } from '../inspect/hijack'
 
-function createFixture(options: {
+const contexts: ViteInspectContext[] = []
+
+afterEach(async () => {
+  await Promise.all(contexts.splice(0).map(ctx => ctx.close()))
+})
+
+async function createFixture(options: {
   root?: string
+  store?: ViteInspectStoreOptions
 } = {}) {
   const config = {
     root: options.root || '/project',
+    resolve: {
+      extensions: ['.js'],
+    },
     plugins: [
       { name: 'vite:load-fallback' },
       { name: 'plugin-a', enforce: 'pre' },
@@ -19,7 +34,8 @@ function createFixture(options: {
     mode: 'build',
     getTopLevelConfig: () => config,
   } as Environment
-  const ctx = new ViteInspectContext()
+  const ctx = await ViteInspectContext.create(options.store)
+  contexts.push(ctx)
   const vite = ctx.getViteContext(config)
   const envCtx = vite.getEnvContext(env)
 
@@ -31,9 +47,15 @@ function createFixture(options: {
   }
 }
 
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let index = 0; index < 1000 && !condition(); index++)
+    await new Promise(resolve => setImmediate(resolve))
+  expect(condition()).toBe(true)
+}
+
 describe('vite inspect context', () => {
-  it('records module transforms and normalizes version query by default', () => {
-    const { envCtx } = createFixture()
+  it('records module transforms and normalizes version query by default', async () => {
+    const { envCtx } = await createFixture()
 
     envCtx.recordTransform('/src/main.ts?v=123456', {
       name: 'plugin-a',
@@ -43,7 +65,7 @@ describe('vite inspect context', () => {
       order: 'pre',
     }, 'const value = 1')
 
-    const modules = envCtx.getModulesList()
+    const modules = await envCtx.getModulesList()
 
     expect(modules).toMatchObject([
       {
@@ -60,8 +82,8 @@ describe('vite inspect context', () => {
     ])
   })
 
-  it('records resolveId chains and plugin metrics', () => {
-    const { envCtx } = createFixture()
+  it('records resolveId chains and plugin metrics', async () => {
+    const { envCtx } = await createFixture()
 
     envCtx.recordResolveId('/src/main.ts', {
       name: 'plugin-a',
@@ -76,8 +98,8 @@ describe('vite inspect context', () => {
       end: 8,
     }, '')
 
-    expect(envCtx.resolveId('/src/main.ts')).toBe('/src/resolved.ts')
-    expect(envCtx.getPluginMetrics()).toEqual(expect.arrayContaining([
+    await expect(envCtx.resolveId('/src/main.ts')).resolves.toBe('/src/resolved.ts')
+    expect(await envCtx.getPluginMetrics()).toEqual(expect.arrayContaining([
       expect.objectContaining({
         name: 'plugin-a',
         resolveId: {
@@ -95,8 +117,8 @@ describe('vite inspect context', () => {
     ]))
   })
 
-  it('records plugin call details by plugin id', () => {
-    const { envCtx, vite } = createFixture()
+  it('records plugin call details by plugin id', async () => {
+    const { envCtx, vite } = await createFixture()
 
     const pluginA = vite.config.plugins[1]!
     const pluginB = vite.config.plugins[2]!
@@ -120,7 +142,7 @@ describe('vite inspect context', () => {
       end: 14,
     }, 'export const value = 1', pluginB)
 
-    expect(envCtx.getPluginDetails(1)).toMatchObject({
+    await expect(envCtx.getPluginDetails(1)).resolves.toMatchObject({
       plugin_name: 'plugin-a',
       plugin_id: 1,
       calls: [
@@ -151,7 +173,7 @@ describe('vite inspect context', () => {
       transformMetrics: [],
     })
 
-    expect(envCtx.getPluginDetails(2)).toMatchObject({
+    await expect(envCtx.getPluginDetails(2)).resolves.toMatchObject({
       plugin_name: 'plugin-b',
       transformMetrics: [
         expect.objectContaining({
@@ -163,8 +185,38 @@ describe('vite inspect context', () => {
     })
   })
 
-  it('clears module-related inspect data on invalidation', () => {
-    const { envCtx, vite } = createFixture()
+  it('maps plugin call modules to graph module ids', async () => {
+    const { envCtx, vite } = await createFixture()
+    const pluginA = vite.config.plugins[1]!
+
+    envCtx.recordResolveId('/src/main.ts', {
+      name: 'plugin-a',
+      result: '/src/resolved.js',
+      start: 0,
+      end: 1,
+    }, pluginA)
+    envCtx.recordResolveIdCall('/src/resolved', {
+      name: 'plugin-a',
+      start: 2,
+      end: 3,
+    }, pluginA)
+
+    await expect(envCtx.getPluginDetails(1)).resolves.toMatchObject({
+      calls: [
+        {
+          module: '/src/resolved.js',
+          graphModuleId: '/src/resolved.js',
+        },
+        {
+          module: '/src/resolved',
+          graphModuleId: '/src/resolved.js',
+        },
+      ],
+    })
+  })
+
+  it('clears module-related inspect data on invalidation', async () => {
+    const { envCtx, vite } = await createFixture()
 
     const pluginA = vite.config.plugins[1]!
     const pluginB = vite.config.plugins[2]!
@@ -196,13 +248,13 @@ describe('vite inspect context', () => {
 
     envCtx.invalidate('/src/resolved.ts')
 
-    expect(envCtx.data.transform['/src/resolved.ts']).toBeUndefined()
-    expect(envCtx.data.transformCounter['/src/resolved.ts']).toBeUndefined()
-    expect(envCtx.data.resolveId['/src/main.ts']).toBeUndefined()
-    expect(envCtx.getModulesList().map(module => module.id)).toEqual(['/src/other.ts'])
-    expect(envCtx.getPluginDetails(1).calls.map(call => call.module)).toEqual(['/src/other.ts'])
-    expect(envCtx.getPluginDetails(2).calls).toEqual([])
-    expect(envCtx.getPluginMetrics()).toEqual(expect.arrayContaining([
+    await expect(envCtx.getModuleTransformInfo('/src/resolved.ts')).resolves.toMatchObject({
+      transforms: [],
+    })
+    expect((await envCtx.getModulesList()).map(module => module.id)).toEqual(['/src/other.ts'])
+    expect((await envCtx.getPluginDetails(1)).calls.map(call => call.module)).toEqual(['/src/other.ts'])
+    expect((await envCtx.getPluginDetails(2)).calls).toEqual([])
+    expect(await envCtx.getPluginMetrics()).toEqual(expect.arrayContaining([
       expect.objectContaining({
         name: 'plugin-a',
         transform: {
@@ -217,8 +269,471 @@ describe('vite inspect context', () => {
     ]))
   })
 
+  it('clears environment inspect data for a full reload', async () => {
+    const { envCtx, vite } = await createFixture()
+
+    const pluginA = vite.config.plugins[1]!
+    envCtx.recordResolveId('/src/main.ts', {
+      name: 'plugin-a',
+      result: '/src/resolved.ts',
+      start: 0,
+      end: 4,
+    }, pluginA)
+    envCtx.recordTransform('/src/resolved.ts', {
+      name: 'plugin-a',
+      result: 'export const value = 1',
+      start: 5,
+      end: 8,
+    }, '', pluginA)
+
+    expect(await envCtx.getModulesList()).toHaveLength(1)
+
+    envCtx.clearScope()
+
+    expect(await envCtx.getModulesList()).toEqual([])
+    expect((await envCtx.getPluginMetrics()).every((metric) => {
+      return metric.transform.invokeCount === 0 && metric.resolveId.invokeCount === 0
+    })).toBe(true)
+    await expect(envCtx.getModuleTransformInfo('/src/resolved.ts')).resolves.toMatchObject({
+      transforms: [],
+    })
+  })
+
+  it('supports file-backed inspect storage', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vite-inspect-'))
+    const storageDir = join(dir, 'inspect')
+    const filename = join(storageDir, 'payloads.bin')
+    const pluginCallsFilename = join(storageDir, 'plugin-calls.bin')
+    const ctx = await ViteInspectContext.create({
+      filename,
+    })
+    contexts.push(ctx)
+    const vite = ctx.getViteContext({
+      root: '/project',
+      plugins: [
+        { name: 'plugin-a' },
+      ],
+    } as ResolvedConfig)
+    const env = {
+      name: 'client',
+      mode: 'build',
+      getTopLevelConfig: () => vite.config,
+    } as Environment
+    const envCtx = vite.getEnvContext(env)
+    const result = `export const value = '${'café'.repeat(4096)}'`
+    const source = `const value = '${'source'.repeat(4096)}'`
+    const sourcemaps = {
+      version: 3,
+      sources: ['/src/main.ts'],
+      sourcesContent: [source],
+      mappings: 'AAAA;'.repeat(4096),
+    }
+
+    envCtx.recordTransform('/src/main.ts', {
+      name: 'plugin-a',
+      result,
+      start: 0,
+      end: 1,
+      sourcemaps,
+    }, source)
+    expect(await envCtx.getModulesList()).toHaveLength(1)
+    await expect(envCtx.getModuleTransformInfo('/src/main.ts')).resolves.toEqual({
+      resolvedId: '/src/main.ts',
+      transforms: [
+        {
+          name: '__load__',
+          result: source,
+          start: 0,
+          end: 0,
+          sourcemaps,
+        },
+        {
+          name: 'plugin-a',
+          plugin_id: 0,
+          result,
+          start: 0,
+          end: 1,
+          sourcemaps,
+        },
+      ],
+    })
+    await expect(envCtx.getPluginDetails(0)).resolves.toMatchObject({
+      calls: [
+        {
+          id: 'transform:0:0',
+          type: 'transform',
+          plugin_id: 0,
+          plugin_name: 'plugin-a',
+          module: '/src/main.ts',
+          duration: 1,
+          unchanged: false,
+        },
+      ],
+    })
+    expect(existsSync(pluginCallsFilename)).toBe(true)
+    expect(statSync(pluginCallsFilename).size).toBe(48)
+
+    await ctx.close()
+
+    expect(existsSync(filename)).toBe(true)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('serializes each sourcemap once before writing its payload', async () => {
+    const { ctx, envCtx, vite } = await createFixture()
+    const toJSON = vi.fn(() => ({
+      version: 3,
+      mappings: 'AAAA',
+    }))
+
+    envCtx.recordTransform('/src/serialized.ts', {
+      name: 'plugin-a',
+      result: 'export const serialized = true',
+      start: 0,
+      end: 1,
+      sourcemaps: { toJSON },
+    }, 'const serialized = true', vite.config.plugins[1])
+
+    await ctx.store.flush()
+    expect(toJSON).toHaveBeenCalledOnce()
+    await expect(envCtx.getModuleTransformInfo('/src/serialized.ts')).resolves.toMatchObject({
+      transforms: [
+        { sourcemaps: { version: 3, mappings: 'AAAA' } },
+        { sourcemaps: { version: 3, mappings: 'AAAA' } },
+      ],
+    })
+    expect(toJSON).toHaveBeenCalledOnce()
+  })
+
+  it('reuses released file payload ranges after invalidation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vite-inspect-reuse-'))
+    const filename = join(dir, 'payloads.bin')
+    const { ctx, envCtx, vite } = await createFixture({
+      store: {
+        filename,
+      },
+    })
+    const recordTransform = async () => {
+      await envCtx.recordTransform('/src/reused.ts', {
+        name: 'plugin-a',
+        result: `export const value = '${'result'.repeat(4096)}'`,
+        start: 0,
+        end: 1,
+        sourcemaps: {
+          version: 3,
+          mappings: 'AAAA;'.repeat(4096),
+        },
+      }, `const value = '${'source'.repeat(4096)}'`, vite.config.plugins[1])
+      await ctx.store.flush()
+    }
+
+    await recordTransform()
+    const initialSize = statSync(filename).size
+
+    for (let cycle = 0; cycle < 5; cycle++) {
+      envCtx.invalidate('/src/reused.ts')
+      await ctx.store.flush()
+      await recordTransform()
+      expect(statSync(filename).size).toBe(initialSize)
+    }
+
+    await ctx.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reuses plugin call slots after invalidation and scope clearing', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vite-inspect-call-reuse-'))
+    const filename = join(dir, 'payloads.bin')
+    const pluginCallsFilename = join(dir, 'plugin-calls.bin')
+    const { ctx, envCtx, vite } = await createFixture({
+      store: {
+        filename,
+        maxBatchItems: 16,
+      },
+    })
+    const plugin = vite.config.plugins[1]!
+    const recordCalls = async (start: number) => {
+      for (let index = 0; index < 64; index++) {
+        envCtx.recordLoadCall('/src/reused.ts', {
+          name: 'plugin-a',
+          start: start + index,
+          end: start + index + 1,
+        }, plugin)
+      }
+      await ctx.store.flush()
+    }
+
+    await recordCalls(0)
+    const initialSize = statSync(pluginCallsFilename).size
+    expect(initialSize).toBe(64 * 48)
+    expect((await envCtx.getPluginDetails(1)).calls).toHaveLength(64)
+
+    envCtx.invalidate('/src/reused.ts')
+    await ctx.store.flush()
+    expect((await envCtx.getPluginDetails(1)).calls).toEqual([])
+
+    await recordCalls(100)
+    expect(statSync(pluginCallsFilename).size).toBe(initialSize)
+    expect((await envCtx.getPluginDetails(1)).calls).toHaveLength(64)
+
+    envCtx.clearScope()
+    await ctx.store.flush()
+    expect((await envCtx.getPluginDetails(1)).calls).toEqual([])
+
+    await recordCalls(200)
+    expect(statSync(pluginCallsFilename).size).toBe(initialSize)
+    expect((await envCtx.getPluginDetails(1)).calls).toHaveLength(64)
+
+    await ctx.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('writes queued records in bounded batches without dropping them', async () => {
+    const { ctx, envCtx, vite } = await createFixture({
+      store: {
+        maxBatchItems: 2,
+      },
+    })
+    for (let index = 0; index < 5; index++) {
+      envCtx.recordTransform(`/src/module-${index}.ts`, {
+        name: 'plugin-a',
+        result: `export const value = ${index}`,
+        start: index,
+        end: index + 1,
+      }, `const value = ${index}`, vite.config.plugins[1])
+    }
+
+    expect(ctx.store.getStats()).toMatchObject({
+      maxBatchItems: 2,
+      queuedItems: 5,
+      peakQueuedItems: 5,
+    })
+    await ctx.store.flush()
+    expect(ctx.store.getStats()).toMatchObject({
+      queuedItems: 0,
+      inFlightItems: 0,
+      writeBatches: 3,
+    })
+    expect(await envCtx.getModulesList()).toHaveLength(5)
+  })
+
+  it('does not delay concurrent plugin hooks while writes are queued', async () => {
+    const { ctx, env, envCtx, vite } = await createFixture({
+      store: {
+        maxBatchItems: 1,
+      },
+    })
+    const plugin = vite.config.plugins[1]! as Plugin & {
+      transform: NonNullable<Plugin['transform']>
+    }
+    const hookResolvers: Array<() => void> = []
+    let startedHooks = 0
+
+    plugin.transform = async (code) => {
+      startedHooks += 1
+      await new Promise<void>(resolve => hookResolvers.push(resolve))
+      return {
+        code: `${code}\n// transformed ${startedHooks}`,
+        map: {
+          version: 3,
+          mappings: '',
+        },
+      }
+    }
+    hijackPlugin(plugin, ctx)
+
+    const calls = Array.from({ length: 4 }, (_, index) => {
+      return (plugin.transform as any).call(
+        { environment: env },
+        `export const value = ${index}`,
+        `/src/module-${index}.ts`,
+      )
+    })
+
+    await waitFor(() => startedHooks === 4)
+    expect(startedHooks).toBe(4)
+    hookResolvers.splice(0).forEach(resolve => resolve())
+    await Promise.all(calls)
+    await ctx.store.flush()
+
+    expect(ctx.store.getStats()).toMatchObject({
+      queuedItems: 0,
+      inFlightItems: 0,
+      writeBatches: 4,
+    })
+    expect(await envCtx.getModulesList()).toHaveLength(4)
+  })
+
+  it('preserves plugin results after inspect storage closes', async () => {
+    const { ctx, env, vite } = await createFixture()
+    const plugin = vite.config.plugins[1]! as Plugin & {
+      transform: NonNullable<Plugin['transform']>
+    }
+    plugin.transform = code => `${code}\n// transformed`
+    hijackPlugin(plugin, ctx)
+    await ctx.close()
+
+    await expect((plugin.transform as any).call(
+      { environment: env },
+      'export const value = 1',
+      '/src/module.ts',
+    )).resolves.toBe('export const value = 1\n// transformed')
+  })
+
+  it('persists an oversized record without truncating it', async () => {
+    const { ctx, envCtx, vite } = await createFixture({
+      store: {
+        maxBatchBytes: 64,
+      },
+    })
+
+    envCtx.recordTransform('/src/large.ts', {
+      name: 'plugin-a',
+      result: 'x'.repeat(1024),
+      start: 0,
+      end: 1,
+    }, 'y'.repeat(1024), vite.config.plugins[1])
+
+    await ctx.store.flush()
+
+    expect(ctx.store.getStats()).toMatchObject({
+      queuedItems: 0,
+      inFlightItems: 0,
+    })
+    expect(ctx.store.getStats().peakQueuedBytes).toBeGreaterThanOrEqual(4096)
+    expect(await envCtx.getModulesList()).toHaveLength(1)
+    await expect(envCtx.getModuleTransformInfo('/src/large.ts')).resolves.toMatchObject({
+      transforms: [
+        { result: 'y'.repeat(1024) },
+        { result: 'x'.repeat(1024) },
+      ],
+    })
+  })
+
+  it('applies invalidation in enqueue order', async () => {
+    const { ctx, envCtx, vite } = await createFixture({
+      store: {
+        maxBatchItems: 1,
+      },
+    })
+    envCtx.recordTransform('/src/stale.ts', {
+      name: 'plugin-a',
+      result: 'export const stale = true',
+      start: 0,
+      end: 1,
+    }, 'const stale = true', vite.config.plugins[1])
+    envCtx.invalidate('/src/stale.ts')
+
+    await ctx.store.flush()
+
+    await expect(envCtx.getModuleTransformInfo('/src/stale.ts')).resolves.toMatchObject({
+      transforms: [],
+    })
+  })
+
+  it('preserves invalidation while payload writes are queued', async () => {
+    const { ctx, envCtx, vite } = await createFixture({
+      store: {
+        maxBatchItems: 1,
+      },
+    })
+
+    envCtx.recordTransform('/src/stale.ts', {
+      name: 'plugin-a',
+      result: 'export const stale = true',
+      start: 0,
+      end: 1,
+    }, 'const stale = true', vite.config.plugins[1])
+    envCtx.invalidate('/src/stale.ts')
+    await ctx.store.flush()
+
+    expect(ctx.store.getStats()).toMatchObject({
+      queuedItems: 0,
+      inFlightItems: 0,
+    })
+    await expect(envCtx.getModuleTransformInfo('/src/stale.ts')).resolves.toMatchObject({
+      transforms: [],
+    })
+  })
+
+  it.runIf(typeof globalThis.gc === 'function')('releases full payloads after persistence', async () => {
+    const { ctx, envCtx, vite } = await createFixture({
+      store: {
+        maxBatchItems: 1,
+      },
+    })
+    let sourcemapRef: WeakRef<object> | undefined
+
+    await (async () => {
+      const sourcemaps = {
+        version: 3,
+        mappings: 'x'.repeat(8 * 1024 * 1024),
+      }
+      sourcemapRef = new WeakRef(sourcemaps)
+      await envCtx.recordTransform('/src/retained.ts', {
+        name: 'plugin-a',
+        result: 'export const retained = true',
+        start: 0,
+        end: 1,
+        sourcemaps,
+      }, 'const retained = true', vite.config.plugins[1]!)
+    })()
+
+    await ctx.store.flush()
+    for (let index = 0; index < 4; index++) {
+      globalThis.gc!()
+      await new Promise(resolve => setImmediate(resolve))
+    }
+
+    expect(sourcemapRef?.deref()).toBeUndefined()
+    expect(ctx.store.getStats()).toMatchObject({
+      queuedItems: 0,
+      inFlightItems: 0,
+    })
+  })
+
+  it.runIf(typeof globalThis.gc === 'function')('releases plugin call objects after persistence', async () => {
+    const { ctx, envCtx } = await createFixture({
+      store: {
+        maxBatchItems: 1,
+      },
+    })
+    let callRef: WeakRef<ViteInspectPluginCallInfo> | undefined
+
+    await (async () => {
+      const call: ViteInspectPluginCallInfo = {
+        type: 'transform',
+        id: 'transform:1:0',
+        duration: 1,
+        plugin_id: 1,
+        plugin_name: 'plugin-a',
+        module: '/src/retained.ts',
+        timestamp_start: 0,
+        timestamp_end: 1,
+        unchanged: false,
+      }
+      callRef = new WeakRef(call)
+      ctx.store.recordPluginCall(envCtx.scope, call)
+    })()
+
+    await ctx.store.flush()
+    for (let index = 0; index < 4; index++) {
+      globalThis.gc!()
+      await new Promise(resolve => setImmediate(resolve))
+    }
+
+    expect(callRef?.deref()).toBeUndefined()
+    await expect(ctx.store.getPluginCalls(envCtx.scope, 1)).resolves.toMatchObject([
+      {
+        id: 'transform:1:0',
+        plugin_name: 'plugin-a',
+        module: '/src/retained.ts',
+      },
+    ])
+  })
+
   it('records empty string load results as load output', async () => {
-    const { ctx, env, envCtx, vite } = createFixture()
+    const { ctx, env, envCtx, vite } = await createFixture()
     const plugin = vite.config.plugins[1]! as Plugin & {
       load: NonNullable<Plugin['load']>
     }
@@ -227,7 +742,7 @@ describe('vite inspect context', () => {
     hijackPlugin(plugin, ctx)
     await (plugin.load as any).call({ environment: env }, '/src/empty.ts')
 
-    expect(envCtx.getPluginDetails(1)).toMatchObject({
+    await expect(envCtx.getPluginDetails(1)).resolves.toMatchObject({
       loadMetrics: [
         {
           type: 'load',
@@ -249,7 +764,7 @@ describe('vite inspect context', () => {
   })
 
   it('keeps empty string transform results in module metrics', async () => {
-    const { envCtx, vite } = createFixture()
+    const { envCtx, vite } = await createFixture()
     const pluginA = vite.config.plugins[1]!
     const pluginB = vite.config.plugins[2]!
 
@@ -266,7 +781,7 @@ describe('vite inspect context', () => {
       end: 8,
     }, '', pluginB)
 
-    expect(envCtx.getModulesList()).toMatchObject([
+    expect(await envCtx.getModulesList()).toMatchObject([
       {
         id: '/src/empty.ts',
         plugins: [
@@ -292,7 +807,7 @@ describe('vite inspect context', () => {
     })
   })
 
-  it('keeps same-name plugin metrics separated by plugin id', () => {
+  it('keeps same-name plugin metrics separated by plugin id', async () => {
     const config = {
       root: '/project',
       plugins: [
@@ -305,7 +820,8 @@ describe('vite inspect context', () => {
       mode: 'build',
       getTopLevelConfig: () => config,
     } as Environment
-    const ctx = new ViteInspectContext()
+    const ctx = await ViteInspectContext.create()
+    contexts.push(ctx)
     const envCtx = ctx.getViteContext(config).getEnvContext(env)
 
     envCtx.recordTransform('/src/a.ts', {
@@ -321,7 +837,7 @@ describe('vite inspect context', () => {
       end: 9,
     }, '', config.plugins[1])
 
-    expect(envCtx.getPluginMetrics().filter(metric => metric.name === 'plugin-a')).toMatchObject([
+    expect((await envCtx.getPluginMetrics()).filter(metric => metric.name === 'plugin-a')).toMatchObject([
       {
         plugin_id: 0,
         transform: {
@@ -340,7 +856,7 @@ describe('vite inspect context', () => {
   })
 
   it('normalizes absolute node_modules ids relative to project root', async () => {
-    const { envCtx } = createFixture({
+    const { envCtx } = await createFixture({
       root: '/workspace/packages/vite',
     })
     const rawId = '/workspace/node_modules/.pnpm/unhead@1.0.0/node_modules/unhead/dist/index.mjs'
@@ -353,7 +869,7 @@ describe('vite inspect context', () => {
       order: 'pre',
     }, 'const head = {}')
 
-    const modules = envCtx.getModulesList()
+    const modules = await envCtx.getModulesList()
 
     expect(modules[0]?.id).toBe('../../node_modules/.pnpm/unhead@1.0.0/node_modules/unhead/dist/index.mjs')
     await expect(envCtx.getModuleTransformInfo(modules[0]!.id)).resolves.toMatchObject({
@@ -365,8 +881,8 @@ describe('vite inspect context', () => {
     })
   })
 
-  it('exposes metadata for vite instances and environments', () => {
-    const { ctx, vite } = createFixture()
+  it('exposes metadata for vite instances and environments', async () => {
+    const { ctx, vite } = await createFixture()
 
     expect(ctx.getMetadata()).toMatchObject({
       instances: [

--- a/packages/vite/src/node/__tests__/inspect-plugin.test.ts
+++ b/packages/vite/src/node/__tests__/inspect-plugin.test.ts
@@ -1,11 +1,18 @@
 import type { Plugin, ResolvedConfig } from 'vite'
-import { describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
 import { createDevToolsContext } from '../../../../core/src/node/context'
+import { getViteInspectContext } from '../inspect/context'
 import { DevToolsViteInspect } from '../inspect/plugin'
 
-function createConfig(plugin: Plugin, command: 'serve' | 'build'): ResolvedConfig {
+function createConfig(plugin: Plugin, command: 'serve' | 'build', options: {
+  cacheDir?: string
+} = {}): ResolvedConfig {
   return {
     root: process.cwd(),
+    cacheDir: options.cacheDir,
     command,
     plugins: [plugin],
     environments: {
@@ -15,28 +22,63 @@ function createConfig(plugin: Plugin, command: 'serve' | 'build'): ResolvedConfi
   } as unknown as ResolvedConfig
 }
 
-async function createContext(command: 'serve' | 'build') {
+async function createContext(command: 'serve' | 'build', options: {
+  cacheDir?: string
+} = {}) {
   const plugin = DevToolsViteInspect()
-  const config = createConfig(plugin, command)
+  const config = createConfig(plugin, command, options)
 
   await (plugin.configResolved as (config: ResolvedConfig) => void | Promise<void>)(config)
+  const ctx = await createDevToolsContext(config)
 
-  return createDevToolsContext(config)
+  return { ctx, plugin }
+}
+
+async function closePlugin(plugin: Plugin) {
+  await (plugin.closeBundle as (() => void | Promise<void>) | undefined)?.()
 }
 
 describe('devToolsViteInspect', () => {
   it('registers inspect RPC in dev mode', async () => {
-    const ctx = await createContext('serve')
+    const { ctx, plugin } = await createContext('serve')
 
-    expect(ctx.rpc.definitions.has('vite:inspect:get-metadata')).toBe(true)
-    expect(ctx.rpc.definitions.has('vite:inspect:get-modules-list')).toBe(true)
-    expect(ctx.rpc.definitions.has('vite:inspect:get-plugin-details')).toBe(true)
+    try {
+      expect(ctx.rpc.definitions.has('vite:inspect:get-metadata')).toBe(true)
+      expect(ctx.rpc.definitions.has('vite:inspect:get-modules-list')).toBe(true)
+      expect(ctx.rpc.definitions.has('vite:inspect:get-plugin-details')).toBe(true)
+    }
+    finally {
+      await closePlugin(plugin)
+    }
   })
 
   it('keeps inspect RPC disabled in build mode', async () => {
-    const ctx = await createContext('build')
+    const { ctx } = await createContext('build')
 
     expect(ctx.rpc.definitions.has('vite:meta-info')).toBe(true)
     expect(ctx.rpc.definitions.has('vite:inspect:get-metadata')).toBe(false)
+  })
+
+  it('closes inspect storage from the plugin lifecycle', async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), 'vite-inspect-plugin-'))
+    const storageDir = join(cacheDir, 'devtools', 'inspect')
+    const { ctx, plugin } = await createContext('serve', { cacheDir })
+
+    try {
+      const inspectContext = getViteInspectContext(ctx)
+      const close = vi.spyOn(inspectContext, 'close')
+
+      expect(existsSync(storageDir)).toBe(true)
+
+      await closePlugin(plugin)
+      await closePlugin(plugin)
+
+      expect(close).toHaveBeenCalledTimes(1)
+      expect(existsSync(storageDir)).toBe(false)
+    }
+    finally {
+      await closePlugin(plugin)
+      rmSync(cacheDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/vite/src/node/__tests__/inspect-server.test.ts
+++ b/packages/vite/src/node/__tests__/inspect-server.test.ts
@@ -1,0 +1,335 @@
+import type { Environment, Plugin, ViteDevServer } from 'vite'
+import type { ViteInspectEnvironmentContext } from '../inspect/context'
+import type { ViteInspectStoreOptions } from '../inspect/store'
+import { createServer } from 'vite'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ViteInspectContext } from '../inspect/context'
+import { hijackPlugin } from '../inspect/hijack'
+import { setupEnvironmentInvalidation, trackTransformRequestId } from '../inspect/server'
+
+interface InspectServerFixture {
+  server: ViteDevServer
+  inspectContext: ViteInspectContext
+  env: Environment
+  envContext: ViteInspectEnvironmentContext
+}
+
+const fixtures: InspectServerFixture[] = []
+
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map(async ({ server, inspectContext }) => {
+    await server.close()
+    await inspectContext.close()
+  }))
+})
+
+async function createInspectServer(
+  source: Map<string, string>,
+  plugins: Plugin[] = [],
+  storeOptions: ViteInspectStoreOptions = {},
+): Promise<InspectServerFixture> {
+  let inspectContext: ViteInspectContext | undefined
+  const inspectProbe: Plugin = {
+    name: 'test:inspect-probe',
+    enforce: 'pre',
+    async configResolved(config) {
+      inspectContext = await ViteInspectContext.create(storeOptions)
+      config.plugins.forEach(plugin => hijackPlugin(plugin, inspectContext!))
+    },
+    configureServer(server) {
+      const vite = inspectContext!.getViteContext(server.config)
+      Object.values(server.environments).forEach(env => vite.getEnvContext(env))
+      setupEnvironmentInvalidation(server, vite)
+    },
+  }
+  const virtualPlugin: Plugin = {
+    name: 'test:virtual-modules',
+    resolveId(id) {
+      if (source.has(id))
+        return id
+    },
+    load(id) {
+      return source.get(id)
+    },
+  }
+  const server = await createServer({
+    root: process.cwd(),
+    configFile: false,
+    logLevel: 'silent',
+    appType: 'custom',
+    server: {
+      middlewareMode: true,
+      fs: {
+        strict: false,
+      },
+    },
+    plugins: [inspectProbe, virtualPlugin, ...plugins],
+  })
+  const env = server.environments.client
+  const context = inspectContext!
+  const envContext = context.getViteContext(server.config).getEnvContext(env)
+  const fixture = {
+    server,
+    inspectContext: context,
+    env,
+    envContext,
+  }
+  fixtures.push(fixture)
+  return fixture
+}
+
+describe('vite inspect server invalidation', () => {
+  it('completes Vite transforms without waiting for payload persistence', async () => {
+    const source = new Map([
+      ['/entry.js', 'export const entry = 1'],
+    ])
+    const { server, inspectContext, envContext } = await createInspectServer(source, [], {
+      maxBatchItems: 1,
+      maxBatchBytes: 1,
+    })
+
+    let timeoutId: NodeJS.Timeout | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(new Error('Vite transform was blocked by inspect storage')), 1000)
+    })
+    try {
+      await expect(Promise.race([
+        server.transformRequest('/entry.js'),
+        timeout,
+      ])).resolves.toMatchObject({
+        code: 'export const entry = 1',
+      })
+    }
+    finally {
+      clearTimeout(timeoutId)
+    }
+
+    await inspectContext.store.flush()
+    expect(inspectContext.store.getStats()).toMatchObject({
+      queuedItems: 0,
+      inFlightItems: 0,
+    })
+    const transformInfo = await envContext.getModuleTransformInfo('/entry.js')
+    expect(transformInfo.transforms).toEqual(expect.arrayContaining([
+      expect.objectContaining({ result: 'export const entry = 1' }),
+    ]))
+  })
+
+  it('keeps soft-invalidated importer data when Vite reuses its transform result', async () => {
+    const source = new Map([
+      ['/leaf.js', 'export const leaf = 1'],
+      ['/importer.js', 'import { leaf } from "/leaf.js"; export const importer = leaf'],
+    ])
+    let transformCalls = 0
+    const counter: Plugin = {
+      name: 'test:transform-counter',
+      transform(_code, id) {
+        if (source.has(id))
+          transformCalls += 1
+        return null
+      },
+    }
+    const { server, env, envContext } = await createInspectServer(source, [counter])
+
+    await server.transformRequest('/leaf.js')
+    await server.transformRequest('/importer.js')
+    const initialTransforms = (await envContext.getModuleTransformInfo('/importer.js')).transforms
+    expect(initialTransforms.length).toBeGreaterThan(0)
+    expect(transformCalls).toBe(2)
+
+    const leaf = env.moduleGraph.getModuleById('/leaf.js')
+    const importer = env.moduleGraph.getModuleById('/importer.js')
+    expect(leaf).toBeDefined()
+    expect(importer).toBeDefined()
+    env.moduleGraph.invalidateModule(leaf!, new Set(), Date.now(), true)
+
+    expect(importer!.invalidationState).not.toBe('HARD_INVALIDATED')
+    await expect(envContext.getModuleTransformInfo('/leaf.js')).resolves.toMatchObject({
+      transforms: [],
+    })
+    await expect(envContext.getModuleTransformInfo('/importer.js')).resolves.toMatchObject({
+      transforms: initialTransforms,
+    })
+
+    await server.transformRequest('/importer.js')
+
+    expect(transformCalls).toBe(2)
+    expect(importer!.transformResult).toBeTruthy()
+    await expect(envContext.getModuleTransformInfo('/importer.js')).resolves.toMatchObject({
+      transforms: initialTransforms,
+    })
+  })
+
+  it('keeps inspect data across a full reload when Vite retains its transform cache', async () => {
+    const source = new Map([
+      ['/entry.js', 'export const entry = 1'],
+    ])
+    let transformCalls = 0
+    const counter: Plugin = {
+      name: 'test:transform-counter',
+      transform(_code, id) {
+        if (source.has(id))
+          transformCalls += 1
+        return null
+      },
+    }
+    const { server, env, envContext } = await createInspectServer(source, [counter])
+
+    await server.transformRequest('/entry.js')
+    const initialTransforms = (await envContext.getModuleTransformInfo('/entry.js')).transforms
+    const clearScope = vi.spyOn(envContext, 'clearScope')
+    expect(initialTransforms.length).toBeGreaterThan(0)
+
+    env.hot.send({ type: 'full-reload', path: '/' })
+
+    expect(env.hot).toBe(server.ws)
+    expect(clearScope).not.toHaveBeenCalled()
+    await expect(envContext.getModuleTransformInfo('/entry.js')).resolves.toMatchObject({
+      transforms: initialTransforms,
+    })
+
+    await server.transformRequest('/entry.js')
+
+    expect(transformCalls).toBe(1)
+    await expect(envContext.getModuleTransformInfo('/entry.js')).resolves.toMatchObject({
+      transforms: initialTransforms,
+    })
+  })
+
+  it('observes each hard-invalidated module once in a diamond graph', async () => {
+    const source = new Map([
+      ['virtual:leaf', 'export const leaf = 1'],
+      ['virtual:left', 'import { leaf } from "virtual:leaf"; export const left = leaf'],
+      ['virtual:right', 'import { leaf } from "virtual:leaf"; export const right = leaf'],
+      ['virtual:root', 'import { left } from "virtual:left"; import { right } from "virtual:right"; export const root = left + right'],
+    ])
+    const virtualIds = new Map(Array.from(source, ([id, code]) => [`\0${id}`, code]))
+    const resolver: Plugin = {
+      name: 'test:virtual-id-resolver',
+      resolveId(id) {
+        if (source.has(id))
+          return `\0${id}`
+      },
+      load(id) {
+        return virtualIds.get(id)
+      },
+    }
+    const { server, env, envContext } = await createInspectServer(new Map(), [resolver])
+    for (const id of source.keys())
+      await server.transformRequest(id)
+
+    const invalidate = vi.spyOn(envContext, 'invalidate')
+    const leaf = env.moduleGraph.getModuleById('\0virtual:leaf')
+    expect(leaf).toBeDefined()
+
+    env.moduleGraph.invalidateModule(leaf!)
+
+    const invalidatedIds = invalidate.mock.calls.map(([id]) => id)
+    expect(invalidatedIds).toHaveLength(4)
+    expect(new Set(invalidatedIds)).toEqual(new Set([
+      '\0virtual:leaf',
+      '\0virtual:left',
+      '\0virtual:right',
+      '\0virtual:root',
+    ]))
+  })
+
+  it('applies invalidation after an older in-flight transform write', async () => {
+    const source = new Map([
+      ['/entry.js', 'export const entry = 1'],
+    ])
+    let resolveTransformStarted!: () => void
+    let releaseTransform!: () => void
+    const transformStarted = new Promise<void>((resolve) => {
+      resolveTransformStarted = resolve
+    })
+    const transformGate = new Promise<void>((resolve) => {
+      releaseTransform = resolve
+    })
+    const blockedTransform: Plugin = {
+      name: 'test:blocked-transform',
+      async transform(code, id) {
+        if (!source.has(id))
+          return null
+        resolveTransformStarted()
+        await transformGate
+        return `${code}\nexport const finished = true`
+      },
+    }
+    const { server, env, envContext } = await createInspectServer(source, [blockedTransform])
+
+    const request = server.transformRequest('/entry.js')
+    await transformStarted
+    const entry = env.moduleGraph.getModuleById('/entry.js')
+    expect(entry).toBeDefined()
+
+    env.moduleGraph.invalidateModule(entry!)
+    releaseTransform()
+    await request
+
+    expect(entry!.transformResult).toBeNull()
+    await expect(envContext.getModuleTransformInfo('/entry.js')).resolves.toMatchObject({
+      transforms: [],
+    })
+  })
+
+  it('invalidates inspect data once for an explicit module clear', async () => {
+    const source = new Map([
+      ['/entry.js', 'export const entry = 1'],
+    ])
+    const { server, envContext } = await createInspectServer(source)
+    await server.transformRequest('/entry.js')
+    const invalidate = vi.spyOn(envContext, 'invalidate')
+
+    await envContext.clearId('/entry.js')
+
+    expect(invalidate).toHaveBeenCalledTimes(1)
+    expect(invalidate).toHaveBeenCalledWith('/entry.js')
+    await expect(envContext.getModuleTransformInfo('/entry.js')).resolves.toMatchObject({
+      transforms: [],
+    })
+  })
+
+  it('detaches completed transform requests from inherited async contexts', async () => {
+    const source = new Map([
+      ['/entry.js', 'export const entry = 1'],
+    ])
+    let releaseBackground!: () => void
+    let resolveBackground!: () => void
+    let request: ReturnType<typeof trackTransformRequestId>
+    let lateRequest: ReturnType<typeof trackTransformRequestId>
+    const backgroundGate = new Promise<void>((resolve) => {
+      releaseBackground = resolve
+    })
+    const backgroundDone = new Promise<void>((resolve) => {
+      resolveBackground = resolve
+    })
+    const backgroundPlugin: Plugin = {
+      name: 'test:background-context',
+      transform(_code, id) {
+        if (!source.has(id))
+          return null
+        request = trackTransformRequestId(id)
+        void backgroundGate.then(() => {
+          lateRequest = trackTransformRequestId('/late.js')
+          resolveBackground()
+        })
+        return null
+      },
+    }
+    const { server } = await createInspectServer(source, [backgroundPlugin])
+
+    await server.transformRequest('/entry.js')
+
+    expect(request).toMatchObject({
+      active: false,
+      stale: false,
+    })
+    expect(request?.ids.size).toBe(0)
+
+    releaseBackground()
+    await backgroundDone
+
+    expect(lateRequest).toBeUndefined()
+  })
+})

--- a/packages/vite/src/node/diagnostics.ts
+++ b/packages/vite/src/node/diagnostics.ts
@@ -10,5 +10,9 @@ export const diagnostics = /* #__PURE__ */ defineDiagnostics({
     VDT0002: {
       why: (p: { target: string, id: string }) => `Vite inspect target "${p.id}" was not found in ${p.target}.`,
     },
+    VDT0003: {
+      why: (p: { operation: string }) => `Vite inspect storage failed while ${p.operation}.`,
+      fix: 'Restart the Vite dev server. If the error persists, clear the Vite cache directory and reinstall dependencies.',
+    },
   },
 })

--- a/packages/vite/src/node/inspect/context.ts
+++ b/packages/vite/src/node/inspect/context.ts
@@ -4,9 +4,13 @@ import type {
   Plugin,
   ResolvedConfig,
 } from 'vite'
+import type { ModuleInfoProvider } from './module'
+import type {
+  ViteInspectStore,
+  ViteInspectStoreOptions,
+} from './store'
 import type {
   ViteInspectModuleInfo,
-  ViteInspectModulePluginMetric,
   ViteInspectModuleTransformInfo,
   ViteInspectPluginCallInfo,
   ViteInspectPluginDetails,
@@ -20,21 +24,21 @@ import { resolve } from 'node:path'
 import { createFilter } from 'vite'
 import { diagnostics } from '../diagnostics'
 import {
-  DUMMY_LOAD_PLUGIN_NAME,
-  getUtf8Size,
+  getModulesList as getEnvironmentModulesList,
+  getModuleTransformInfo as getEnvironmentModuleTransformInfo,
+} from './module'
+import {
+  getPluginDetails as getEnvironmentPluginDetails,
+  getPluginMetrics as getEnvironmentPluginMetrics,
+} from './plugins'
+import { createViteInspectStore } from './store'
+import {
   normalizeModuleId,
   removeVersionQuery,
   serializePlugin,
 } from './utils'
 
 let viteCount = 0
-
-interface ModuleInfoProvider {
-  getModuleInfo: (id: string) => {
-    importedIds?: readonly string[]
-    importers?: readonly string[]
-  } | null | undefined
-}
 
 const contextMap = new WeakMap<ViteDevToolsNodeContext, ViteInspectContext>()
 
@@ -53,6 +57,16 @@ export class ViteInspectContext {
   readonly filter = createFilter()
   readonly configToInstances = new Map<ResolvedConfig, ViteInspectViteContext>()
   readonly idToInstances = new Map<string, ViteInspectViteContext>()
+
+  static async create(options: ViteInspectStoreOptions = {}): Promise<ViteInspectContext> {
+    return new ViteInspectContext(await createViteInspectStore(options))
+  }
+
+  constructor(readonly store: ViteInspectStore) {}
+
+  async close(): Promise<void> {
+    await this.store.close()
+  }
 
   getMetadata() {
     return {
@@ -148,184 +162,144 @@ export class ViteInspectViteContext {
 }
 
 export class ViteInspectEnvironmentContext {
-  readonly data: {
-    transform: Record<string, ViteInspectTransformInfo[]>
-    resolveId: Record<string, ViteInspectResolveIdInfo[]>
-    pluginCalls: Record<number, ViteInspectPluginCallInfo[]>
-    transformCounter: Record<string, number>
-  } = {
-    transform: {},
-    resolveId: {},
-    pluginCalls: {},
-    transformCounter: {},
-  }
-
+  readonly scope: string
   private pluginCallCount = 0
 
   constructor(
-    readonly contextMain: ViteInspectContext,
-    readonly contextVite: ViteInspectViteContext,
+    readonly inspectContext: ViteInspectContext,
+    readonly viteContext: ViteInspectViteContext,
     readonly env: Environment,
-  ) {}
+  ) {
+    this.scope = `${viteContext.id}:${env.name}`
+  }
 
-  recordTransform(id: string, info: ViteInspectTransformInfo, preTransformCode: string, plugin?: Plugin): void {
+  recordTransform(
+    id: string,
+    info: ViteInspectTransformInfo,
+    preTransformCode: string,
+    plugin?: Plugin,
+  ): void {
     id = this.normalizeId(id)
+    const publicModuleId = this.getPublicModuleId(id)
     const pluginId = this.getPluginId(plugin, info.name)
-
-    let transforms = this.data.transform[id]
-    if (!transforms || !transforms.some(transform => transform.result != null)) {
-      transforms = [{
-        name: DUMMY_LOAD_PLUGIN_NAME,
-        result: preTransformCode,
-        start: info.start,
-        end: info.start,
-        sourcemaps: info.sourcemaps,
-      }]
-      this.data.transform[id] = transforms
-      this.data.transformCounter[id] = (this.data.transformCounter[id] || 0) + 1
-    }
-
-    transforms.push({
-      ...info,
-      plugin_id: pluginId,
-    })
-
-    this.recordPluginCall({
+    const pluginCall = this.createPluginCall({
       type: 'transform',
       pluginId,
       pluginName: info.name,
-      module: this.getPublicModuleId(id),
+      module: publicModuleId,
       start: info.start,
       end: info.end,
       unchanged: info.result == null || info.result === preTransformCode,
     })
-  }
 
-  recordLoad(id: string, info: ViteInspectTransformInfo, plugin?: Plugin): void {
-    id = this.normalizeId(id)
-    const pluginId = this.getPluginId(plugin, info.name)
-    this.data.transform[id] = [{
+    this.inspectContext.store.recordTransform(this.scope, id, publicModuleId, {
       ...info,
       plugin_id: pluginId,
-    }]
-    this.data.transformCounter[id] = (this.data.transformCounter[id] || 0) + 1
+    }, preTransformCode, pluginCall)
+  }
 
-    this.recordPluginCall({
+  recordLoad(
+    id: string,
+    info: ViteInspectTransformInfo,
+    plugin?: Plugin,
+  ): void {
+    id = this.normalizeId(id)
+    const publicModuleId = this.getPublicModuleId(id)
+    const pluginId = this.getPluginId(plugin, info.name)
+    const pluginCall = this.createPluginCall({
       type: 'load',
       pluginId,
       pluginName: info.name,
-      module: this.getPublicModuleId(id),
+      module: publicModuleId,
       start: info.start,
       end: info.end,
       unchanged: info.result == null,
     })
+
+    this.inspectContext.store.recordLoad(this.scope, id, publicModuleId, {
+      ...info,
+      plugin_id: pluginId,
+    }, pluginCall)
   }
 
-  recordLoadCall(id: string, info: ViteInspectTransformInfo, plugin?: Plugin): void {
+  recordLoadCall(
+    id: string,
+    info: ViteInspectTransformInfo,
+    plugin?: Plugin,
+  ): void {
     id = this.normalizeId(id)
-    this.recordPluginCall({
+    const publicModuleId = this.getPublicModuleId(id)
+    const pluginCall = this.createPluginCall({
       type: 'load',
       pluginId: this.getPluginId(plugin, info.name),
       pluginName: info.name,
-      module: this.getPublicModuleId(id),
+      module: publicModuleId,
       start: info.start,
       end: info.end,
       unchanged: true,
     })
+    if (!pluginCall)
+      return
+
+    this.inspectContext.store.recordPluginCall(this.scope, pluginCall)
   }
 
-  recordResolveId(id: string, info: ViteInspectResolveIdInfo, plugin?: Plugin): void {
+  recordResolveId(
+    id: string,
+    info: ViteInspectResolveIdInfo,
+    plugin?: Plugin,
+  ): void {
     id = this.normalizeId(id)
     const pluginId = this.getPluginId(plugin, info.name)
     const normalizedResult = this.normalizeId(info.result)
-    const resolveIds = this.data.resolveId[id] ||= []
-    resolveIds.push({
-      ...info,
-      plugin_id: pluginId,
-      result: normalizedResult,
-    })
-
-    this.recordPluginCall({
+    const sourcePublicId = this.getPublicModuleId(id)
+    const resultPublicId = this.getPublicModuleId(normalizedResult)
+    const pluginCall = this.createPluginCall({
       type: 'resolve',
       pluginId,
       pluginName: info.name,
-      module: this.getPublicModuleId(normalizedResult),
+      module: resultPublicId,
       start: info.start,
       end: info.end,
     })
+
+    this.inspectContext.store.recordResolveId(this.scope, id, sourcePublicId, {
+      ...info,
+      plugin_id: pluginId,
+      result: normalizedResult,
+    }, resultPublicId, pluginCall)
   }
 
-  recordResolveIdCall(id: string, info: Omit<ViteInspectResolveIdInfo, 'result'> & { result?: string | null }, plugin?: Plugin): void {
+  recordResolveIdCall(
+    id: string,
+    info: Omit<ViteInspectResolveIdInfo, 'result'> & { result?: string | null },
+    plugin?: Plugin,
+  ): void {
     id = this.normalizeId(id)
     const result = info.result ? this.normalizeId(info.result) : id
-    this.recordPluginCall({
+    const resultPublicId = this.getPublicModuleId(result)
+    const pluginCall = this.createPluginCall({
       type: 'resolve',
       pluginId: this.getPluginId(plugin, info.name),
       pluginName: info.name,
-      module: this.getPublicModuleId(result),
+      module: resultPublicId,
       start: info.start,
       end: info.end,
     })
+    if (!pluginCall)
+      return
+
+    this.inspectContext.store.recordPluginCall(this.scope, pluginCall)
   }
 
   invalidate(id: string): void {
     const normalizedId = this.normalizeId(id)
-    const invalidatedIds = new Set([normalizedId])
-    const invalidatedPublicIds = new Set([this.getPublicModuleId(normalizedId)])
-
-    for (const rawId of this.getRawModuleIds()) {
-      const publicId = this.getPublicModuleId(rawId)
-      if (invalidatedPublicIds.has(publicId)) {
-        invalidatedIds.add(rawId)
-        invalidatedPublicIds.add(publicId)
-      }
-    }
-
-    for (const [sourceId, resolveIds] of Object.entries(this.data.resolveId)) {
-      if (this.matchesInvalidatedModule(sourceId, invalidatedIds, invalidatedPublicIds)) {
-        invalidatedIds.add(this.normalizeId(sourceId))
-        invalidatedPublicIds.add(this.getPublicModuleId(sourceId))
-      }
-
-      for (const resolveId of resolveIds) {
-        if (this.matchesInvalidatedModule(resolveId.result, invalidatedIds, invalidatedPublicIds)) {
-          const normalizedResult = this.normalizeId(resolveId.result)
-          invalidatedIds.add(normalizedResult)
-          invalidatedPublicIds.add(this.getPublicModuleId(normalizedResult))
-        }
-      }
-    }
-
-    for (const rawId of invalidatedIds) {
-      delete this.data.transform[rawId]
-      delete this.data.transformCounter[rawId]
-    }
-
-    for (const [sourceId, resolveIds] of Object.entries(this.data.resolveId)) {
-      const remaining = resolveIds.filter((resolveId) => {
-        return !this.matchesInvalidatedModule(sourceId, invalidatedIds, invalidatedPublicIds)
-          && !this.matchesInvalidatedModule(resolveId.result, invalidatedIds, invalidatedPublicIds)
-      })
-
-      if (remaining.length)
-        this.data.resolveId[sourceId] = remaining
-      else
-        delete this.data.resolveId[sourceId]
-    }
-
-    for (const [pluginId, calls] of Object.entries(this.data.pluginCalls)) {
-      const remaining = calls.filter(call => !invalidatedPublicIds.has(call.module))
-      if (remaining.length)
-        this.data.pluginCalls[Number(pluginId)] = remaining
-      else
-        delete this.data.pluginCalls[Number(pluginId)]
-    }
+    const publicModuleId = this.getPublicModuleId(normalizedId)
+    this.inspectContext.store.invalidate(this.scope, normalizedId, publicModuleId)
   }
 
-  private matchesInvalidatedModule(id: string, invalidatedIds: Set<string>, invalidatedPublicIds: Set<string>): boolean {
-    const normalizedId = this.normalizeId(id)
-    return invalidatedIds.has(normalizedId)
-      || invalidatedPublicIds.has(this.getPublicModuleId(normalizedId))
+  clearScope(): void {
+    this.inspectContext.store.clearScope(this.scope)
   }
 
   normalizeId(id: string): string {
@@ -340,24 +314,18 @@ export class ViteInspectEnvironmentContext {
     return normalizeModuleId(this.normalizeId(id), this.getModuleIdBaseRoot())
   }
 
-  getRawModuleId(id: string): string {
+  async getModuleId(id: string): Promise<string> {
     const normalizedId = this.getPublicModuleId(id)
-    for (const rawId of this.getRawModuleIds()) {
-      if (this.getPublicModuleId(rawId) === normalizedId)
-        return rawId
-    }
+    const moduleId = await this.inspectContext.store.findModuleId(this.scope, normalizedId)
+    if (moduleId)
+      return moduleId
     if (normalizedId.startsWith('./') || normalizedId.startsWith('../'))
       return resolve(this.getModuleIdBaseRoot(), normalizedId).replace(/\\/g, '/')
     return normalizedId
   }
 
-  getRawModuleIds(): string[] {
-    const ids = new Set(Object.keys(this.data.transform))
-    for (const resolveIds of Object.values(this.data.resolveId)) {
-      for (const id of resolveIds)
-        ids.add(this.normalizeId(id.result))
-    }
-    return Array.from(ids)
+  getModuleIds(): Promise<string[]> {
+    return this.inspectContext.store.getModuleIds(this.scope)
   }
 
   getPluginId(plugin: Plugin | undefined, name: string): number {
@@ -370,7 +338,7 @@ export class ViteInspectEnvironmentContext {
     return this.env.getTopLevelConfig().plugins.findIndex(item => item.name === name)
   }
 
-  recordPluginCall(options: {
+  private createPluginCall(options: {
     type: ViteInspectPluginCallInfo['type']
     pluginId: number
     pluginName: string
@@ -378,12 +346,11 @@ export class ViteInspectEnvironmentContext {
     start: number
     end: number
     unchanged?: boolean
-  }): void {
+  }): ViteInspectPluginCallInfo | undefined {
     if (options.pluginId < 0)
-      return
+      return undefined
 
-    const calls = this.data.pluginCalls[options.pluginId] ||= []
-    calls.push({
+    return {
       type: options.type,
       id: `${options.type}:${options.pluginId}:${this.pluginCallCount++}`,
       duration: Math.max(0, options.end - options.start),
@@ -393,153 +360,42 @@ export class ViteInspectEnvironmentContext {
       timestamp_start: options.start,
       timestamp_end: options.end,
       unchanged: options.unchanged,
-    })
+    }
   }
 
-  getModulesList(pluginCtx?: ModuleInfoProvider): ViteInspectModuleInfo[] {
-    const moduleGraph = this.env.mode === 'dev' ? this.env.moduleGraph : undefined
-    const getDeps = moduleGraph
-      ? (id: string) => Array.from(moduleGraph.getModuleById(id)?.importedModules || []).map(module => module.id || '').filter(Boolean)
-      : pluginCtx
-        ? (id: string) => Array.from(pluginCtx.getModuleInfo(id)?.importedIds || [])
-        : () => []
-    const getImporters = moduleGraph
-      ? (id: string) => Array.from(moduleGraph.getModuleById(id)?.importers || []).map(module => module.id || '').filter(Boolean)
-      : pluginCtx
-        ? (id: string) => Array.from(pluginCtx.getModuleInfo(id)?.importers || [])
-        : () => []
-
-    const transformedIdMap = Object.values(this.data.resolveId).reduce<Record<string, ViteInspectResolveIdInfo[]>>((map, ids) => {
-      ids.forEach((id) => {
-        const result = this.normalizeId(id.result)
-        const resolvedIds = map[result] ||= []
-        resolvedIds.push(id)
-      })
-      return map
-    }, {})
-
-    const ids = new Set(Object.keys(this.data.transform).concat(Object.keys(transformedIdMap)))
-
-    return Array.from(ids).sort().map((id) => {
-      let totalTime = 0
-      const transformPlugins: ViteInspectModulePluginMetric[] = (this.data.transform[id] || [])
-        .filter(transform => transform.result != null)
-        .map((transform) => {
-          const delta = transform.end - transform.start
-          totalTime += delta
-          return {
-            name: transform.name,
-            transform: delta,
-          }
-        })
-      const resolveIdPlugins: ViteInspectModulePluginMetric[] = (transformedIdMap[id] || []).map(resolveId => ({
-        name: resolveId.name,
-        resolveId: resolveId.end - resolveId.start,
-      }))
-      const plugins = transformPlugins.concat(resolveIdPlugins)
-
-      return {
-        id: this.getPublicModuleId(id),
-        deps: getDeps(id).map(dep => this.getPublicModuleId(dep)),
-        importers: getImporters(id).map(importer => this.getPublicModuleId(importer)),
-        plugins,
-        virtual: isVirtual(plugins[0]?.name || '', this.data.transform[id]?.[0]?.name || ''),
-        totalTime,
-        invokeCount: this.data.transformCounter[id] || 0,
-        sourceSize: getUtf8Size(this.data.transform[id]?.[0]?.result),
-        distSize: getUtf8Size(this.data.transform[id]?.at(-1)?.result),
-      }
-    })
+  async getModulesList(pluginCtx?: ModuleInfoProvider): Promise<ViteInspectModuleInfo[]> {
+    return getEnvironmentModulesList(this, pluginCtx)
   }
 
-  resolveId(id = ''): string {
-    id = this.getRawModuleId(id)
+  async resolveId(id = ''): Promise<string> {
+    id = await this.getModuleId(id)
     if (id.startsWith('./'))
       id = resolve(this.getModuleIdBaseRoot(), id).replace(/\\/g, '/')
     return this.resolveIdRecursive(id)
   }
 
-  resolveIdRecursive(id: string): string {
-    const resolved = this.data.resolveId[id]?.[0]?.result
-    return resolved ? this.resolveIdRecursive(this.normalizeId(resolved)) : id
+  async resolveIdRecursive(id: string, seen = new Set<string>()): Promise<string> {
+    if (seen.has(id))
+      return id
+    seen.add(id)
+    const resolved = await this.inspectContext.store.getFirstResolveResult(this.scope, id)
+    return resolved ? this.resolveIdRecursive(this.normalizeId(resolved), seen) : id
   }
 
-  getPluginMetrics(): ViteInspectPluginMetric[] {
-    const map: Record<string, ViteInspectPluginMetric> = {}
-    const defaultMetricInfo = () => ({
-      transform: {
-        invokeCount: 0,
-        totalTime: 0,
-      },
-      resolveId: {
-        invokeCount: 0,
-        totalTime: 0,
-      },
-    })
-
-    this.env.getTopLevelConfig().plugins.forEach((plugin: Plugin, pluginId) => {
-      map[pluginId] = {
-        ...defaultMetricInfo(),
-        name: plugin.name,
-        plugin_id: pluginId,
-        enforce: plugin.enforce,
-      }
-    })
-
-    Object.values(this.data.transform).forEach((transformInfos) => {
-      transformInfos.forEach(({ name, plugin_id: pluginId, start, end }) => {
-        if (name === DUMMY_LOAD_PLUGIN_NAME)
-          return
-        const key = pluginId == null || pluginId < 0 ? name : String(pluginId)
-        map[key] ||= {
-          ...defaultMetricInfo(),
-          name,
-          plugin_id: pluginId,
-        }
-        map[key].transform.totalTime += end - start
-        map[key].transform.invokeCount += 1
-      })
-    })
-
-    Object.values(this.data.resolveId).forEach((resolveIdInfos) => {
-      resolveIdInfos.forEach(({ name, plugin_id: pluginId, start, end }) => {
-        const key = pluginId == null || pluginId < 0 ? name : String(pluginId)
-        map[key] ||= {
-          ...defaultMetricInfo(),
-          name,
-          plugin_id: pluginId,
-        }
-        map[key].resolveId.totalTime += end - start
-        map[key].resolveId.invokeCount += 1
-      })
-    })
-
-    return Object.values(map).filter(Boolean).sort((a, b) => a.name.localeCompare(b.name))
+  async getPluginMetrics(): Promise<ViteInspectPluginMetric[]> {
+    return getEnvironmentPluginMetrics(this)
   }
 
   async getModuleTransformInfo(id: string): Promise<ViteInspectModuleTransformInfo> {
-    const resolvedId = this.resolveId(id)
-    return {
-      resolvedId,
-      transforms: this.data.transform[resolvedId] || [],
-    }
+    return getEnvironmentModuleTransformInfo(this, id)
   }
 
-  getPluginDetails(pluginId: number): ViteInspectPluginDetails {
-    const plugin = this.env.getTopLevelConfig().plugins[pluginId]
-    const calls = this.data.pluginCalls[pluginId] ?? []
-    return {
-      plugin_name: plugin?.name ?? calls[0]?.plugin_name ?? '',
-      plugin_id: pluginId,
-      calls,
-      resolveIdMetrics: calls.filter(call => call.type === 'resolve'),
-      loadMetrics: calls.filter(call => call.type === 'load'),
-      transformMetrics: calls.filter(call => call.type === 'transform'),
-    }
+  async getPluginDetails(pluginId: number): Promise<ViteInspectPluginDetails> {
+    return getEnvironmentPluginDetails(this, pluginId)
   }
 
   async clearModuleTransform(id: string): Promise<void> {
-    this.clearId(id)
+    await this.clearId(id)
     try {
       if (this.env.mode === 'dev')
         await this.env.transformRequest(id)
@@ -547,8 +403,8 @@ export class ViteInspectEnvironmentContext {
     catch {}
   }
 
-  clearId(rawId: string): void {
-    const id = this.resolveId(rawId)
+  async clearId(moduleId: string): Promise<void> {
+    const id = await this.resolveId(moduleId)
     if (!id)
       return
 
@@ -556,12 +412,7 @@ export class ViteInspectEnvironmentContext {
     const mod = moduleGraph?.getModuleById(id)
     if (mod)
       moduleGraph?.invalidateModule(mod)
-    this.invalidate(id)
+    else
+      this.invalidate(id)
   }
-}
-
-function isVirtual(pluginName: string, transformName: string): boolean {
-  return pluginName !== DUMMY_LOAD_PLUGIN_NAME
-    && transformName !== 'vite:load-fallback'
-    && transformName !== 'vite:build-load-fallback'
 }

--- a/packages/vite/src/node/inspect/hijack.ts
+++ b/packages/vite/src/node/inspect/hijack.ts
@@ -1,5 +1,9 @@
 import type { Plugin } from 'vite'
 import type { ViteInspectContext } from './context'
+import {
+  isTransformRequestStale,
+  trackTransformRequestId,
+} from './server'
 import { parseError, stringifyError } from './utils'
 
 type PluginWithOrder = Plugin & {
@@ -53,6 +57,8 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
   hijackHook(plugin, 'transform', async (fn, context, args, order) => {
     const code = args[0] as string
     const id = args[1] as string
+    const transformRequest = trackTransformRequestId(id)
+    const envContext = ctx.filter(id) ? ctx.getEnvContext(context?.environment) : undefined
     let resultValue: any
     let error: unknown
     const start = Date.now()
@@ -71,9 +77,9 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
         ? resultValue
         : resultValue?.code?.toString()
 
-    if (ctx.filter(id)) {
+    if (envContext && !isTransformRequestStale(transformRequest)) {
       const sourcemaps = typeof resultValue === 'string' ? null : resultValue?.map
-      ctx.getEnvContext(context?.environment)?.recordTransform(id, {
+      envContext.recordTransform(id, {
         name: plugin.name,
         result,
         start,
@@ -91,6 +97,8 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
 
   hijackHook(plugin, 'load', async (fn, context, args) => {
     const id = args[0] as string
+    const transformRequest = trackTransformRequestId(id)
+    const envContext = ctx.getEnvContext(context?.environment)
     let resultValue: any
     let error: unknown
     const start = Date.now()
@@ -119,14 +127,14 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
       error: error ? parseError(error) : undefined,
     }
 
-    if (result != null) {
-      ctx.getEnvContext(context?.environment)?.recordLoad(id, {
+    if (result != null && envContext && !isTransformRequestStale(transformRequest)) {
+      envContext.recordLoad(id, {
         ...info,
         result,
       }, plugin)
     }
-    else {
-      ctx.getEnvContext(context?.environment)?.recordLoadCall(id, {
+    else if (envContext && !isTransformRequestStale(transformRequest)) {
+      envContext.recordLoadCall(id, {
         name: plugin.name,
         start,
         end,
@@ -141,6 +149,8 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
 
   hijackHook(plugin, 'resolveId', async (fn, context, args) => {
     const id = args[0] as string
+    const transformRequest = trackTransformRequestId(id)
+    const envContext = ctx.filter(id) ? ctx.getEnvContext(context?.environment) : undefined
     let resultValue: any
     let error: unknown
     const start = Date.now()
@@ -153,7 +163,13 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
     }
 
     const end = Date.now()
-    if (!ctx.filter(id)) {
+    if (!envContext) {
+      if (error)
+        throw error
+      return resultValue
+    }
+
+    if (isTransformRequestStale(transformRequest)) {
       if (error)
         throw error
       return resultValue
@@ -166,7 +182,7 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
         : resultValue
 
     if (result && result !== id) {
-      ctx.getEnvContext(context?.environment)?.recordResolveId(id, {
+      envContext.recordResolveId(id, {
         name: plugin.name,
         result,
         start,
@@ -175,7 +191,7 @@ export function hijackPlugin(plugin: Plugin, ctx: ViteInspectContext): void {
       }, plugin)
     }
     else {
-      ctx.getEnvContext(context?.environment)?.recordResolveIdCall(id, {
+      envContext.recordResolveIdCall(id, {
         name: plugin.name,
         result,
         start,

--- a/packages/vite/src/node/inspect/module.ts
+++ b/packages/vite/src/node/inspect/module.ts
@@ -1,0 +1,141 @@
+import type { ViteInspectEnvironmentContext } from './context'
+import type {
+  ViteInspectModuleInfo,
+  ViteInspectModulePluginMetric,
+  ViteInspectModuleTransformInfo,
+} from './types'
+import { DUMMY_LOAD_PLUGIN_NAME } from './utils'
+
+export interface ModuleInfoProvider {
+  getModuleInfo: (id: string) => {
+    importedIds?: readonly string[]
+    importers?: readonly string[]
+  } | null | undefined
+}
+
+export async function getModulesList(
+  ctx: ViteInspectEnvironmentContext,
+  pluginCtx?: ModuleInfoProvider,
+): Promise<ViteInspectModuleInfo[]> {
+  const moduleGraph = ctx.env.mode === 'dev' ? ctx.env.moduleGraph : undefined
+  const getDeps = moduleGraph
+    ? (id: string) => Array.from(moduleGraph.getModuleById(id)?.importedModules || []).map(module => module.id || '').filter(Boolean)
+    : pluginCtx
+      ? (id: string) => Array.from(pluginCtx.getModuleInfo(id)?.importedIds || [])
+      : () => []
+  const getImporters = moduleGraph
+    ? (id: string) => Array.from(moduleGraph.getModuleById(id)?.importers || []).map(module => module.id || '').filter(Boolean)
+    : pluginCtx
+      ? (id: string) => Array.from(pluginCtx.getModuleInfo(id)?.importers || [])
+      : () => []
+
+  const transformList = await ctx.inspectContext.store.getTransformList(ctx.scope)
+  const resolveIdList = await ctx.inspectContext.store.getResolveIdList(ctx.scope)
+
+  const transformsById = transformList.reduce<Record<string, typeof transformList>>((map, transform) => {
+    const transforms = map[transform.moduleId] ||= []
+    transforms.push(transform)
+    return map
+  }, {})
+  const transformedIdMap = resolveIdList.reduce<Record<string, typeof resolveIdList>>((map, resolveId) => {
+    const result = ctx.normalizeId(resolveId.result)
+    const resolvedIds = map[result] ||= []
+    resolvedIds.push(resolveId)
+    return map
+  }, {})
+
+  const ids = new Set(Object.keys(transformsById).concat(Object.keys(transformedIdMap)))
+
+  return Array.from(ids).sort().map((id) => {
+    let totalTime = 0
+    const transforms = transformsById[id] || []
+    const transformPlugins: ViteInspectModulePluginMetric[] = transforms
+      .filter(transform => transform.hasResult)
+      .map((transform) => {
+        const delta = transform.end - transform.start
+        totalTime += delta
+        return {
+          name: transform.name,
+          transform: delta,
+        }
+      })
+    const resolveIdPlugins: ViteInspectModulePluginMetric[] = (transformedIdMap[id] || []).map(resolveId => ({
+      name: resolveId.name,
+      resolveId: resolveId.end - resolveId.start,
+    }))
+    const plugins = transformPlugins.concat(resolveIdPlugins)
+    const firstTransform = transforms[0]
+    const lastTransform = transforms.at(-1)
+
+    return {
+      id: ctx.getPublicModuleId(id),
+      deps: getDeps(id).map(dep => ctx.getPublicModuleId(dep)),
+      importers: getImporters(id).map(importer => ctx.getPublicModuleId(importer)),
+      plugins,
+      virtual: isVirtual(plugins[0]?.name || '', firstTransform?.name || ''),
+      totalTime,
+      invokeCount: firstTransform?.invokeCount || 0,
+      sourceSize: firstTransform?.hasResult ? firstTransform.resultSize : 0,
+      distSize: lastTransform?.hasResult ? lastTransform.resultSize : 0,
+    }
+  })
+}
+
+export async function getPublicGraphModuleIds(ctx: ViteInspectEnvironmentContext): Promise<string[]> {
+  return (await ctx.getModuleIds()).map(id => ctx.getPublicModuleId(id))
+}
+
+export function createGraphModuleIdResolver(moduleIds: string[], extensions: readonly string[] = []) {
+  const moduleIdMap = new Map<string, string | false>()
+  const sortedExtensions = extensions.slice().sort((a, b) => b.length - a.length)
+
+  for (const moduleId of moduleIds) {
+    addModuleId(moduleIdMap, moduleId, moduleId)
+
+    const extensionlessId = removeResolvedExtension(moduleId, sortedExtensions)
+    if (extensionlessId)
+      addModuleId(moduleIdMap, extensionlessId, moduleId)
+  }
+
+  return (moduleId: string): string | undefined => {
+    return moduleIdMap.get(moduleId) || undefined
+  }
+}
+
+export async function getModuleTransformInfo(
+  ctx: ViteInspectEnvironmentContext,
+  id: string,
+): Promise<ViteInspectModuleTransformInfo> {
+  const resolvedId = await ctx.resolveId(id)
+  return {
+    resolvedId,
+    transforms: await ctx.inspectContext.store.getModuleTransforms(ctx.scope, resolvedId),
+  }
+}
+
+function isVirtual(pluginName: string, transformName: string): boolean {
+  return pluginName !== DUMMY_LOAD_PLUGIN_NAME
+    && transformName !== 'vite:load-fallback'
+    && transformName !== 'vite:build-load-fallback'
+}
+
+function addModuleId(moduleIdMap: Map<string, string | false>, key: string, target: string): void {
+  const existing = moduleIdMap.get(key)
+  if (existing === undefined) {
+    moduleIdMap.set(key, target)
+  }
+  else if (existing !== target) {
+    moduleIdMap.set(key, false)
+  }
+}
+
+function removeResolvedExtension(id: string, extensions: readonly string[]): string | undefined {
+  const queryIndex = id.search(/[?#]/)
+  const path = queryIndex < 0 ? id : id.slice(0, queryIndex)
+  const query = queryIndex < 0 ? '' : id.slice(queryIndex)
+  const extension = extensions.find(extension => path.endsWith(extension))
+
+  return extension
+    ? `${path.slice(0, -extension.length)}${query}`
+    : undefined
+}

--- a/packages/vite/src/node/inspect/plugin.ts
+++ b/packages/vite/src/node/inspect/plugin.ts
@@ -2,16 +2,25 @@ import type { PluginWithDevTools } from '@vitejs/devtools-kit'
 import type { SharedState } from '@vitejs/devtools-kit/utils/shared-state'
 import type { ResolvedConfig, ResolveFn } from 'vite'
 import type { ViteInspectModuleUpdatedState } from '../rpc'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
 import { debounce } from 'perfect-debounce'
 import { diagnostics } from '../diagnostics'
 import { inspectRpcFunctions, VITE_INSPECT_MODULE_UPDATED_STATE_KEY, viteRpcFunctions } from '../rpc'
 import { setViteInspectContext, ViteInspectContext } from './context'
 import { hijackPlugin } from './hijack'
-import { setupEnvironmentInvalidation, setupMiddlewarePerformance } from './server'
+import {
+  isTransformRequestStale,
+  setupEnvironmentInvalidation,
+  setupMiddlewarePerformance,
+  trackTransformRequestId,
+} from './server'
 
 export function DevToolsViteInspect(): PluginWithDevTools {
-  let resolvedConfig: ResolvedConfig | undefined
   let inspectContext: ViteInspectContext | undefined
+  let inspectContextPromise: Promise<ViteInspectContext> | undefined
+  let closingInspectContext: Promise<void> | undefined
+  let inspectStorageDir: string | undefined
   let inspectModuleUpdatedState: SharedState<ViteInspectModuleUpdatedState> | undefined
 
   function notifyInspectModuleUpdated(ids: string[] | null = null) {
@@ -22,11 +31,54 @@ export function DevToolsViteInspect(): PluginWithDevTools {
     })
   }
 
-  function getInspectContext(config: ResolvedConfig): ViteInspectContext | undefined {
+  async function createInspectContext(config: ResolvedConfig): Promise<ViteInspectContext> {
+    const cacheDir = config.cacheDir || join(config.root, 'node_modules/.vite')
+    const storageDir = join(cacheDir, 'devtools', 'inspect')
+    inspectStorageDir = storageDir
+    removeInspectStorage()
+
+    try {
+      const ctx = await ViteInspectContext.create({
+        filename: join(storageDir, 'payloads.bin'),
+      })
+      inspectContext = ctx
+      return ctx
+    }
+    catch (error) {
+      removeInspectStorage()
+      throw error
+    }
+  }
+
+  function ensureInspectContext(config: ResolvedConfig): Promise<ViteInspectContext | undefined> {
     if (config.command !== 'serve')
-      return undefined
-    inspectContext ||= new ViteInspectContext()
-    return inspectContext
+      return Promise.resolve(undefined)
+
+    inspectContextPromise ??= createInspectContext(config)
+    return inspectContextPromise
+  }
+
+  async function closeInspectContext(): Promise<void> {
+    const ctx = inspectContext ?? await inspectContextPromise
+    if (!ctx)
+      return
+
+    closingInspectContext ??= (async () => {
+      await ctx.close()
+      removeInspectStorage()
+    })()
+    await closingInspectContext
+  }
+
+  function removeInspectStorage(): void {
+    if (inspectStorageDir)
+      rmSync(inspectStorageDir, { recursive: true, force: true })
+  }
+
+  async function resolveInspectContext(): Promise<ViteInspectContext | undefined> {
+    if (inspectContext)
+      return inspectContext
+    return inspectContextPromise
   }
 
   return {
@@ -40,8 +92,10 @@ export function DevToolsViteInspect(): PluginWithDevTools {
         for (const fn of viteRpcFunctions)
           ctx.rpc.register(fn as any)
 
-        if (inspectContext) {
-          setViteInspectContext(ctx, inspectContext)
+        const currentInspectContext = await resolveInspectContext()
+
+        if (currentInspectContext) {
+          setViteInspectContext(ctx, currentInspectContext)
           for (const fn of inspectRpcFunctions)
             ctx.rpc.register(fn as any)
 
@@ -67,9 +121,8 @@ export function DevToolsViteInspect(): PluginWithDevTools {
       },
     },
 
-    configResolved(config) {
-      resolvedConfig = config
-      const ctx = getInspectContext(config)
+    async configResolved(config) {
+      const ctx = await ensureInspectContext(config)
       if (!ctx)
         return
 
@@ -86,11 +139,12 @@ export function DevToolsViteInspect(): PluginWithDevTools {
         const resolver = createResolver.apply(this, args)
         return async (...resolverArgs: Parameters<ResolveFn>) => {
           const [id, , aliasOnly, ssr] = resolverArgs
+          const transformRequest = trackTransformRequestId(id)
           const start = Date.now()
           const result = await resolver(...resolverArgs)
           const end = Date.now()
 
-          if (result && result !== id) {
+          if (result && result !== id && !isTransformRequestStale(transformRequest)) {
             const pluginName = aliasOnly ? 'alias' : 'vite:resolve (+alias)'
             const envName = ssr ? 'ssr' : 'client'
             vite.environments.get(envName)?.recordResolveId(id, {
@@ -107,7 +161,7 @@ export function DevToolsViteInspect(): PluginWithDevTools {
     },
 
     configureServer(server) {
-      const ctx = resolvedConfig ? getInspectContext(resolvedConfig) : inspectContext
+      const ctx = inspectContext
       if (!ctx)
         return
 
@@ -120,12 +174,8 @@ export function DevToolsViteInspect(): PluginWithDevTools {
       }
     },
 
-    load: {
-      order: 'pre',
-      handler(id) {
-        inspectContext?.getEnvContext(this.environment)?.invalidate(id)
-        return null
-      },
+    async closeBundle() {
+      await closeInspectContext()
     },
 
     hotUpdate({ modules }) {

--- a/packages/vite/src/node/inspect/plugins.ts
+++ b/packages/vite/src/node/inspect/plugins.ts
@@ -1,0 +1,86 @@
+import type { Plugin } from 'vite'
+import type { ViteInspectEnvironmentContext } from './context'
+import type {
+  ViteInspectPluginCallInfo,
+  ViteInspectPluginDetails,
+  ViteInspectPluginMetric,
+} from './types'
+import { createGraphModuleIdResolver, getPublicGraphModuleIds } from './module'
+
+export async function getPluginMetrics(ctx: ViteInspectEnvironmentContext): Promise<ViteInspectPluginMetric[]> {
+  const map: Record<string, ViteInspectPluginMetric> = {}
+  const defaultMetricInfo = () => ({
+    transform: {
+      invokeCount: 0,
+      totalTime: 0,
+    },
+    resolveId: {
+      invokeCount: 0,
+      totalTime: 0,
+    },
+  })
+
+  ctx.env.getTopLevelConfig().plugins.forEach((plugin: Plugin, pluginId) => {
+    map[pluginId] = {
+      ...defaultMetricInfo(),
+      name: plugin.name,
+      plugin_id: pluginId,
+      enforce: plugin.enforce,
+    }
+  })
+
+  for (const row of await ctx.inspectContext.store.getPluginTransformMetrics(ctx.scope)) {
+    const key = row.pluginId == null || row.pluginId < 0 ? row.pluginName : String(row.pluginId)
+    map[key] ||= {
+      ...defaultMetricInfo(),
+      name: row.pluginName,
+      plugin_id: row.pluginId,
+    }
+    map[key].transform.totalTime += row.totalTime
+    map[key].transform.invokeCount += row.invokeCount
+  }
+
+  for (const row of await ctx.inspectContext.store.getPluginResolveIdMetrics(ctx.scope)) {
+    const key = row.pluginId == null || row.pluginId < 0 ? row.pluginName : String(row.pluginId)
+    map[key] ||= {
+      ...defaultMetricInfo(),
+      name: row.pluginName,
+      plugin_id: row.pluginId,
+    }
+    map[key].resolveId.totalTime += row.totalTime
+    map[key].resolveId.invokeCount += row.invokeCount
+  }
+
+  return Object.values(map).filter(Boolean).sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export async function getPluginDetails(
+  ctx: ViteInspectEnvironmentContext,
+  pluginId: number,
+): Promise<ViteInspectPluginDetails> {
+  const plugin = ctx.env.getTopLevelConfig().plugins[pluginId]
+  const calls = await withGraphModuleIds(ctx, await ctx.inspectContext.store.getPluginCalls(ctx.scope, pluginId))
+  return {
+    plugin_name: plugin?.name ?? calls[0]?.plugin_name ?? '',
+    plugin_id: pluginId,
+    calls,
+    resolveIdMetrics: calls.filter(call => call.type === 'resolve'),
+    loadMetrics: calls.filter(call => call.type === 'load'),
+    transformMetrics: calls.filter(call => call.type === 'transform'),
+  }
+}
+
+async function withGraphModuleIds(
+  ctx: ViteInspectEnvironmentContext,
+  calls: ViteInspectPluginCallInfo[],
+): Promise<ViteInspectPluginCallInfo[]> {
+  const resolveGraphModuleId = createGraphModuleIdResolver(
+    await getPublicGraphModuleIds(ctx),
+    ctx.env.getTopLevelConfig().resolve?.extensions ?? [],
+  )
+
+  return calls.map(call => ({
+    ...call,
+    graphModuleId: resolveGraphModuleId(call.module),
+  }))
+}

--- a/packages/vite/src/node/inspect/server.ts
+++ b/packages/vite/src/node/inspect/server.ts
@@ -1,25 +1,108 @@
 import type { Connect, ViteDevServer } from 'vite'
-import type { ViteInspectViteContext } from './context'
+import type {
+  ViteInspectEnvironmentContext,
+  ViteInspectViteContext,
+} from './context'
+import { AsyncLocalStorage } from 'node:async_hooks'
 
 const timestampRE = /\bt=\d{13}&?\b/
 const trailingSeparatorRE = /[?&]$/
+
+export interface ViteInspectTransformRequestState {
+  active: boolean
+  ids: Set<string>
+  stale: boolean
+}
+
+interface EnvironmentInvalidationState {
+  activeRequests: Set<ViteInspectTransformRequestState>
+  contexts: Set<ViteInspectEnvironmentContext>
+}
 
 interface MiddlewareLayer {
   handle?: unknown
 }
 
+const transformRequestStorage = new AsyncLocalStorage<ViteInspectTransformRequestState>()
+const environmentInvalidationStates = new WeakMap<object, EnvironmentInvalidationState>()
+
+export function trackTransformRequestId(id: string): ViteInspectTransformRequestState | undefined {
+  const request = transformRequestStorage.getStore()
+  if (request?.active)
+    request.ids.add(normalizeRequestId(id))
+  return request?.active ? request : undefined
+}
+
+export function isTransformRequestStale(request?: ViteInspectTransformRequestState): boolean {
+  return request?.stale === true
+}
+
 export function setupEnvironmentInvalidation(server: ViteDevServer, vite: ViteInspectViteContext): void {
   Object.values(server.environments).forEach((env) => {
     const envContext = vite.getEnvContext(env)
+    const existingState = environmentInvalidationStates.get(env)
+    if (existingState) {
+      existingState.contexts.add(envContext)
+      return
+    }
+
+    const state: EnvironmentInvalidationState = {
+      activeRequests: new Set(),
+      contexts: new Set([envContext]),
+    }
+    environmentInvalidationStates.set(env, state)
+
+    const transformRequest = env.transformRequest
+    env.transformRequest = function (...args) {
+      const request: ViteInspectTransformRequestState = {
+        active: true,
+        ids: new Set([normalizeRequestId(args[0])]),
+        stale: false,
+      }
+      state.activeRequests.add(request)
+      return transformRequestStorage.run(request, () => transformRequest.apply(this, args))
+        .finally(() => {
+          request.active = false
+          request.ids.clear()
+          state.activeRequests.delete(request)
+        })
+    }
+
     const invalidateModule = env.moduleGraph.invalidateModule
 
     env.moduleGraph.invalidateModule = function (...args) {
       const mod = args[0]
-      if (mod?.id)
-        envContext.invalidate(mod.id)
+      const seen = args[1]
+      const softInvalidate = args[4] === true
+      const invalidationState = (mod as { invalidationState?: unknown } | undefined)?.invalidationState
+      const alreadyHardInvalidated = invalidationState === 'HARD_INVALIDATED'
+      const shouldInvalidateInspect = !softInvalidate
+        && (!seen?.has(mod) || !alreadyHardInvalidated)
+      if (mod) {
+        markStaleRequests(state.activeRequests, mod.id, mod.url)
+        if (mod.id && shouldInvalidateInspect) {
+          for (const context of state.contexts)
+            context.invalidate(mod.id)
+        }
+      }
       return invalidateModule.apply(this, args)
     }
   })
+}
+
+function markStaleRequests(
+  requests: Set<ViteInspectTransformRequestState>,
+  ...ids: Array<string | null | undefined>
+): void {
+  const normalizedIds = ids.filter(id => id != null).map(normalizeRequestId)
+  for (const request of requests) {
+    if (normalizedIds.some(id => request.ids.has(id)))
+      request.stale = true
+  }
+}
+
+function normalizeRequestId(id: string): string {
+  return id.replace(timestampRE, '').replace(trailingSeparatorRE, '')
 }
 
 export function setupMiddlewarePerformance(vite: ViteInspectViteContext, middlewares: MiddlewareLayer[]): void {

--- a/packages/vite/src/node/inspect/store/index.ts
+++ b/packages/vite/src/node/inspect/store/index.ts
@@ -1,0 +1,904 @@
+import type {
+  ViteInspectPluginCallInfo,
+  ViteInspectResolveIdInfo,
+  ViteInspectTransformInfo,
+} from '../types'
+import type { InspectPayloadStore } from './payload'
+import type {
+  InspectPluginCallStore,
+  InspectPluginCallWrite,
+} from './plugin-calls'
+import type {
+  PendingWrite,
+  QueuedWrite,
+  StoredViteInspectTransformInfo,
+  ViteInspectPayloadRange,
+  ViteInspectPluginMetricItem,
+  ViteInspectResolveIdItem,
+  ViteInspectStore,
+  ViteInspectStoreOptions,
+  ViteInspectStoreStats,
+  ViteInspectTransformListItem,
+} from './types'
+import { mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { diagnostics } from '../../diagnostics'
+import { DUMMY_LOAD_PLUGIN_NAME } from '../utils'
+import { createInspectPayloadStore } from './payload'
+import { createInspectPluginCallStore } from './plugin-calls'
+
+const DEFAULT_MAX_BATCH_ITEMS = 256
+const DEFAULT_MAX_BATCH_BYTES = 8 * 1024 * 1024
+
+interface StoredModuleTransforms {
+  publicModuleId: string
+  invokeCount: number
+  items: StoredViteInspectTransformInfo[]
+}
+
+interface ScopeData {
+  transforms: Map<string, StoredModuleTransforms>
+  resolveIds: Map<string, ViteInspectResolveIdItem[]>
+}
+
+interface PreparedWrite {
+  write: Exclude<QueuedWrite, { operation: 'invalidate' | 'clearScope' }>
+  resultIndex?: number
+  sourceIndex?: number
+  sourcemapIndex?: number
+}
+
+export type {
+  ViteInspectPluginMetricItem,
+  ViteInspectResolveIdItem,
+  ViteInspectStore,
+  ViteInspectStoreOptions,
+  ViteInspectStoreStats,
+  ViteInspectTransformListItem,
+} from './types'
+
+export async function createViteInspectStore(options: ViteInspectStoreOptions = {}): Promise<ViteInspectStore> {
+  const filename = options.filename === ':memory:' ? undefined : options.filename
+  if (filename)
+    mkdirSync(dirname(filename), { recursive: true })
+
+  let payloads: InspectPayloadStore | undefined
+  try {
+    payloads = await createInspectPayloadStore(filename)
+    const pluginCalls = await createInspectPluginCallStore(
+      filename ? join(dirname(filename), 'plugin-calls.bin') : undefined,
+    )
+    return new PayloadViteInspectStore(payloads, pluginCalls, options)
+  }
+  catch (error) {
+    await payloads?.close().catch(() => {})
+    reportStorageError('opening the inspect archives', error)
+    throw error
+  }
+}
+
+class PayloadViteInspectStore implements ViteInspectStore {
+  private readonly maxBatchItems: number
+  private readonly maxBatchBytes: number
+  private readonly payloads: InspectPayloadStore
+  private readonly pluginCalls: InspectPluginCallStore
+  private readonly scopes = new Map<string, ScopeData>()
+
+  private queue: Array<PendingWrite | undefined> = []
+  private queueHead = 0
+  private scheduledPump?: NodeJS.Immediate
+  private pumpPromise?: Promise<void>
+  private lastWriteError?: Error
+  private closing = false
+  private closed = false
+  private closePromise?: Promise<void>
+
+  private queuedItems = 0
+  private queuedBytes = 0
+  private inFlightItems = 0
+  private peakQueuedItems = 0
+  private peakQueuedBytes = 0
+  private writeBatches = 0
+
+  private activeReaders = 0
+  private readerWaiters: Array<() => void> = []
+
+  constructor(
+    payloads: InspectPayloadStore,
+    pluginCalls: InspectPluginCallStore,
+    options: ViteInspectStoreOptions,
+  ) {
+    this.payloads = payloads
+    this.pluginCalls = pluginCalls
+    this.maxBatchItems = positiveInteger(options.maxBatchItems, DEFAULT_MAX_BATCH_ITEMS)
+    this.maxBatchBytes = positiveInteger(options.maxBatchBytes, DEFAULT_MAX_BATCH_BYTES)
+  }
+
+  recordTransform(
+    scope: string,
+    moduleId: string,
+    publicModuleId: string,
+    info: ViteInspectTransformInfo,
+    preTransformCode: string,
+    pluginCall?: ViteInspectPluginCallInfo,
+  ): void {
+    this.enqueue({
+      operation: 'recordTransform',
+      scope,
+      moduleId,
+      publicModuleId,
+      info,
+      preTransformCode,
+      pluginCall,
+    })
+  }
+
+  recordLoad(
+    scope: string,
+    moduleId: string,
+    publicModuleId: string,
+    info: ViteInspectTransformInfo,
+    pluginCall?: ViteInspectPluginCallInfo,
+  ): void {
+    this.enqueue({
+      operation: 'recordLoad',
+      scope,
+      moduleId,
+      publicModuleId,
+      info,
+      pluginCall,
+    })
+  }
+
+  recordResolveId(
+    scope: string,
+    sourceId: string,
+    sourcePublicId: string,
+    info: ViteInspectResolveIdInfo,
+    resultPublicId: string,
+    pluginCall?: ViteInspectPluginCallInfo,
+  ): void {
+    this.enqueue({
+      operation: 'recordResolveId',
+      scope,
+      sourceId,
+      sourcePublicId,
+      info,
+      resultPublicId,
+      pluginCall,
+    })
+  }
+
+  recordPluginCall(scope: string, info: ViteInspectPluginCallInfo): void {
+    this.enqueue({
+      operation: 'recordPluginCall',
+      scope,
+      info,
+    })
+  }
+
+  invalidate(scope: string, moduleId: string, publicModuleId: string): void {
+    this.enqueue({
+      operation: 'invalidate',
+      scope,
+      moduleId,
+      publicModuleId,
+    })
+  }
+
+  clearScope(scope: string): void {
+    this.enqueue({
+      operation: 'clearScope',
+      scope,
+    })
+  }
+
+  async getTransformList(scope: string): Promise<ViteInspectTransformListItem[]> {
+    await this.flush()
+    const result: ViteInspectTransformListItem[] = []
+    for (const [moduleId, transforms] of this.scopes.get(scope)?.transforms ?? []) {
+      for (const transform of transforms.items) {
+        result.push({
+          moduleId,
+          publicModuleId: transforms.publicModuleId,
+          name: transform.name,
+          pluginId: transform.pluginId,
+          hasResult: transform.hasResult,
+          resultSize: transform.resultSize,
+          start: transform.start,
+          end: transform.end,
+          invokeCount: transforms.invokeCount,
+        })
+      }
+    }
+    return result
+  }
+
+  async getResolveIdList(scope: string): Promise<ViteInspectResolveIdItem[]> {
+    await this.flush()
+    return Array.from(this.scopes.get(scope)?.resolveIds.values() ?? []).flat()
+  }
+
+  async getPluginTransformMetrics(scope: string): Promise<ViteInspectPluginMetricItem[]> {
+    await this.flush()
+    const metrics = new Map<string, ViteInspectPluginMetricItem>()
+    for (const transforms of this.scopes.get(scope)?.transforms.values() ?? []) {
+      for (const transform of transforms.items) {
+        if (transform.name === DUMMY_LOAD_PLUGIN_NAME)
+          continue
+        addMetric(metrics, transform.pluginId, transform.name, transform.end - transform.start)
+      }
+    }
+    return Array.from(metrics.values())
+  }
+
+  async getPluginResolveIdMetrics(scope: string): Promise<ViteInspectPluginMetricItem[]> {
+    await this.flush()
+    const metrics = new Map<string, ViteInspectPluginMetricItem>()
+    for (const resolveIds of this.scopes.get(scope)?.resolveIds.values() ?? []) {
+      for (const resolveId of resolveIds)
+        addMetric(metrics, resolveId.pluginId, resolveId.name, resolveId.end - resolveId.start)
+    }
+    return Array.from(metrics.values())
+  }
+
+  async getModuleTransforms(scope: string, moduleId: string): Promise<ViteInspectTransformInfo[]> {
+    return this.readSnapshot(async () => {
+      const transforms = this.scopes.get(scope)?.transforms.get(moduleId)?.items ?? []
+      return Promise.all(transforms.map(transform => this.restoreTransformInfo(transform)))
+    })
+  }
+
+  async getPluginCalls(scope: string, pluginId: number): Promise<ViteInspectPluginCallInfo[]> {
+    return this.readSnapshot(() => this.pluginCalls.read(scope, pluginId))
+  }
+
+  async getFirstResolveResult(scope: string, sourceId: string): Promise<string | undefined> {
+    await this.flush()
+    return this.scopes.get(scope)?.resolveIds.get(sourceId)?.[0]?.result
+  }
+
+  async findModuleId(scope: string, publicModuleId: string): Promise<string | undefined> {
+    await this.flush()
+    const data = this.scopes.get(scope)
+    if (!data)
+      return undefined
+
+    for (const [moduleId, transforms] of data.transforms) {
+      if (transforms.publicModuleId === publicModuleId)
+        return moduleId
+    }
+    for (const resolveIds of data.resolveIds.values()) {
+      const matched = resolveIds.find(resolveId => resolveId.resultPublicId === publicModuleId)
+      if (matched)
+        return matched.result
+    }
+    return undefined
+  }
+
+  async getModuleIds(scope: string): Promise<string[]> {
+    await this.flush()
+    const data = this.scopes.get(scope)
+    if (!data)
+      return []
+
+    const moduleIds = new Set(data.transforms.keys())
+    for (const resolveIds of data.resolveIds.values()) {
+      for (const resolveId of resolveIds)
+        moduleIds.add(resolveId.result)
+    }
+    return Array.from(moduleIds)
+  }
+
+  getStats(): ViteInspectStoreStats {
+    return {
+      maxBatchItems: this.maxBatchItems,
+      maxBatchBytes: this.maxBatchBytes,
+      queuedItems: this.queuedItems,
+      queuedBytes: this.queuedBytes,
+      inFlightItems: this.inFlightItems,
+      peakQueuedItems: this.peakQueuedItems,
+      peakQueuedBytes: this.peakQueuedBytes,
+      writeBatches: this.writeBatches,
+    }
+  }
+
+  async flush(): Promise<void> {
+    this.throwWriteError()
+    while (this.queuedItems > 0 || this.scheduledPump || this.pumpPromise) {
+      if (this.scheduledPump) {
+        clearImmediate(this.scheduledPump)
+        this.scheduledPump = undefined
+      }
+      this.startPump()
+      if (this.pumpPromise)
+        await this.pumpPromise
+    }
+    this.throwWriteError()
+  }
+
+  async close(): Promise<void> {
+    this.closePromise ||= this.closeInternal()
+    await this.closePromise
+  }
+
+  private enqueue(write: QueuedWrite): void {
+    if (this.closing || this.closed || this.lastWriteError)
+      return
+
+    const estimatedBytes = estimateWriteBytes(write)
+    this.queue.push({ write, estimatedBytes })
+    this.queuedItems += 1
+    this.queuedBytes += estimatedBytes
+    this.peakQueuedItems = Math.max(this.peakQueuedItems, this.queuedItems)
+    this.peakQueuedBytes = Math.max(this.peakQueuedBytes, this.queuedBytes)
+    this.schedulePump()
+  }
+
+  private schedulePump(): void {
+    if (this.scheduledPump || this.pumpPromise || this.queuedItems === 0)
+      return
+    this.scheduledPump = setImmediate(() => {
+      this.scheduledPump = undefined
+      this.startPump()
+    })
+  }
+
+  private startPump(): void {
+    if (this.pumpPromise || this.queuedItems === 0 || this.lastWriteError)
+      return
+
+    this.pumpPromise = this.drainQueue()
+      .catch((error) => {
+        this.lastWriteError = toError(error)
+        reportStorageError('writing the inspect archives', error)
+      })
+      .finally(() => {
+        this.pumpPromise = undefined
+        this.inFlightItems = 0
+        if (this.queuedItems > 0 && !this.lastWriteError)
+          this.schedulePump()
+      })
+  }
+
+  private async drainQueue(): Promise<void> {
+    while (this.queuedItems > 0) {
+      await this.waitForReaders()
+      const batch = this.takeBatch()
+      this.inFlightItems = batch.length
+      this.writeBatches += 1
+      await this.writeBatch(batch)
+      this.inFlightItems = 0
+    }
+  }
+
+  private takeBatch(): PendingWrite[] {
+    const batch: PendingWrite[] = []
+    let batchBytes = 0
+
+    while (this.queueHead < this.queue.length && batch.length < this.maxBatchItems) {
+      const pending = this.queue[this.queueHead]!
+      if (batch.length > 0 && batchBytes + pending.estimatedBytes > this.maxBatchBytes)
+        break
+      batch.push(pending)
+      batchBytes += pending.estimatedBytes
+      this.queue[this.queueHead] = undefined
+      this.queueHead += 1
+    }
+
+    this.queuedItems -= batch.length
+    this.queuedBytes = Math.max(0, this.queuedBytes - batchBytes)
+    if (this.queueHead === this.queue.length) {
+      this.queue = []
+      this.queueHead = 0
+    }
+    else if (this.queueHead >= 4096 && this.queueHead * 2 >= this.queue.length) {
+      this.queue = this.queue.slice(this.queueHead)
+      this.queueHead = 0
+    }
+    return batch
+  }
+
+  private async writeBatch(batch: PendingWrite[]): Promise<void> {
+    let dataWrites: Array<Exclude<QueuedWrite, { operation: 'invalidate' | 'clearScope' }>> = []
+    const flushDataWrites = async () => {
+      if (dataWrites.length === 0)
+        return
+      const current = dataWrites
+      dataWrites = []
+      await this.writeDataBatch(current)
+    }
+
+    for (const { write } of batch) {
+      if (write.operation === 'invalidate') {
+        await flushDataWrites()
+        this.invalidateNow(write.scope, write.moduleId, write.publicModuleId)
+      }
+      else if (write.operation === 'clearScope') {
+        await flushDataWrites()
+        this.clearScopeNow(write.scope)
+      }
+      else {
+        dataWrites.push(write)
+      }
+    }
+    await flushDataWrites()
+  }
+
+  private async writeDataBatch(
+    writes: Array<Exclude<QueuedWrite, { operation: 'invalidate' | 'clearScope' }>>,
+  ): Promise<void> {
+    const values: Array<string | null | undefined> = []
+    const prepared: PreparedWrite[] = []
+    const pluginCallWrites: InspectPluginCallWrite[] = []
+    const sourceState = new Map<string, boolean>()
+
+    const hasSource = (scope: string, moduleId: string): boolean => {
+      const key = scopeKey(scope, moduleId)
+      const pending = sourceState.get(key)
+      if (pending != null)
+        return pending
+      const stored = this.scopes.get(scope)?.transforms.get(moduleId)?.items.some(item => item.hasResult) ?? false
+      sourceState.set(key, stored)
+      return stored
+    }
+
+    for (const write of writes) {
+      const pluginCall = getQueuedPluginCall(write)
+      if (pluginCall) {
+        pluginCallWrites.push({
+          scope: write.scope,
+          info: pluginCall,
+        })
+      }
+      if (write.operation === 'recordPluginCall')
+        continue
+
+      const item: PreparedWrite = { write }
+      if (write.operation === 'recordTransform') {
+        const key = scopeKey(write.scope, write.moduleId)
+        if (!hasSource(write.scope, write.moduleId)) {
+          item.sourceIndex = values.push(write.preTransformCode) - 1
+          sourceState.set(key, true)
+        }
+        item.resultIndex = values.push(write.info.result) - 1
+        item.sourcemapIndex = pushSerializedPayload(values, write.info.sourcemaps)
+      }
+      else if (write.operation === 'recordLoad') {
+        item.resultIndex = values.push(write.info.result) - 1
+        item.sourcemapIndex = pushSerializedPayload(values, write.info.sourcemaps)
+        sourceState.set(scopeKey(write.scope, write.moduleId), write.info.result != null)
+      }
+      prepared.push(item)
+    }
+
+    const [ranges] = await Promise.all([
+      values.length > 0 ? this.payloads.write(values) : Promise.resolve([]),
+      this.pluginCalls.write(pluginCallWrites),
+    ])
+    for (const item of prepared)
+      this.applyPreparedWrite(item, ranges)
+  }
+
+  private applyPreparedWrite(
+    prepared: PreparedWrite,
+    ranges: Array<ViteInspectPayloadRange | undefined>,
+  ): void {
+    const { write } = prepared
+    if (write.operation === 'recordTransform') {
+      this.applyTransform(
+        write,
+        rangeAt(ranges, prepared.resultIndex),
+        rangeAt(ranges, prepared.sourceIndex),
+        rangeAt(ranges, prepared.sourcemapIndex),
+      )
+    }
+    else if (write.operation === 'recordLoad') {
+      this.applyLoad(
+        write,
+        rangeAt(ranges, prepared.resultIndex),
+        rangeAt(ranges, prepared.sourcemapIndex),
+      )
+    }
+    else if (write.operation === 'recordResolveId') {
+      const data = this.getScope(write.scope)
+      let resolveIds = data.resolveIds.get(write.sourceId)
+      if (!resolveIds) {
+        resolveIds = []
+        data.resolveIds.set(write.sourceId, resolveIds)
+      }
+      resolveIds.push({
+        sourceId: write.sourceId,
+        sourcePublicId: write.sourcePublicId,
+        result: write.info.result,
+        resultPublicId: write.resultPublicId,
+        name: write.info.name,
+        pluginId: write.info.plugin_id,
+        start: write.info.start,
+        end: write.info.end,
+      })
+    }
+  }
+
+  private applyTransform(
+    write: Extract<QueuedWrite, { operation: 'recordTransform' }>,
+    result: ViteInspectPayloadRange | undefined,
+    source: ViteInspectPayloadRange | undefined,
+    sourcemaps: ViteInspectPayloadRange | undefined,
+  ): void {
+    const data = this.getScope(write.scope)
+    let transforms = data.transforms.get(write.moduleId)
+    if (!transforms) {
+      transforms = {
+        publicModuleId: write.publicModuleId,
+        invokeCount: 0,
+        items: [],
+      }
+      data.transforms.set(write.moduleId, transforms)
+    }
+
+    if (!transforms.items.some(item => item.hasResult)) {
+      transforms.items.push({
+        name: DUMMY_LOAD_PLUGIN_NAME,
+        hasResult: true,
+        result: source,
+        resultSize: source?.length ?? 0,
+        start: write.info.start,
+        end: write.info.start,
+        sourcemaps,
+      })
+      transforms.invokeCount += 1
+    }
+    transforms.items.push(toStoredTransformInfo(write.info, result, sourcemaps))
+  }
+
+  private applyLoad(
+    write: Extract<QueuedWrite, { operation: 'recordLoad' }>,
+    result: ViteInspectPayloadRange | undefined,
+    sourcemaps: ViteInspectPayloadRange | undefined,
+  ): void {
+    const data = this.getScope(write.scope)
+    const existing = data.transforms.get(write.moduleId)
+    if (existing)
+      this.payloads.reclaim(collectPayloadRanges(existing.items))
+    data.transforms.set(write.moduleId, {
+      publicModuleId: write.publicModuleId,
+      invokeCount: (existing?.invokeCount ?? 0) + 1,
+      items: [toStoredTransformInfo(write.info, result, sourcemaps)],
+    })
+  }
+
+  private invalidateNow(scope: string, moduleId: string, publicModuleId: string): void {
+    const data = this.scopes.get(scope)
+    if (!data) {
+      this.pluginCalls.invalidate(scope, new Set([publicModuleId]))
+      return
+    }
+
+    const invalidIds = new Set([moduleId])
+    const invalidPublicIds = new Set([publicModuleId])
+    let changed = true
+    while (changed) {
+      changed = false
+      for (const [id, transforms] of data.transforms) {
+        if (invalidIds.has(id) || invalidPublicIds.has(transforms.publicModuleId))
+          changed = addInvalidId(invalidIds, invalidPublicIds, id, transforms.publicModuleId) || changed
+      }
+      for (const resolveIds of data.resolveIds.values()) {
+        for (const resolveId of resolveIds) {
+          if (!matchesInvalid(resolveId.sourceId, resolveId.sourcePublicId, invalidIds, invalidPublicIds)
+            && !matchesInvalid(resolveId.result, resolveId.resultPublicId, invalidIds, invalidPublicIds)) {
+            continue
+          }
+          changed = addInvalidId(invalidIds, invalidPublicIds, resolveId.sourceId, resolveId.sourcePublicId) || changed
+          changed = addInvalidId(invalidIds, invalidPublicIds, resolveId.result, resolveId.resultPublicId) || changed
+        }
+      }
+    }
+
+    const reclaimed: ViteInspectPayloadRange[] = []
+    for (const [id, transforms] of data.transforms) {
+      if (!matchesInvalid(id, transforms.publicModuleId, invalidIds, invalidPublicIds))
+        continue
+      reclaimed.push(...collectPayloadRanges(transforms.items))
+      data.transforms.delete(id)
+    }
+    this.payloads.reclaim(reclaimed)
+
+    for (const [sourceId, resolveIds] of data.resolveIds) {
+      const remaining = resolveIds.filter((resolveId) => {
+        return !matchesInvalid(sourceId, resolveId.sourcePublicId, invalidIds, invalidPublicIds)
+          && !matchesInvalid(resolveId.result, resolveId.resultPublicId, invalidIds, invalidPublicIds)
+      })
+      if (remaining.length > 0)
+        data.resolveIds.set(sourceId, remaining)
+      else
+        data.resolveIds.delete(sourceId)
+    }
+
+    this.pluginCalls.invalidate(scope, invalidPublicIds)
+  }
+
+  private clearScopeNow(scope: string): void {
+    const data = this.scopes.get(scope)
+    if (!data) {
+      this.pluginCalls.clearScope(scope)
+      return
+    }
+    const ranges: ViteInspectPayloadRange[] = []
+    for (const transforms of data.transforms.values())
+      ranges.push(...collectPayloadRanges(transforms.items))
+    this.payloads.reclaim(ranges)
+    this.pluginCalls.clearScope(scope)
+    this.scopes.delete(scope)
+  }
+
+  private async restoreTransformInfo(info: StoredViteInspectTransformInfo): Promise<ViteInspectTransformInfo> {
+    const [result, sourcemaps] = await Promise.all([
+      info.result ? this.payloads.read(info.result) : undefined,
+      info.sourcemaps ? this.payloads.read(info.sourcemaps) : undefined,
+    ])
+    return {
+      name: info.name,
+      plugin_id: info.pluginId,
+      result: info.hasResult ? result : undefined,
+      start: info.start,
+      end: info.end,
+      order: info.order,
+      sourcemaps: sourcemaps == null ? undefined : parsePayload(sourcemaps),
+      error: info.error,
+    }
+  }
+
+  private async readSnapshot<T>(read: () => Promise<T>): Promise<T> {
+    await this.flush()
+    this.activeReaders += 1
+    try {
+      return await read()
+    }
+    finally {
+      this.activeReaders -= 1
+      if (this.activeReaders === 0) {
+        for (const resolve of this.readerWaiters.splice(0))
+          resolve()
+      }
+    }
+  }
+
+  private waitForReaders(): Promise<void> | undefined {
+    if (this.activeReaders === 0)
+      return undefined
+    return new Promise((resolve) => {
+      this.readerWaiters.push(resolve)
+    })
+  }
+
+  private getScope(scope: string): ScopeData {
+    let data = this.scopes.get(scope)
+    if (!data) {
+      data = {
+        transforms: new Map(),
+        resolveIds: new Map(),
+      }
+      this.scopes.set(scope, data)
+    }
+    return data
+  }
+
+  private async closeInternal(): Promise<void> {
+    this.closing = true
+    let thrownError: unknown
+    try {
+      await this.flush()
+    }
+    catch (error) {
+      thrownError = error
+    }
+
+    if (this.scheduledPump) {
+      clearImmediate(this.scheduledPump)
+      this.scheduledPump = undefined
+    }
+    try {
+      await this.payloads.close()
+    }
+    catch (error) {
+      thrownError ??= error
+      reportStorageError('closing the payload archive', error)
+    }
+    try {
+      await this.pluginCalls.close()
+    }
+    catch (error) {
+      thrownError ??= error
+      reportStorageError('closing the plugin call archive', error)
+    }
+    this.queue = []
+    this.queueHead = 0
+    this.queuedItems = 0
+    this.queuedBytes = 0
+    this.scopes.clear()
+    this.closed = true
+
+    if (thrownError)
+      throw thrownError
+  }
+
+  private throwWriteError(): void {
+    if (this.lastWriteError)
+      throw this.lastWriteError
+  }
+}
+
+function addMetric(
+  metrics: Map<string, ViteInspectPluginMetricItem>,
+  pluginId: number | undefined,
+  pluginName: string,
+  duration: number,
+): void {
+  const key = pluginId == null || pluginId < 0 ? pluginName : String(pluginId)
+  let metric = metrics.get(key)
+  if (!metric) {
+    metric = {
+      pluginId,
+      pluginName,
+      invokeCount: 0,
+      totalTime: 0,
+    }
+    metrics.set(key, metric)
+  }
+  metric.invokeCount += 1
+  metric.totalTime += duration
+}
+
+function addInvalidId(
+  ids: Set<string>,
+  publicIds: Set<string>,
+  id: string,
+  publicId: string,
+): boolean {
+  const idSize = ids.size
+  const publicIdSize = publicIds.size
+  ids.add(id)
+  publicIds.add(publicId)
+  return ids.size !== idSize || publicIds.size !== publicIdSize
+}
+
+function matchesInvalid(
+  id: string,
+  publicId: string,
+  ids: Set<string>,
+  publicIds: Set<string>,
+): boolean {
+  return ids.has(id) || publicIds.has(publicId)
+}
+
+function collectPayloadRanges(items: StoredViteInspectTransformInfo[]): ViteInspectPayloadRange[] {
+  const ranges = new Map<string, ViteInspectPayloadRange>()
+  for (const item of items) {
+    for (const range of [item.result, item.sourcemaps]) {
+      if (range)
+        ranges.set(`${range.offset}:${range.length}`, range)
+    }
+  }
+  return Array.from(ranges.values())
+}
+
+function toStoredTransformInfo(
+  info: ViteInspectTransformInfo,
+  result: ViteInspectPayloadRange | undefined,
+  sourcemaps: ViteInspectPayloadRange | undefined,
+): StoredViteInspectTransformInfo {
+  return {
+    name: info.name,
+    pluginId: info.plugin_id,
+    hasResult: info.result != null,
+    result,
+    resultSize: result?.length ?? 0,
+    start: info.start,
+    end: info.end,
+    order: info.order,
+    sourcemaps,
+    error: info.error,
+  }
+}
+
+function pushSerializedPayload(
+  values: Array<string | null | undefined>,
+  value: unknown,
+): number | undefined {
+  const serialized = serializePayload(value)
+  if (serialized == null)
+    return undefined
+  return values.push(serialized) - 1
+}
+
+function serializePayload(value: unknown): string | undefined {
+  if (value == null)
+    return undefined
+  try {
+    return JSON.stringify(value)
+  }
+  catch {
+    return JSON.stringify(String(value))
+  }
+}
+
+function parsePayload(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  }
+  catch {
+    return undefined
+  }
+}
+
+function rangeAt(
+  ranges: Array<ViteInspectPayloadRange | undefined>,
+  index: number | undefined,
+): ViteInspectPayloadRange | undefined {
+  return index == null ? undefined : ranges[index]
+}
+
+function scopeKey(scope: string, moduleId: string): string {
+  return `${scope}\0${moduleId}`
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && value! > 0
+    ? Math.max(1, Math.floor(value!))
+    : fallback
+}
+
+function estimateWriteBytes(write: QueuedWrite): number {
+  const pluginCall = write.operation === 'invalidate' || write.operation === 'clearScope'
+    ? undefined
+    : getQueuedPluginCall(write)
+  const pluginCallBytes = pluginCall
+    ? (48
+      + estimateStringBytes(pluginCall.id)
+      + estimateStringBytes(pluginCall.plugin_name)
+      + estimateStringBytes(pluginCall.module))
+    : 0
+  if (write.operation === 'recordTransform') {
+    return pluginCallBytes
+      + estimateStringBytes(write.info.result)
+      + estimateStringBytes(write.preTransformCode)
+      + estimateTopLevelSourcemapBytes(write.info.sourcemaps)
+  }
+  if (write.operation === 'recordLoad') {
+    return pluginCallBytes
+      + estimateStringBytes(write.info.result)
+      + estimateTopLevelSourcemapBytes(write.info.sourcemaps)
+  }
+  return pluginCallBytes
+}
+
+function getQueuedPluginCall(
+  write: Exclude<QueuedWrite, { operation: 'invalidate' | 'clearScope' }>,
+): ViteInspectPluginCallInfo | undefined {
+  return write.operation === 'recordPluginCall' ? write.info : write.pluginCall
+}
+
+function estimateStringBytes(value: unknown): number {
+  return typeof value === 'string' ? value.length * 2 : 0
+}
+
+function estimateTopLevelSourcemapBytes(value: unknown): number {
+  if (value == null)
+    return 0
+  if (typeof value === 'string')
+    return value.length * 2
+  if (typeof value !== 'object')
+    return 0
+  const mappings = (value as { mappings?: unknown }).mappings
+  return estimateStringBytes(mappings)
+}
+
+function reportStorageError(operation: string, error: unknown): void {
+  diagnostics.VDT0003({ operation, cause: toError(error) }, { method: 'error' })
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/packages/vite/src/node/inspect/store/payload.ts
+++ b/packages/vite/src/node/inspect/store/payload.ts
@@ -1,0 +1,213 @@
+import type { FileHandle } from 'node:fs/promises'
+import type { ViteInspectPayloadRange } from './types'
+import { Buffer } from 'node:buffer'
+import { open } from 'node:fs/promises'
+import { diagnostics } from '../../diagnostics'
+
+export interface InspectPayloadStore {
+  write: (values: Array<string | null | undefined>) => Promise<Array<ViteInspectPayloadRange | undefined>>
+  read: (range: ViteInspectPayloadRange) => Promise<string>
+  reclaim: (ranges: ViteInspectPayloadRange[]) => void
+  close: () => Promise<void>
+}
+
+export async function createInspectPayloadStore(filename?: string): Promise<InspectPayloadStore> {
+  if (!filename)
+    return new MemoryInspectPayloadStore()
+  return new FileInspectPayloadStore(await open(filename, 'w+'))
+}
+
+class MemoryInspectPayloadStore implements InspectPayloadStore {
+  private readonly values = new Map<number, string>()
+  private nextOffset = 0
+
+  async write(values: Array<string | null | undefined>): Promise<Array<ViteInspectPayloadRange | undefined>> {
+    return values.map((value) => {
+      if (value == null)
+        return undefined
+      const offset = this.nextOffset
+      const length = Buffer.byteLength(value)
+      this.nextOffset += Math.max(length, 1)
+      this.values.set(offset, value)
+      return { offset, length }
+    })
+  }
+
+  async read(range: ViteInspectPayloadRange): Promise<string> {
+    const value = this.values.get(range.offset)
+    if (value == null) {
+      throw diagnostics.VDT0003({
+        operation: 'reading an in-memory inspect payload',
+      })
+    }
+    return value
+  }
+
+  reclaim(ranges: ViteInspectPayloadRange[]): void {
+    for (const range of ranges)
+      this.values.delete(range.offset)
+  }
+
+  async close(): Promise<void> {
+    this.values.clear()
+  }
+}
+
+class FileInspectPayloadStore implements InspectPayloadStore {
+  private nextOffset = 0
+  private freeRanges: ViteInspectPayloadRange[] = []
+
+  constructor(private readonly file: FileHandle) {}
+
+  async write(values: Array<string | null | undefined>): Promise<Array<ViteInspectPayloadRange | undefined>> {
+    const ranges: Array<ViteInspectPayloadRange | undefined> = []
+    const writes: Array<{
+      buffer: Buffer
+      range: ViteInspectPayloadRange
+    }> = []
+
+    for (const value of values) {
+      if (value == null) {
+        ranges.push(undefined)
+        continue
+      }
+      const buffer = Buffer.from(value)
+      const range = this.allocate(buffer.length)
+      ranges.push(range)
+      if (buffer.length > 0)
+        writes.push({ buffer, range })
+    }
+    await this.writeAllocatedPayloads(writes)
+    return ranges
+  }
+
+  async read(range: ViteInspectPayloadRange): Promise<string> {
+    if (range.length === 0)
+      return ''
+
+    const buffer = Buffer.allocUnsafe(range.length)
+    let readOffset = 0
+    while (readOffset < buffer.length) {
+      const { bytesRead } = await this.file.read(
+        buffer,
+        readOffset,
+        buffer.length - readOffset,
+        range.offset + readOffset,
+      )
+      if (bytesRead === 0) {
+        throw diagnostics.VDT0003({
+          operation: 'reading the inspect payload archive',
+        })
+      }
+      readOffset += bytesRead
+    }
+    return buffer.toString()
+  }
+
+  async close(): Promise<void> {
+    this.freeRanges.length = 0
+    await this.file.close()
+  }
+
+  reclaim(ranges: ViteInspectPayloadRange[]): void {
+    this.freeRanges.push(...ranges.filter(range => range.length > 0))
+    this.mergeFreeRanges()
+  }
+
+  private allocate(length: number): ViteInspectPayloadRange {
+    if (length === 0)
+      return { offset: this.nextOffset, length }
+
+    let bestIndex = -1
+    for (let index = 0; index < this.freeRanges.length; index++) {
+      const range = this.freeRanges[index]!
+      if (range.length < length)
+        continue
+      if (bestIndex < 0 || range.length < this.freeRanges[bestIndex]!.length)
+        bestIndex = index
+    }
+
+    if (bestIndex >= 0) {
+      const range = this.freeRanges[bestIndex]!
+      const allocated = { offset: range.offset, length }
+      if (range.length === length) {
+        this.freeRanges.splice(bestIndex, 1)
+      }
+      else {
+        range.offset += length
+        range.length -= length
+      }
+      return allocated
+    }
+
+    const allocated = { offset: this.nextOffset, length }
+    this.nextOffset += length
+    return allocated
+  }
+
+  private async writeAllocatedPayloads(
+    writes: Array<{ buffer: Buffer, range: ViteInspectPayloadRange }>,
+  ): Promise<void> {
+    const ordered = writes.toSorted((a, b) => a.range.offset - b.range.offset)
+    let buffers: Buffer[] = []
+    let startOffset = 0
+    let endOffset = 0
+
+    for (const write of ordered) {
+      if (buffers.length > 0 && write.range.offset !== endOffset) {
+        await this.writeBuffers(buffers, startOffset)
+        buffers = []
+      }
+      if (buffers.length === 0)
+        startOffset = write.range.offset
+      buffers.push(write.buffer)
+      endOffset = write.range.offset + write.range.length
+    }
+    if (buffers.length > 0)
+      await this.writeBuffers(buffers, startOffset)
+  }
+
+  private async writeBuffers(input: Buffer[], startOffset: number): Promise<void> {
+    let buffers = input
+    let offset = startOffset
+    while (buffers.length > 0) {
+      const { bytesWritten } = await this.file.writev(buffers, offset)
+      if (bytesWritten === 0) {
+        throw diagnostics.VDT0003({
+          operation: 'writing the inspect payload archive',
+        })
+      }
+      buffers = consumeBuffers(buffers, bytesWritten)
+      offset += bytesWritten
+    }
+  }
+
+  private mergeFreeRanges(): void {
+    this.freeRanges.sort((a, b) => a.offset - b.offset)
+    const merged: ViteInspectPayloadRange[] = []
+    for (const range of this.freeRanges) {
+      const previous = merged.at(-1)
+      if (!previous || range.offset > previous.offset + previous.length) {
+        merged.push({ ...range })
+        continue
+      }
+      previous.length = Math.max(
+        previous.length,
+        range.offset + range.length - previous.offset,
+      )
+    }
+    this.freeRanges = merged
+  }
+}
+
+function consumeBuffers(input: Buffer[], bytes: number): Buffer[] {
+  const buffers = input.slice()
+  let consumed = bytes
+  while (buffers.length > 0 && consumed >= buffers[0]!.length) {
+    consumed -= buffers[0]!.length
+    buffers.shift()
+  }
+  if (buffers.length > 0 && consumed > 0)
+    buffers[0] = buffers[0]!.subarray(consumed)
+  return buffers
+}

--- a/packages/vite/src/node/inspect/store/plugin-calls.ts
+++ b/packages/vite/src/node/inspect/store/plugin-calls.ts
@@ -1,0 +1,465 @@
+import type { FileHandle } from 'node:fs/promises'
+import type {
+  ViteInspectPluginCallInfo,
+  ViteInspectPluginCallType,
+} from '../types'
+import { Buffer } from 'node:buffer'
+import { open } from 'node:fs/promises'
+import { diagnostics } from '../../diagnostics'
+
+const RECORD_SIZE = 48
+const READ_RECORDS_PER_CHUNK = 4096
+const SLOT_STATE_CHUNK_SIZE = 64 * 1024
+
+const TYPE_RESOLVE = 0
+const TYPE_LOAD = 1
+const TYPE_TRANSFORM = 2
+
+const FLAG_HAS_UNCHANGED = 1 << 0
+const FLAG_UNCHANGED = 1 << 1
+
+const OFFSET_SCOPE_ID = 0
+const OFFSET_MODULE_ID = 4
+const OFFSET_PLUGIN_ID = 8
+const OFFSET_PLUGIN_NAME_ID = 12
+const OFFSET_SEQUENCE = 16
+const OFFSET_START = 24
+const OFFSET_END = 32
+const OFFSET_TYPE = 40
+const OFFSET_FLAGS = 41
+
+export interface InspectPluginCallWrite {
+  scope: string
+  info: ViteInspectPluginCallInfo
+}
+
+export interface InspectPluginCallStore {
+  write: (calls: InspectPluginCallWrite[]) => Promise<void>
+  read: (scope: string, pluginId: number) => Promise<ViteInspectPluginCallInfo[]>
+  invalidate: (scope: string, modules: Set<string>) => void
+  clearScope: (scope: string) => void
+  close: () => Promise<void>
+}
+
+interface ScopeState {
+  id: number
+  activeCalls: number
+  moduleIds: Map<string, number>
+  moduleNames: string[]
+  moduleHeads: number[]
+  pluginNameIds: Map<string, number>
+  pluginNames: string[]
+}
+
+interface EncodedCall {
+  slot: number
+  sourceOffset: number
+}
+
+interface WriteChunk {
+  startSlot: number
+  buffer: Buffer
+}
+
+interface PluginCallStorage {
+  write: (chunks: WriteChunk[]) => Promise<void>
+  read: (startSlot: number, count: number) => Promise<Buffer>
+  close: () => Promise<void>
+}
+
+export async function createInspectPluginCallStore(filename?: string): Promise<InspectPluginCallStore> {
+  const storage: PluginCallStorage = filename
+    ? new FilePluginCallStorage(await open(filename, 'w+'))
+    : new MemoryPluginCallStorage()
+  return new BinaryInspectPluginCallStore(storage)
+}
+
+class BinaryInspectPluginCallStore implements InspectPluginCallStore {
+  private readonly scopes = new Map<string, ScopeState>()
+  private readonly activeChunks: Uint8Array[] = []
+  private readonly nextSlotChunks: Uint32Array[] = []
+  private freeHead = 0
+  private nextScopeId = 0
+  private slotCount = 0
+
+  constructor(private readonly storage: PluginCallStorage) {}
+
+  async write(calls: InspectPluginCallWrite[]): Promise<void> {
+    if (calls.length === 0)
+      return
+
+    const buffer = Buffer.allocUnsafe(calls.length * RECORD_SIZE)
+    const encoded: EncodedCall[] = []
+
+    for (let index = 0; index < calls.length; index++) {
+      const call = calls[index]!
+      const scope = this.getScope(call.scope)
+      const moduleId = internString(scope.moduleIds, scope.moduleNames, call.info.module)
+      const pluginNameId = internString(scope.pluginNameIds, scope.pluginNames, call.info.plugin_name)
+      const slot = this.allocateSlot()
+      const offset = index * RECORD_SIZE
+
+      this.setNextSlot(slot, scope.moduleHeads[moduleId] ?? 0)
+      scope.moduleHeads[moduleId] = slot + 1
+      scope.activeCalls += 1
+      this.setActive(slot, true)
+      encodeCall(buffer, offset, scope.id, moduleId, pluginNameId, call.info)
+      encoded.push({ slot, sourceOffset: offset })
+    }
+
+    await this.storage.write(createWriteChunks(buffer, encoded))
+  }
+
+  async read(scopeName: string, pluginId: number): Promise<ViteInspectPluginCallInfo[]> {
+    const scope = this.scopes.get(scopeName)
+    if (!scope || scope.activeCalls === 0)
+      return []
+
+    const calls: ViteInspectPluginCallInfo[] = []
+    for (let startSlot = 0; startSlot < this.slotCount; startSlot += READ_RECORDS_PER_CHUNK) {
+      const count = Math.min(READ_RECORDS_PER_CHUNK, this.slotCount - startSlot)
+      const buffer = await this.storage.read(startSlot, count)
+      for (let index = 0; index < count; index++) {
+        const slot = startSlot + index
+        if (!this.isActive(slot))
+          continue
+
+        const offset = index * RECORD_SIZE
+        if (buffer.readUInt32LE(offset + OFFSET_SCOPE_ID) !== scope.id)
+          continue
+        if (buffer.readUInt32LE(offset + OFFSET_PLUGIN_ID) !== pluginId)
+          continue
+
+        const moduleId = buffer.readUInt32LE(offset + OFFSET_MODULE_ID)
+        const pluginNameId = buffer.readUInt32LE(offset + OFFSET_PLUGIN_NAME_ID)
+        const type = decodeType(buffer.readUInt8(offset + OFFSET_TYPE))
+        const flags = buffer.readUInt8(offset + OFFSET_FLAGS)
+        const sequence = buffer.readDoubleLE(offset + OFFSET_SEQUENCE)
+        const start = buffer.readDoubleLE(offset + OFFSET_START)
+        const end = buffer.readDoubleLE(offset + OFFSET_END)
+        calls.push({
+          type,
+          id: `${type}:${pluginId}:${sequence}`,
+          duration: Math.max(0, end - start),
+          plugin_id: pluginId,
+          plugin_name: scope.pluginNames[pluginNameId]!,
+          module: scope.moduleNames[moduleId]!,
+          timestamp_start: start,
+          timestamp_end: end,
+          unchanged: flags & FLAG_HAS_UNCHANGED
+            ? Boolean(flags & FLAG_UNCHANGED)
+            : undefined,
+        })
+      }
+      await yieldToEventLoop()
+    }
+    calls.sort((a, b) => callSequence(a.id) - callSequence(b.id))
+    return calls
+  }
+
+  invalidate(scopeName: string, modules: Set<string>): void {
+    const scope = this.scopes.get(scopeName)
+    if (!scope)
+      return
+
+    for (const module of modules) {
+      const moduleId = scope.moduleIds.get(module)
+      if (moduleId == null)
+        continue
+      this.releaseModuleSlots(scope, moduleId)
+    }
+  }
+
+  clearScope(scopeName: string): void {
+    const scope = this.scopes.get(scopeName)
+    if (!scope)
+      return
+    for (let moduleId = 0; moduleId < scope.moduleHeads.length; moduleId++)
+      this.releaseModuleSlots(scope, moduleId)
+    this.scopes.delete(scopeName)
+  }
+
+  async close(): Promise<void> {
+    this.scopes.clear()
+    this.activeChunks.length = 0
+    this.nextSlotChunks.length = 0
+    this.freeHead = 0
+    await this.storage.close()
+  }
+
+  private getScope(scopeName: string): ScopeState {
+    let scope = this.scopes.get(scopeName)
+    if (scope)
+      return scope
+    if (this.nextScopeId > 0xFFFF_FFFF) {
+      throw diagnostics.VDT0003({
+        operation: 'allocating an inspect plugin call scope',
+      })
+    }
+    scope = {
+      id: this.nextScopeId++,
+      activeCalls: 0,
+      moduleIds: new Map(),
+      moduleNames: [],
+      moduleHeads: [],
+      pluginNameIds: new Map(),
+      pluginNames: [],
+    }
+    this.scopes.set(scopeName, scope)
+    return scope
+  }
+
+  private allocateSlot(): number {
+    if (this.freeHead > 0) {
+      const slot = this.freeHead - 1
+      this.freeHead = this.getNextSlot(slot)
+      this.setNextSlot(slot, 0)
+      return slot
+    }
+    const slot = this.slotCount++
+    this.ensureSlotState(slot)
+    return slot
+  }
+
+  private releaseModuleSlots(scope: ScopeState, moduleId: number): void {
+    let head = scope.moduleHeads[moduleId] ?? 0
+    scope.moduleHeads[moduleId] = 0
+    while (head > 0) {
+      const slot = head - 1
+      const next = this.getNextSlot(slot)
+      if (this.isActive(slot)) {
+        this.setActive(slot, false)
+        this.setNextSlot(slot, this.freeHead)
+        this.freeHead = slot + 1
+        scope.activeCalls -= 1
+      }
+      head = next
+    }
+  }
+
+  private ensureSlotState(slot: number): void {
+    const chunkIndex = Math.floor(slot / SLOT_STATE_CHUNK_SIZE)
+    while (this.activeChunks.length <= chunkIndex) {
+      this.activeChunks.push(new Uint8Array(SLOT_STATE_CHUNK_SIZE))
+      this.nextSlotChunks.push(new Uint32Array(SLOT_STATE_CHUNK_SIZE))
+    }
+  }
+
+  private isActive(slot: number): boolean {
+    const chunkIndex = Math.floor(slot / SLOT_STATE_CHUNK_SIZE)
+    return this.activeChunks[chunkIndex]?.[slot % SLOT_STATE_CHUNK_SIZE] === 1
+  }
+
+  private setActive(slot: number, active: boolean): void {
+    this.ensureSlotState(slot)
+    this.activeChunks[Math.floor(slot / SLOT_STATE_CHUNK_SIZE)]![slot % SLOT_STATE_CHUNK_SIZE] = active ? 1 : 0
+  }
+
+  private getNextSlot(slot: number): number {
+    return this.nextSlotChunks[Math.floor(slot / SLOT_STATE_CHUNK_SIZE)]![slot % SLOT_STATE_CHUNK_SIZE]!
+  }
+
+  private setNextSlot(slot: number, next: number): void {
+    this.ensureSlotState(slot)
+    this.nextSlotChunks[Math.floor(slot / SLOT_STATE_CHUNK_SIZE)]![slot % SLOT_STATE_CHUNK_SIZE] = next
+  }
+}
+
+class FilePluginCallStorage implements PluginCallStorage {
+  constructor(private readonly file: FileHandle) {}
+
+  async write(chunks: WriteChunk[]): Promise<void> {
+    await Promise.all(chunks.map(chunk => writeBuffer(
+      this.file,
+      chunk.buffer,
+      chunk.startSlot * RECORD_SIZE,
+    )))
+  }
+
+  async read(startSlot: number, count: number): Promise<Buffer> {
+    const buffer = Buffer.allocUnsafe(count * RECORD_SIZE)
+    let offset = 0
+    while (offset < buffer.length) {
+      const { bytesRead } = await this.file.read(
+        buffer,
+        offset,
+        buffer.length - offset,
+        startSlot * RECORD_SIZE + offset,
+      )
+      if (bytesRead === 0) {
+        throw diagnostics.VDT0003({
+          operation: 'reading the inspect plugin call archive',
+        })
+      }
+      offset += bytesRead
+    }
+    return buffer
+  }
+
+  async close(): Promise<void> {
+    await this.file.close()
+  }
+}
+
+class MemoryPluginCallStorage implements PluginCallStorage {
+  private buffer = Buffer.alloc(0)
+
+  async write(chunks: WriteChunk[]): Promise<void> {
+    const requiredBytes = chunks.reduce((size, chunk) => {
+      return Math.max(size, chunk.startSlot * RECORD_SIZE + chunk.buffer.length)
+    }, this.buffer.length)
+    if (requiredBytes > this.buffer.length) {
+      const next = Buffer.allocUnsafe(Math.max(requiredBytes, this.buffer.length * 2, RECORD_SIZE * 1024))
+      this.buffer.copy(next)
+      this.buffer = next
+    }
+    for (const chunk of chunks)
+      chunk.buffer.copy(this.buffer, chunk.startSlot * RECORD_SIZE)
+  }
+
+  async read(startSlot: number, count: number): Promise<Buffer> {
+    return this.buffer.subarray(
+      startSlot * RECORD_SIZE,
+      (startSlot + count) * RECORD_SIZE,
+    )
+  }
+
+  async close(): Promise<void> {
+    this.buffer = Buffer.alloc(0)
+  }
+}
+
+function encodeCall(
+  buffer: Buffer,
+  offset: number,
+  scopeId: number,
+  moduleId: number,
+  pluginNameId: number,
+  info: ViteInspectPluginCallInfo,
+): void {
+  const sequence = callSequence(info.id)
+  if (!Number.isSafeInteger(sequence) || sequence < 0 || info.plugin_id < 0 || info.plugin_id > 0xFFFF_FFFF) {
+    throw diagnostics.VDT0003({
+      operation: 'encoding an inspect plugin call',
+    })
+  }
+  buffer.writeUInt32LE(scopeId, offset + OFFSET_SCOPE_ID)
+  buffer.writeUInt32LE(moduleId, offset + OFFSET_MODULE_ID)
+  buffer.writeUInt32LE(info.plugin_id, offset + OFFSET_PLUGIN_ID)
+  buffer.writeUInt32LE(pluginNameId, offset + OFFSET_PLUGIN_NAME_ID)
+  buffer.writeDoubleLE(sequence, offset + OFFSET_SEQUENCE)
+  buffer.writeDoubleLE(info.timestamp_start, offset + OFFSET_START)
+  buffer.writeDoubleLE(info.timestamp_end, offset + OFFSET_END)
+  buffer.writeUInt8(encodeType(info.type), offset + OFFSET_TYPE)
+  buffer.writeUInt8(
+    info.unchanged == null
+      ? 0
+      : FLAG_HAS_UNCHANGED | (info.unchanged ? FLAG_UNCHANGED : 0),
+    offset + OFFSET_FLAGS,
+  )
+  buffer.fill(0, offset + OFFSET_FLAGS + 1, offset + RECORD_SIZE)
+}
+
+function createWriteChunks(buffer: Buffer, calls: EncodedCall[]): WriteChunk[] {
+  const ordered = calls.toSorted((a, b) => a.slot - b.slot)
+  const chunks: WriteChunk[] = []
+  let start = 0
+  while (start < ordered.length) {
+    let end = start + 1
+    while (end < ordered.length && ordered[end]!.slot === ordered[end - 1]!.slot + 1)
+      end += 1
+
+    const firstSourceOffset = ordered[start]!.sourceOffset
+    const chunk = hasContiguousSources(ordered, start, end, firstSourceOffset)
+      ? buffer.subarray(firstSourceOffset, firstSourceOffset + (end - start) * RECORD_SIZE)
+      : copyEncodedCalls(buffer, ordered, start, end)
+    chunks.push({
+      startSlot: ordered[start]!.slot,
+      buffer: chunk,
+    })
+    start = end
+  }
+  return chunks
+}
+
+function hasContiguousSources(calls: EncodedCall[], start: number, end: number, firstOffset: number): boolean {
+  for (let index = start; index < end; index++) {
+    if (calls[index]!.sourceOffset !== firstOffset + (index - start) * RECORD_SIZE)
+      return false
+  }
+  return true
+}
+
+function copyEncodedCalls(buffer: Buffer, calls: EncodedCall[], start: number, end: number): Buffer {
+  const chunk = Buffer.allocUnsafe((end - start) * RECORD_SIZE)
+  for (let index = start; index < end; index++) {
+    buffer.copy(
+      chunk,
+      (index - start) * RECORD_SIZE,
+      calls[index]!.sourceOffset,
+      calls[index]!.sourceOffset + RECORD_SIZE,
+    )
+  }
+  return chunk
+}
+
+async function writeBuffer(file: FileHandle, buffer: Buffer, position: number): Promise<void> {
+  let offset = 0
+  while (offset < buffer.length) {
+    const { bytesWritten } = await file.write(
+      buffer,
+      offset,
+      buffer.length - offset,
+      position + offset,
+    )
+    if (bytesWritten === 0) {
+      throw diagnostics.VDT0003({
+        operation: 'writing the inspect plugin call archive',
+      })
+    }
+    offset += bytesWritten
+  }
+}
+
+function internString(ids: Map<string, number>, values: string[], value: string): number {
+  const existing = ids.get(value)
+  if (existing != null)
+    return existing
+  if (values.length > 0xFFFF_FFFF) {
+    throw diagnostics.VDT0003({
+      operation: 'interning inspect plugin call metadata',
+    })
+  }
+  const id = values.length
+  ids.set(value, id)
+  values.push(value)
+  return id
+}
+
+function callSequence(id: string): number {
+  return Number(id.slice(id.lastIndexOf(':') + 1))
+}
+
+function encodeType(type: ViteInspectPluginCallType): number {
+  if (type === 'resolve')
+    return TYPE_RESOLVE
+  if (type === 'load')
+    return TYPE_LOAD
+  return TYPE_TRANSFORM
+}
+
+function decodeType(type: number): ViteInspectPluginCallType {
+  if (type === TYPE_RESOLVE)
+    return 'resolve'
+  if (type === TYPE_LOAD)
+    return 'load'
+  if (type === TYPE_TRANSFORM)
+    return 'transform'
+  throw diagnostics.VDT0003({
+    operation: 'decoding an inspect plugin call',
+  })
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve))
+}

--- a/packages/vite/src/node/inspect/store/types.ts
+++ b/packages/vite/src/node/inspect/store/types.ts
@@ -1,0 +1,163 @@
+import type {
+  ViteInspectErrorInfo,
+  ViteInspectPluginCallInfo,
+  ViteInspectResolveIdInfo,
+  ViteInspectTransformInfo,
+} from '../types'
+
+export interface ViteInspectStoreOptions {
+  filename?: string
+  maxBatchItems?: number
+  maxBatchBytes?: number
+}
+
+export interface ViteInspectStoreStats {
+  maxBatchItems: number
+  maxBatchBytes: number
+  queuedItems: number
+  queuedBytes: number
+  inFlightItems: number
+  peakQueuedItems: number
+  peakQueuedBytes: number
+  writeBatches: number
+}
+
+export interface ViteInspectPayloadRange {
+  offset: number
+  length: number
+}
+
+export interface StoredViteInspectTransformInfo {
+  name: string
+  pluginId?: number
+  hasResult: boolean
+  result?: ViteInspectPayloadRange
+  resultSize: number
+  start: number
+  end: number
+  order?: string
+  sourcemaps?: ViteInspectPayloadRange
+  error?: ViteInspectErrorInfo
+}
+
+export interface ViteInspectTransformListItem {
+  moduleId: string
+  publicModuleId: string
+  name: string
+  pluginId?: number
+  hasResult: boolean
+  resultSize: number
+  start: number
+  end: number
+  invokeCount: number
+}
+
+export interface ViteInspectResolveIdItem {
+  sourceId: string
+  sourcePublicId: string
+  result: string
+  resultPublicId: string
+  name: string
+  pluginId?: number
+  start: number
+  end: number
+}
+
+export interface ViteInspectPluginMetricItem {
+  pluginId?: number
+  pluginName: string
+  invokeCount: number
+  totalTime: number
+}
+
+export interface ViteInspectStore {
+  recordTransform: (
+    scope: string,
+    moduleId: string,
+    publicModuleId: string,
+    info: ViteInspectTransformInfo,
+    preTransformCode: string,
+    pluginCall?: ViteInspectPluginCallInfo,
+  ) => void
+  recordLoad: (
+    scope: string,
+    moduleId: string,
+    publicModuleId: string,
+    info: ViteInspectTransformInfo,
+    pluginCall?: ViteInspectPluginCallInfo,
+  ) => void
+  recordResolveId: (
+    scope: string,
+    sourceId: string,
+    sourcePublicId: string,
+    info: ViteInspectResolveIdInfo,
+    resultPublicId: string,
+    pluginCall?: ViteInspectPluginCallInfo,
+  ) => void
+  recordPluginCall: (
+    scope: string,
+    info: ViteInspectPluginCallInfo,
+  ) => void
+  invalidate: (scope: string, moduleId: string, publicModuleId: string) => void
+  clearScope: (scope: string) => void
+  getTransformList: (scope: string) => Promise<ViteInspectTransformListItem[]>
+  getResolveIdList: (scope: string) => Promise<ViteInspectResolveIdItem[]>
+  getPluginTransformMetrics: (scope: string) => Promise<ViteInspectPluginMetricItem[]>
+  getPluginResolveIdMetrics: (scope: string) => Promise<ViteInspectPluginMetricItem[]>
+  getModuleTransforms: (scope: string, moduleId: string) => Promise<ViteInspectTransformInfo[]>
+  getPluginCalls: (scope: string, pluginId: number) => Promise<ViteInspectPluginCallInfo[]>
+  getFirstResolveResult: (scope: string, sourceId: string) => Promise<string | undefined>
+  findModuleId: (scope: string, publicModuleId: string) => Promise<string | undefined>
+  getModuleIds: (scope: string) => Promise<string[]>
+  getStats: () => ViteInspectStoreStats
+  flush: () => Promise<void>
+  close: () => Promise<void>
+}
+
+export type QueuedWrite
+  = | {
+    operation: 'recordTransform'
+    scope: string
+    moduleId: string
+    publicModuleId: string
+    info: ViteInspectTransformInfo
+    preTransformCode: string
+    pluginCall?: ViteInspectPluginCallInfo
+  }
+  | {
+    operation: 'recordLoad'
+    scope: string
+    moduleId: string
+    publicModuleId: string
+    info: ViteInspectTransformInfo
+    pluginCall?: ViteInspectPluginCallInfo
+  }
+  | {
+    operation: 'recordResolveId'
+    scope: string
+    sourceId: string
+    sourcePublicId: string
+    info: ViteInspectResolveIdInfo
+    resultPublicId: string
+    pluginCall?: ViteInspectPluginCallInfo
+  }
+  | {
+    operation: 'recordPluginCall'
+    scope: string
+    info: ViteInspectPluginCallInfo
+  }
+  | {
+    operation: 'invalidate'
+    scope: string
+    moduleId: string
+    publicModuleId: string
+  }
+  | {
+    operation: 'clearScope'
+    scope: string
+  }
+
+export interface PendingWrite {
+  estimatedBytes: number
+  write: QueuedWrite
+}

--- a/packages/vite/src/node/inspect/types.ts
+++ b/packages/vite/src/node/inspect/types.ts
@@ -75,6 +75,7 @@ export interface ViteInspectPluginCallInfo {
   plugin_id: number
   plugin_name: string
   module: string
+  graphModuleId?: string
   timestamp_start: number
   timestamp_end: number
   unchanged?: boolean

--- a/packages/vite/src/node/inspect/utils.ts
+++ b/packages/vite/src/node/inspect/utils.ts
@@ -59,14 +59,12 @@ export function parseError(error: unknown) {
       stack: typeof error.stack === 'string'
         ? error.stack.split('\n').map(line => line.trim()).filter(Boolean)
         : [],
-      raw: error,
     }
   }
 
   return {
     message: String(error),
     stack: [],
-    raw: error,
   }
 }
 
@@ -89,7 +87,7 @@ export function getAllQueryEnvs(ctx: ViteInspectContext): ViteInspectQuery[] {
   return result
 }
 
-export function getAllModuleIds(ctx: ViteInspectContext): [ViteInspectQuery, string][] {
+export async function getAllModuleIds(ctx: ViteInspectContext): Promise<[ViteInspectQuery, string][]> {
   const result: [ViteInspectQuery, string][] = []
   for (const vite of ctx.idToInstances.values()) {
     for (const [envName, env] of vite.environments) {
@@ -97,7 +95,7 @@ export function getAllModuleIds(ctx: ViteInspectContext): [ViteInspectQuery, str
         vite: vite.id,
         env: envName,
       }
-      for (const id of Object.keys(env.data.transform))
+      for (const id of await env.getModuleIds())
         result.push([query, id])
     }
   }

--- a/packages/vite/src/node/rpc/functions/vite-get-module-transform-info.ts
+++ b/packages/vite/src/node/rpc/functions/vite-get-module-transform-info.ts
@@ -9,8 +9,9 @@ export const viteGetModuleTransformInfo = defineRpcFunction({
   jsonSerializable: true,
   dump: async (devtoolsCtx) => {
     const ctx = getViteInspectContext(devtoolsCtx)
+    const moduleIds = await getAllModuleIds(ctx)
     return {
-      inputs: getAllModuleIds(ctx).map(([query, id]) => [query, id] satisfies [ViteInspectQuery, string]),
+      inputs: moduleIds.map(([query, id]) => [query, id] satisfies [ViteInspectQuery, string]),
     }
   },
   setup: (devtoolsCtx) => {

--- a/packages/vite/src/node/rpc/functions/vite-resolve-id.ts
+++ b/packages/vite/src/node/rpc/functions/vite-resolve-id.ts
@@ -9,8 +9,9 @@ export const viteResolveId = defineRpcFunction({
   jsonSerializable: true,
   dump: async (devtoolsCtx) => {
     const ctx = getViteInspectContext(devtoolsCtx)
+    const moduleIds = await getAllModuleIds(ctx)
     return {
-      inputs: getAllModuleIds(ctx).map(([query, id]) => [query, id] satisfies [ViteInspectQuery, string]),
+      inputs: moduleIds.map(([query, id]) => [query, id] satisfies [ViteInspectQuery, string]),
     }
   },
   setup: (devtoolsCtx) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7670,10 +7670,9 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.2:
-    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -9343,7 +9342,7 @@ snapshots:
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.8.5
-      tar: 7.5.2
+      tar: 7.5.19
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15970,7 +15969,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@7.5.2:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
# Context
 
This PR updates the persistence approach after evaluating a database-backed replacement for the previous memory-based solution.

 I first tried using a DB for both reading and writing runtime data, but found that Vite core generate data much faster than the DB can persist it. Under that write pressure, the DB approach becomes a bottleneck and is not viable for this use case.

After testing and comparing alternatives, this PR adopts disk  logs with in-memory metadata instead. This keeps high-volume writes append-friendly on disk while allowing the runtime to maintain fast metadata access in memory, which better matches the data flow and performance profile of Vite core.


# Benchmark

Compared the latest `perf/inspect-vite` working tree based on `bee29fc` with `main@67cf430`.

The workload uses 10,000 modules, 200 plugins, and 160,000 plugin calls. Results are medians from seven fresh Node.js processes using the production disk-backed storage path. Each run returned the expected 10,000 modules, 200 plugin metrics, 800 calls for the selected plugin, and 13 transform hooks for the selected module.

The benchmark ran on Node.js 24.14.0 and macOS 26.3. The harness follows the documented workload and result dimensions for this branch.

## Results

### Processing Time

| Operation | This branch | `main` | Change |
| --- | ---: | ---: | ---: |
| Ingest all events | 234.44 ms | 153.64 ms | 52.6% slower |
| Get modules list | 22.08 ms | 20.36 ms | 8.5% slower |
| Get plugin metrics | 4.72 ms | 16.63 ms | 71.6% faster |
| Get plugin details | 1.31 ms | 0.13 ms | 10.4x slower |
| Get module transform info | 0.86 ms | 6.70 ms | 87.2% faster |

Ingesting 160,000 plugin hook calls takes 234.44 ms on this branch, compared with 153.64 ms on `main`. While the relative increase is significant, the absolute overhead is about 81 ms, which is still modest for a workload of this size.

### Memory

| Metric | This branch | `main` | Change |
| --- | ---: | ---: | ---: |
| Incremental retained heap | +16.52 MiB | +142.84 MiB | 88.4% lower |
| Incremental RSS after ingestion | +75.70 MiB | +157.47 MiB | 51.9% lower |
| Incremental peak RSS | +75.70 MiB | +157.42 MiB | 51.9% lower |
| Inspect archive size | 116.14 MiB | 0 MiB | Stored on disk |

## Conclusion

- Plugin metrics are 71.6% faster, and module-transform queries are 87.2% faster than `main`.
- Plugin details read only the selected plugin's indexed segments and return its complete 800-call history. The query remains 10.4x slower than `main` because it reads and materializes those calls from disk.
- Module-list queries are 8.5% slower. This path also constructs the graph-module resolver that subsequent plugin-details queries reuse.
- At 160,000 plugin hook calls, disk persistence adds about 81 ms of ingestion overhead, a modest absolute cost for a workload of this size.
- Incremental retained heap is 88.4% lower, while retained and peak RSS are 51.9% lower than `main`.
