### PR TITLE
fix(dock): prevent group buttons from sharing popover state

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockGroupButton.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockGroupButton.vue
@@ -71,11 +71,13 @@ function togglePanel() {
 }
 
 // Delay syncing internal visibility from the store so it doesn't race the
-// "click outside" dismissal (same pattern as the overflow button).
+// "click outside" dismissal (same pattern as the overflow button). Compare by
+// element because `docksGroupPanel` is a single shared ref across every group
+// button — a sibling group's popover must not light up this one.
 watchDebounced(
   () => docksGroupPanel.value,
   (value) => {
-    isPanelVisible.value = !!value
+    isPanelVisible.value = value?.el === groupButton.value
   },
   { debounce: 1000 },
 )


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed an issue where opening the Vite+ or Playground dropdown menu caused the Vite+, Playground, and Nuxt icons to enlarge simultaneously.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
