### PR TITLE
fix(core): propagate connection meta and owner document to popup

### DIFF
--- a/packages/core/src/client/webcomponents/state/__tests__/popup.test.ts
+++ b/packages/core/src/client/webcomponents/state/__tests__/popup.test.ts
@@ -52,6 +52,9 @@ function createMockContext(
     docks: {
       switchEntry: vi.fn(),
     },
+    rpc: {
+      connectionMeta: { backend: 'ws' },
+    },
   } as unknown as DocksContext
 }
 
@@ -175,6 +178,8 @@ describe('dock popup state', () => {
     expect(appRoot).toBeTruthy()
     expect(appRoot.id).toBe('vite-devtools-popup-root')
     expect(appRoot.appended).toHaveLength(1)
+    expect((popup as unknown as { __DEVFRAME_CONNECTION_META__?: unknown }).__DEVFRAME_CONNECTION_META__)
+      .toBe(context.rpc.connectionMeta)
   })
 
   it('hides dock overflow panel when opening popup', async () => {

--- a/packages/core/src/client/webcomponents/state/popup.ts
+++ b/packages/core/src/client/webcomponents/state/popup.ts
@@ -18,6 +18,7 @@ const PANEL_MAX_SIZE = 100
 const POPUP_MIN_WIDTH = 320
 const POPUP_MIN_HEIGHT = 240
 const MAIN_FRAME_ACTION_HANDLER_KEY = '__VITE_DEVTOOLS_TRIGGER_DOCK_ACTION__'
+const DEVFRAME_CONNECTION_META_KEY = '__DEVFRAME_CONNECTION_META__'
 
 const popupWindow = shallowRef<Window | null>(null)
 const isPopupOpen = shallowRef(false)
@@ -178,6 +179,8 @@ async function mountStandaloneApp(context: DocksContext, popup: Window) {
   popup.document.title = 'Vite DevTools'
   popup.document.head?.appendChild(baseStyle)
   popup.document.body.textContent = ''
+
+  ;(popup as Window & { [DEVFRAME_CONNECTION_META_KEY]?: unknown })[DEVFRAME_CONNECTION_META_KEY] = context.rpc.connectionMeta
 
   const appRoot = popup.document.createElement('div')
   appRoot.id = 'vite-devtools-popup-root'

--- a/packages/core/src/client/webcomponents/utils/useIframePanes.ts
+++ b/packages/core/src/client/webcomponents/utils/useIframePanes.ts
@@ -25,7 +25,7 @@ export function useIframePanes(
     container,
     (el) => {
       if (el && !panes.value) {
-        panes.value = markRaw(createIframePanes({ container: el }))
+        panes.value = markRaw(createIframePanes({ container: el, document: el.ownerDocument }))
         stop()
       }
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed the issue where iframes stayed stuck on "Loading iframe..." in popup mode, and the subsequent DevFrame connection issue that was exposed after fixing the iframe loading bug.

<img width="1335" height="733" alt="Vite DevTools Playground 2026_7_13 21_41_47" src="https://github.com/user-attachments/assets/31c5320f-b4c9-44bb-bfa6-e398577938f8" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
