### PR TITLE
fix(core): scroll selected command palette item into view inside shad…

### DIFF
--- a/packages/core/src/client/webcomponents/components/command-palette/CommandPalette.vue
+++ b/packages/core/src/client/webcomponents/components/command-palette/CommandPalette.vue
@@ -19,6 +19,7 @@ const show = computed({
 const search = ref('')
 const selectedIndex = ref(0)
 const searchInput = useTemplateRef<HTMLInputElement>('searchInput')
+const listContainer = useTemplateRef<HTMLElement>('listContainer')
 const visible = ref(false)
 
 // Breadcrumb stack for sub-command drill-down
@@ -113,7 +114,8 @@ function scrollToItem() {
   const item = filtered.value[selectedIndex.value]
   if (!item)
     return
-  const el = document.getElementById(`cmd-${item.entry.id}`)
+  const root = listContainer.value?.getRootNode() as ShadowRoot | Document | undefined
+  const el = root?.getElementById(`cmd-${item.entry.id}`)
   el?.scrollIntoView({ block: 'nearest' })
 }
 
@@ -289,7 +291,7 @@ function getKeybindings(id: string) {
           </header>
 
           <!-- Items -->
-          <div class="flex-1 of-y-auto p-1.5">
+          <div ref="listContainer" class="flex-1 of-y-auto p-1.5">
             <CommandPaletteItem
               v-for="(item, idx) of filtered"
               :key="item.entry.id"


### PR DESCRIPTION
…ow root

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix an issue where the view doesn't scroll to follow keyboard navigation in the `Toggle Command Palette`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
