### PR TITLE
fix(core): reposition FloatingPopover on window resize

### DIFF
--- a/packages/core/src/client/webcomponents/components/floating/FloatingPopover.ts
+++ b/packages/core/src/client/webcomponents/components/floating/FloatingPopover.ts
@@ -1,6 +1,6 @@
 import type { PropType, VNode } from 'vue'
 import type { FloatingPopoverProps } from '../../state/floating-tooltip'
-import { onClickOutside, useDebounceFn } from '@vueuse/core'
+import { onClickOutside, useDebounceFn, useEventListener } from '@vueuse/core'
 import { defineComponent, h, ref, useTemplateRef, watch } from 'vue'
 
 // @unocss-include
@@ -25,6 +25,11 @@ const FloatingPopoverComponent = defineComponent({
     const panel = useTemplateRef<HTMLDivElement>('panel')
     const el = ref(props.item?.el)
     const renderCounter = ref(0)
+
+    useEventListener(window, 'resize', () => {
+      if (el.value)
+        renderCounter.value++
+    })
 
     const clearThrottled = useDebounceFn(() => {
       if (props.item?.el == null)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Update the dropdown menu position in real time as the browser window is resized.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
