### PR TITLE
fix(core): prevent duplicate plugins in standalone mode

### DIFF
--- a/packages/core/playground/vite.config.ts
+++ b/packages/core/playground/vite.config.ts
@@ -1,8 +1,5 @@
 import process from 'node:process'
-import { createInspectDevframe } from '@devframes/plugin-inspect'
-import { createMessagesDevframe } from '@devframes/plugin-messages'
-import { createTerminalsDevframe } from '@devframes/plugin-terminals'
-import { createPluginFromDevframe, createSimpleClientScript } from '@vitejs/devtools-kit/node'
+import { createSimpleClientScript } from '@vitejs/devtools-kit/node'
 import Vue from '@vitejs/plugin-vue'
 import UnoCSS from 'unocss/vite'
 import { defineConfig } from 'vite'
@@ -13,7 +10,6 @@ import { A11yCheckerPlugin } from '../../../examples/plugin-a11y-checker/src/nod
 import { GitUIPlugin } from '../../../examples/plugin-git-ui/src/node'
 import { DevTools } from '../../core/src'
 import { buildCSS } from '../../core/src/client/webcomponents/scripts/build-css'
-import { hideDockWhenEmpty } from '../../core/src/node/plugins/auto-hide'
 import { DevToolsOxc } from '../../oxc/src/vite'
 // eslint-disable-next-line ts/ban-ts-comment
 // @ts-ignore ignore the type error
@@ -39,30 +35,6 @@ export default defineConfig({
   plugins: [
     VueRouter(),
     Vue(),
-    ...(() => {
-      // Mirror the shipped `DevTools()` mounts (the playground runs with
-      // `builtinDevTools: false`, so it re-creates them by hand): terminals
-      // and messages auto-hide from the dock bar while empty.
-      const terminalsDevframe = createTerminalsDevframe()
-      const messagesDevframe = createMessagesDevframe()
-      return [
-        createPluginFromDevframe(terminalsDevframe, {
-          dock: { category: '~builtin' },
-          setup(ctx) {
-            hideDockWhenEmpty(ctx, terminalsDevframe.id, () => ctx.terminals.sessions.size === 0)
-          },
-        }),
-        createPluginFromDevframe(messagesDevframe, {
-          dock: { category: '~builtin' },
-          setup(ctx) {
-            hideDockWhenEmpty(ctx, messagesDevframe.id, () => ctx.messages.entries.size === 0)
-          },
-        }),
-      ]
-    })(),
-    createPluginFromDevframe(createInspectDevframe(), {
-      dock: { category: '~builtin', icon: 'ph:stethoscope-duotone' },
-    }),
     {
       name: 'build-css',
       handleHotUpdate({ file }) {

--- a/packages/core/src/node/__tests__/standalone.test.ts
+++ b/packages/core/src/node/__tests__/standalone.test.ts
@@ -1,0 +1,40 @@
+import type { Plugin } from 'vite'
+import { describe, expect, it } from 'vitest'
+import { dedupeVitePlugins } from '../standalone'
+
+describe('dedupeVitePlugins', () => {
+  it('deduplicates every plugin injected by standalone regardless of its name prefix', () => {
+    const injectedNames = new Set([
+      'vite:devtools:server',
+      'devframe:devframes-plugin-messages',
+      'devtools-oxc',
+    ])
+    const plugins = [
+      { name: 'vite:devtools:server' },
+      { name: 'devframe:devframes-plugin-messages' },
+      { name: 'devtools-oxc' },
+      { name: 'vite:devtools:server' },
+      { name: 'devframe:devframes-plugin-messages' },
+      { name: 'devtools-oxc' },
+    ] as Plugin[]
+
+    dedupeVitePlugins(plugins, plugin => injectedNames.has(plugin.name))
+
+    expect(plugins.map(plugin => plugin.name)).toEqual([
+      'vite:devtools:server',
+      'devframe:devframes-plugin-messages',
+      'devtools-oxc',
+    ])
+  })
+
+  it('preserves duplicate plugins outside the standalone injection set', () => {
+    const plugins = [
+      { name: 'user-plugin' },
+      { name: 'user-plugin' },
+    ] as Plugin[]
+
+    dedupeVitePlugins(plugins, () => false)
+
+    expect(plugins).toHaveLength(2)
+  })
+})

--- a/packages/core/src/node/standalone.ts
+++ b/packages/core/src/node/standalone.ts
@@ -23,21 +23,21 @@ export async function startStandaloneDevTools(options: StandaloneDevToolsOptions
   } = options
 
   const { resolveConfig } = await import('vite')
+  const standalonePlugins = await DevTools()
   const resolved = await resolveConfig(
     {
       configFile: options.config,
       root: cwd,
-      plugins: [
-        DevTools(),
-      ],
+      plugins: standalonePlugins,
     },
     command,
     mode,
   )
 
+  const standalonePluginNames = new Set(standalonePlugins.map(plugin => plugin.name))
   dedupeVitePlugins(
     resolved.plugins as Plugin[],
-    plugin => plugin.name?.startsWith('vite:devtools'),
+    plugin => standalonePluginNames.has(plugin.name),
   )
 
   const context = await createDevToolsContext(resolved)


### PR DESCRIPTION
## Context

`play:standalone` resolves both the plugins declared in the playground Vite config and the plugins injected by the standalone launcher.

The previous deduplication only matched plugin names starting with `vite:devtools`. Devframe plugins and optional integrations use other names, so they could be initialized more than once, causing duplicate setup and RPC registrations.

## Changes

- Resolve the standalone `DevTools()` plugins once and deduplicate using their exact plugin names.
- Preserve duplicate user plugins that are unrelated to the standalone injection.
- Remove the playground’s redundant manual mounts for built-in Devframe plugins.