### PR TITLE
fix(core): hide CommandPalette while dock popup is open

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockEmbedded.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEmbedded.vue
@@ -71,7 +71,7 @@ onUnmounted(() => {
     </template>
     <FloatingElements />
   </template>
-  <CommandPalette :context />
+  <CommandPalette v-if="!isDockPopupOpen" :context />
   <ToastOverlay :context />
   <Confirm v-if="!isDockPopupOpen" />
 </template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In popup mode, pressing `Ctrl+K` to open the Toggle Command Palette would open it in both the host page and the popup window, resulting in two Command Palettes being displayed. The host page should not open the palette in this scenario. This fix resolves the issue completely.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
