### PR TITLE
feat(core): allow configuring extra allowed origins for the DevTools WS transport

### DIFF
--- a/packages/core/src/node/config.ts
+++ b/packages/core/src/node/config.ts
@@ -24,6 +24,16 @@ export interface DevToolsConfig extends Partial<StartOptions> {
    * will be auto-approved without a terminal prompt.
    */
   clientAuthTokens?: string[]
+  /**
+   * Origins allowed to open the DevTools WebSocket connection, in addition to the built-in
+   * loopback allowlist (`localhost`, `127.0.0.1`, etc).
+   *
+   * The loopback check is a plain string match against the `Origin` header, not a DNS/hosts-file
+   * resolution — a custom dev hostname that resolves to loopback via `/etc/hosts` or a local DNS
+   * override (e.g. `dev-my-app.example.com`) is invisible to it and gets rejected. List such
+   * hostnames here explicitly.
+   */
+  allowedOrigins?: string[]
 }
 
 export interface ResolvedDevToolsConfig {

--- a/packages/core/src/node/ws.ts
+++ b/packages/core/src/node/ws.ts
@@ -15,6 +15,7 @@ import { attachWsRpcTransport } from 'devframe/rpc/transports/ws-server'
 import { colors as c } from 'devframe/utils/colors'
 import { getPort } from 'get-port-please'
 import { createDebug } from 'obug'
+import type { DevToolsConfig } from './config'
 import { getAuthHandler } from './auth-handler'
 import { MARK_INFO } from './constants'
 import { diagnostics } from './diagnostics'
@@ -146,8 +147,16 @@ export async function createWsServer(options: CreateWsServerOptions) {
     ? { server: viteHttpServer, path: DEVTOOLS_WS_PATH, destroyUnmatched: false }
     : { port: port!, host, https }
 
+  // Vite's published types bundle a frozen snapshot of `DevToolsConfig` (to type
+  // `ResolvedConfig.devtools` without depending on this package at runtime), so a field just
+  // added here isn't visible through `context.viteConfig.devtools.config` until Vite re-vendors
+  // it — the same gap `vite-augment.ts` works around for `Plugin.devtools`. Read it through a
+  // narrow cast rather than waiting on that.
+  const allowedOrigins = (context.viteConfig.devtools?.config as DevToolsConfig | undefined)?.allowedOrigins
+
   attachWsRpcTransport(rpcGroup, {
     ...binding,
+    allowedOrigins,
     definitions: rpcHost.definitions,
     onConnected: (peer, meta) => {
       // crossws exposes the upgrade request (with its query string + headers)


### PR DESCRIPTION
## Summary

The WS transport's origin check (`isAllowedOrigin` in `devframe`'s `attachWsRpcTransport`) only recognizes literal loopback hostname patterns (`localhost`, `127.0.0.1`, `::1`, `*.localhost`) — it's a plain string match against the `Origin` header, not a DNS/hosts-file resolution. A custom dev hostname that resolves to loopback via `/etc/hosts` (a common pattern for running several HTTPS dev servers locally, each with its own hostname/cert) is invisible to that check, so every real browser connection gets rejected with a `403` before the WS handshake completes — even though the connection is genuinely local.

`attachWsRpcTransport` already accepts an `allowedOrigins` option for exactly this case, but `@vitejs/devtools`'s own `createWsServer` never passes it through, and `DevToolsConfig` has no field for it.

This PR:
- Adds `DevToolsConfig.allowedOrigins?: string[]`
- Threads it through to `attachWsRpcTransport({ ..., allowedOrigins })` in `packages/core/src/node/ws.ts`

Read through a narrow local cast rather than `context.viteConfig.devtools?.config?.allowedOrigins` directly, since Vite's published types bundle a frozen snapshot of `DevToolsConfig` and won't see a brand-new field until re-vendored — the same gap `vite-augment.ts` already works around for `Plugin.devtools`.

## Test plan

Reproduced against a local embedded (route-bound) DevTools instance behind a custom `/etc/hosts`-aliased HTTPS hostname:
- [x] Before this change: every real browser connection to `/__devtools/__ws` got `403 Forbidden` immediately (confirmed via a raw `https.request` upgrade probe with the browser's actual `Origin` header) — the client sat in `status: "error"` / `isTrusted: false` and eventually surfaced "Unauthorized" / a 60s RPC-trust timeout in the UI.
- [x] After this change, with the custom origin added via `devtools: { allowedOrigins: [...] }`: the WS handshake completes (`101`), the client reaches `status: "connected"` / `isTrusted: true`, and a custom dock renders live data.
- [x] `tsc --noEmit` on `packages/core` shows no new errors from these two files.
- [x] `oxlint` on the two touched files is clean.