### PR TITLE
fix(kit): disable devframe auth prompt fallback

### DIFF
--- a/packages/kit/src/client/connection.test.ts
+++ b/packages/kit/src/client/connection.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDevToolsRpcClient } from './connection'
+
+const mocks = vi.hoisted(() => ({
+  getDevframeRpcClient: vi.fn(async () => ({})),
+}))
+
+vi.mock('@devframes/hub/client', () => ({
+  getDevframeRpcClient: mocks.getDevframeRpcClient,
+}))
+
+describe('getDevToolsRpcClient', () => {
+  beforeEach(() => {
+    mocks.getDevframeRpcClient.mockClear()
+  })
+
+  it('disables devframe simple auth in favor of the Vite DevTools auth UI', async () => {
+    await getDevToolsRpcClient({ baseURL: '/__devtools/' })
+
+    expect(mocks.getDevframeRpcClient).toHaveBeenCalledWith({
+      baseURL: '/__devtools/',
+      simpleAuth: false,
+    })
+  })
+
+  it('does not allow callers to enable the browser-prompt fallback', async () => {
+    await getDevToolsRpcClient({ simpleAuth: true })
+
+    expect(mocks.getDevframeRpcClient).toHaveBeenCalledWith({
+      simpleAuth: false,
+    })
+  })
+})

--- a/packages/kit/src/client/connection.ts
+++ b/packages/kit/src/client/connection.ts
@@ -12,9 +12,15 @@ import { getDevframeRpcClient } from '@devframes/hub/client'
  * `__connection.json` without dialing its own base's (wrong) endpoint — is
  * handled natively by devframe's client via `ConnectionMeta.baseUrl` since
  * devframe 0.7.2 (devframes/devframe#98), so no extra rewriting is needed here.
+ *
+ * Vite DevTools provides its own interactive authorization view, so disable
+ * devframe's native browser-prompt fallback for every kit-managed connection.
  */
 export function getDevToolsRpcClient(
   options: DevframeRpcClientOptions = {},
 ): Promise<DevframeRpcClient> {
-  return getDevframeRpcClient(options)
+  return getDevframeRpcClient({
+    ...options,
+    simpleAuth: false,
+  })
 }


### PR DESCRIPTION
## Summary

- disable devframe simple auth for kit-managed RPC clients
- keep authorization in the Vite DevTools interactive OTP UI
- cover the enforced client option with regression tests

## Testing

- pnpm exec vitest run
- pnpm typecheck
- pnpm exec eslint packages/kit/src/client/connection.ts packages/kit/src/client/connection.test.ts
- pnpm -C packages/kit run build