### PR TITLE
fix(core): use standalone root for integration detection

### DIFF
--- a/packages/core/src/node/plugins/__tests__/index.test.ts
+++ b/packages/core/src/node/plugins/__tests__/index.test.ts
@@ -1,0 +1,25 @@
+import { isPackageExists } from 'local-pkg'
+import { resolve } from 'pathe'
+import { describe, expect, it, vi } from 'vitest'
+import { DevTools } from '../index'
+
+vi.mock('local-pkg', () => ({
+  isPackageExists: vi.fn(() => false),
+}))
+
+describe('devTools', () => {
+  it('resolves optional integrations from the configured project directory', async () => {
+    const cwd = 'project/root'
+    const resolvedCwd = resolve(cwd)
+
+    await DevTools({ cwd })
+
+    expect(vi.mocked(isPackageExists)).toHaveBeenCalledTimes(4)
+    expect(vi.mocked(isPackageExists).mock.calls).toEqual([
+      ['@vitejs/devtools-rolldown', { paths: [resolvedCwd] }],
+      ['@vitejs/devtools-vite', { paths: [resolvedCwd] }],
+      ['@vitejs/devtools-vitest', { paths: [resolvedCwd] }],
+      ['@vitejs/devtools-oxc', { paths: [resolvedCwd] }],
+    ])
+  })
+})

--- a/packages/core/src/node/plugins/index.ts
+++ b/packages/core/src/node/plugins/index.ts
@@ -6,6 +6,7 @@ import { createTerminalsDevframe } from '@devframes/plugin-terminals'
 import { DEVTOOLS_INSPECTOR_DOCK_ID, DEVTOOLS_VITEPLUS_GROUP_ID } from '@vitejs/devtools-kit/constants'
 import { createInstallLauncher, createPluginFromDevframe } from '@vitejs/devtools-kit/node'
 import { isPackageExists } from 'local-pkg'
+import { resolve } from 'pathe'
 import { version } from '../../../package.json'
 import { hideDockWhenEmpty } from './auto-hide'
 import { DevToolsBuild } from './build'
@@ -90,6 +91,8 @@ const BUILTIN_INTEGRATIONS: BuiltinIntegration[] = [
 ]
 
 export interface DevToolsOptions {
+  /** Directory to search for installed integrations. */
+  cwd?: string
   /**
    * Include the Vite builtin devtools UI.
    *
@@ -120,6 +123,7 @@ export async function DevTools(options: DevToolsOptions = {}): Promise<Plugin[]>
     builtinDevTools = true,
     build,
   } = options
+  const cwd = resolve(options.cwd ?? process.cwd())
 
   const plugins = [
     DevToolsInjection(),
@@ -137,7 +141,6 @@ export async function DevTools(options: DevToolsOptions = {}): Promise<Plugin[]>
     // package is installed, its real plugin is mounted; when absent, a
     // discovery launcher is shown that installs it on demand, then prompts a
     // restart so the next config resolution mounts the real plugin.
-    const cwd = process.cwd()
     for (const integration of BUILTIN_INTEGRATIONS) {
       if (isPackageExists(integration.pkg, { paths: [cwd] })) {
         plugins.push(...await integration.load())

--- a/packages/core/src/node/standalone.ts
+++ b/packages/core/src/node/standalone.ts
@@ -28,7 +28,7 @@ export async function startStandaloneDevTools(options: StandaloneDevToolsOptions
       configFile: options.config,
       root: cwd,
       plugins: [
-        DevTools(),
+        DevTools({ cwd }),
       ],
     },
     command,


### PR DESCRIPTION
## Context

Standalone DevTools accepts a target project directory through `cwd`, but optional integrations were detected relative to `process.cwd()`.

When the CLI was launched from another directory, such as with `--root`, it could load integrations from the wrong project or show install launchers for integrations that were already installed. Relative `--root` values also need to be normalized before package resolution.

## Changes

- Allow `DevTools()` to use a configured directory for integration detection.
- Normalize the directory to an absolute path before resolving packages.
- Pass the standalone project directory to `DevTools()`.