### PR TITLE
fix(core): command palette dark-on-dark text + glass-panel mismatch

### DIFF
--- a/packages/core/src/client/webcomponents/components/command-palette/CommandPalette.vue
+++ b/packages/core/src/client/webcomponents/components/command-palette/CommandPalette.vue
@@ -265,7 +265,7 @@ function getKeybindings(id: string) {
       >
         <ViteDevToolsLogo class="absolute top--32px left-5px w-60 pointer-events-none" />
         <div
-          class="w-full w-lg bg-base border border-base rounded-lg shadow-xl pointer-events-auto of-hidden flex flex-col max-h-[60vh]"
+          class="w-full w-lg bg-glass:75 color-base border border-base rounded-lg shadow-xl pointer-events-auto of-hidden flex flex-col max-h-[60vh]"
         >
           <!-- Header -->
           <header class="border-b border-base flex items-center px-3">
@@ -284,7 +284,7 @@ function getKeybindings(id: string) {
             <input
               ref="searchInput"
               v-model="search"
-              class="flex-1 bg-transparent py-3 outline-none text-sm text-base"
+              class="flex-1 bg-transparent py-3 outline-none text-sm color-base"
               placeholder="Type a command..."
               @keydown="onKeyDown"
             >

--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsDocks.vue
@@ -418,7 +418,7 @@ function resetCustomOrderForContainer(container: string) {
               >
                 <div
                   :class="settings.docksPinned.includes(dock.id) ? 'i-ph-push-pin-fill rotate--45' : 'i-ph-push-pin'"
-                  class="text-base"
+                  class="color-base"
                 />
               </button>
             </div>
@@ -542,7 +542,7 @@ function resetCustomOrderForContainer(container: string) {
                     >
                       <div
                         :class="settings.docksPinned.includes(member.id) ? 'i-ph-push-pin-fill rotate--45' : 'i-ph-push-pin'"
-                        class="text-base"
+                        class="color-base"
                       />
                     </button>
                   </div>


### PR DESCRIPTION
## Summary

The command palette overlay (Cmd+K) had two small visual bugs, both traced to a shortcut-name typo:

- **Dark-on-dark text**: the search input and the pin-toggle icons in the Docks settings view used class `text-base` — that's UnoCSS/Tailwind's built-in font-size utility (`font-size: 1rem`), not a color shortcut. It sets no `color` at all. The dark-aware text-color shortcut in this repo is `color-base` (`packages/ui/src/unocss/shared-shortcuts.ts`). Since the dialog background correctly switches to near-black in dark mode but the input text fell back to the browser default, the result was unreadable text in dark mode.
- **Glass-panel mismatch**: the palette dialog used an opaque `bg-base` background, while the actual docked panels (`DockPanel.vue`, `DockEdge.vue`) both use the translucent/blurred `bg-glass:75` shortcut. The palette was the one surface that didn't match the rest of the floating dock chrome.

## Changes

- `CommandPalette.vue`: `text-base` → `color-base` on the search input; `bg-base` → `bg-glass:75 color-base` on the dialog surface (matches `DockPanel.vue`/`DockEdge.vue` exactly).
- `SettingsDocks.vue`: same `text-base` → `color-base` typo fix on the two pin-toggle icons (identical bug, bundled since it's a one-line, zero-risk fix).

| Before | After |
|---|---|
| <img width="540" height="533" alt="Screenshot 2026-07-24 at 23 04 25" src="https://github.com/user-attachments/assets/f9992e26-686d-49e3-be50-b9afb751cde5" /> | <img width="540" height="533" alt="image" src="https://github.com/user-attachments/assets/a89ed25e-acc1-4c84-b0dd-d2324c3feac0" />
|


## Test plan

- [x] Verified in the `playgrounds/core` dev server, dark mode: command palette input text is now readable, dialog background matches the docked panel's glass/blur look (confirmed via computed styles: `background-color: rgba(17,17,17,0.75)`, `backdrop-filter: blur(7px)`, identical to `DockPanel`/`DockEdge`).
- [x] Verified light mode: no regression.
- [x] `pnpm run typecheck` (`vue-tsc -b`) clean.
- [x] eslint clean on both touched files.