### PR TITLE
chore: align package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "play:standalone": "pnpm -C packages/core run play:standalone",
     "example:plugin-file-explorer": "pnpm -C examples/plugin-file-explorer run play:dev",
     "postinstall": "npx simple-git-hooks && pnpm -C packages/rolldown run dev:prepare && skills-npm",
-    "lint": "eslint --cache",
+    "lint": "eslint --cache && pnpm -C packages/oxc run lint",
     "test": "vitest",
     "test:e2e": "pnpm -C e2e run test",
     "release": "bumpp -r",

--- a/packages/oxc/package.json
+++ b/packages/oxc/package.json
@@ -38,9 +38,7 @@
     "dev:prepare": "nuxi prepare src",
     "lint": "oxlint --ignore-pattern 'src/app/fixtures/**' && oxfmt --check . '!src/app/fixtures/**'",
     "lint:fix": "oxlint --fix --ignore-pattern 'src/app/fixtures/**' && oxfmt . '!src/app/fixtures/**'",
-    "play": "pnpm -C playground dev",
-    "prepack": "pnpm build",
-    "typecheck": "vue-tsc --noEmit"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "@vitejs/devtools-kit": "workspace:*",


### PR DESCRIPTION

### Description

- Ensure CI runs the Oxc package’s oxlint and oxfmt checks through the root lint script.
- Remove the unused play and typecheck scripts from the Oxc package.

### Linked Issues

N/A

### Additional context

N/A
