### PR TITLE
fix(core): hide stale panes when switching docks in popup mode

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockPanel.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockPanel.vue
@@ -6,7 +6,7 @@ import type { DockLayout } from './dock-layout'
 import { useElementBounding, useWindowSize } from '@vueuse/core'
 import { computed, onMounted, reactive, ref, toRefs, useTemplateRef } from 'vue'
 import { getEntryGroup } from '../../state/dock-settings'
-import { useIframePanes } from '../../utils/useIframePanes'
+import { getEntryPaneKey, useIframePanes } from '../../utils/useIframePanes'
 import ViewEntry from '../views/ViewEntry.vue'
 import { DEFAULT_DOCK_LAYOUT, resolveDockAnchor } from './dock-layout'
 import { openDockContextMenu } from './DockContextMenu'
@@ -36,7 +36,7 @@ const mousePosition = reactive({ x: 0, y: 0 })
 
 const dockPanel = useTemplateRef<HTMLDivElement>('dockPanel')
 const viewsContainer = useTemplateRef<HTMLElement>('viewsContainer')
-const panes = useIframePanes(viewsContainer, context.panel)
+const panes = useIframePanes(viewsContainer, context.panel, () => getEntryPaneKey(selected.value))
 
 function openContextMenu(e: MouseEvent) {
   if (!dockPanel.value)

--- a/packages/core/src/client/webcomponents/components/dock/DockStandalone.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockStandalone.vue
@@ -2,7 +2,7 @@
 import type { DocksContext } from '@vitejs/devtools-kit/client'
 import { computed, useTemplateRef, watch } from 'vue'
 import { getEntryGroup } from '../../state/dock-settings'
-import { useIframePanes } from '../../utils/useIframePanes'
+import { getEntryPaneKey, useIframePanes } from '../../utils/useIframePanes'
 import { useIsRpcTrusted } from '../../utils/useIsRpcTrusted'
 import CommandPalette from '../command-palette/CommandPalette.vue'
 import Confirm from '../display/Confirm.vue'
@@ -20,7 +20,7 @@ const props = defineProps<{
 
 const context = props.context
 const viewsContainer = useTemplateRef<HTMLElement>('viewsContainer')
-const panes = useIframePanes(viewsContainer, context.panel)
+const panes = useIframePanes(viewsContainer, context.panel, () => getEntryPaneKey(context.docks.selected))
 
 const isRpcTrusted = useIsRpcTrusted(context, (isTrusted) => {
   if (!isTrusted) {

--- a/packages/core/src/client/webcomponents/utils/useIframePanes.ts
+++ b/packages/core/src/client/webcomponents/utils/useIframePanes.ts
@@ -1,8 +1,15 @@
+import type { DevToolsDockEntry } from '@vitejs/devtools-kit'
 import type { DocksPanelContext } from '@vitejs/devtools-kit/client'
 import type { IframePanes } from 'iframe-pane'
 import type { ShallowRef } from 'vue'
 import { createIframePanes } from 'iframe-pane'
 import { markRaw, onScopeDispose, shallowRef, watch } from 'vue'
+
+export function getEntryPaneKey(entry: DevToolsDockEntry | null | undefined): string | null {
+  if (!entry)
+    return null
+  return entry.type === 'iframe' ? (entry.frameId ?? entry.id) : entry.id
+}
 
 /**
  * Own an {@link IframePanes} manager for a dock shell, parking its persistent
@@ -18,6 +25,7 @@ import { markRaw, onScopeDispose, shallowRef, watch } from 'vue'
 export function useIframePanes(
   container: Readonly<ShallowRef<HTMLElement | undefined | null>>,
   panel?: DocksPanelContext,
+  getActiveKey?: () => string | null,
 ): Readonly<ShallowRef<IframePanes | undefined>> {
   const panes = shallowRef<IframePanes>()
 
@@ -31,6 +39,19 @@ export function useIframePanes(
     },
     { immediate: true, flush: 'post' },
   )
+
+  if (getActiveKey) {
+    watch(
+      getActiveKey,
+      (activeKey) => {
+        panes.value?.list().forEach((pane) => {
+          if (pane.id !== activeKey)
+            pane.hide()
+        })
+      },
+      { flush: 'post' },
+    )
+  }
 
   if (panel) {
     // A panel move changes its box position without resizing the target, so the


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed the issue where stale panes were not hidden when switching docks in `popup` mode, causing panel overlap.

like this:
<img width="1080" height="587" alt="屏幕截图_24-7-2026_22290_" src="https://github.com/user-attachments/assets/7c55ab83-0c59-43e1-b517-992799277f42" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
