### PR TITLE
fix(shortcuts): hide shortcut binding for non-executable commands

### DIFF
--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsShortcuts.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsShortcuts.vue
@@ -54,6 +54,10 @@ function getEffectiveKeybindings(id: string): DevToolsCommandKeybinding[] {
   return commandsCtx.getKeybindings(id)
 }
 
+function isExecutable(command: DevToolsCommandEntry): boolean {
+  return command.source === 'server' || !!command.action
+}
+
 function isOverridden(id: string): boolean {
   return isKeybindingOverrideDifferentFromDefault(shortcutOverrides.value[id], getDefaultKeybindings(id))
 }
@@ -278,7 +282,7 @@ watch(editorOpen, (v) => {
       </div>
 
       <!-- Keybinding display -->
-      <div class="flex items-center gap-1.5 shrink-0">
+      <div v-if="isExecutable(row.command)" class="flex items-center gap-1.5 shrink-0">
         <template v-if="getEffectiveKeybindings(row.command.id).length > 0">
           <button
             v-for="(kb, ki) of getEffectiveKeybindings(row.command.id)"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed the issue where Dock Mode and Docks required shortcut bindings but could not be used. Since Dock Mode and Docks are group commands, they should not have shortcut bindings.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
