### PR TITLE
fix(core): prevent popup dock icons from being dimmed

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockEntries.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntries.vue
@@ -8,12 +8,15 @@ import { sharedStateToRef } from '../../state/docks'
 import DockEntry from './DockEntry.vue'
 import DockGroupButton from './DockGroupButton.vue'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   context: DocksContext
   entries: DevToolsDockEntry[]
   selected: DevToolsDockEntry | null
   isVertical: boolean
-}>()
+  dimInactive?: boolean
+}>(), {
+  dimInactive: true,
+})
 
 const emit = defineEmits<{
   (e: 'select', entry: DevToolsDockEntry): void
@@ -62,6 +65,7 @@ function toggleDockEntry(dock: DevToolsDockEntry) {
         :group="dock"
         :is-vertical="isVertical"
         :selected="selected"
+        :dim-inactive="dimInactive"
         @select="(e) => emit('select', e)"
       />
       <DockEntry
@@ -70,7 +74,7 @@ function toggleDockEntry(dock: DevToolsDockEntry) {
         :dock
         :is-action="dock.type === 'action'"
         :is-selected="selected?.id === dock.id"
-        :is-dimmed="selected ? (selected.id !== dock.id) : false"
+        :is-dimmed="dimInactive && selected ? (selected.id !== dock.id) : false"
         :is-vertical="isVertical"
         :badge="dock.badge"
         @click="toggleDockEntry(dock)"

--- a/packages/core/src/client/webcomponents/components/dock/DockEntriesWithCategories.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntriesWithCategories.vue
@@ -10,8 +10,10 @@ withDefaults(defineProps<{
   selected: DevToolsDockEntry | null
   isVertical: boolean
   rotate?: boolean
+  dimInactive?: boolean
 }>(), {
   rotate: true,
+  dimInactive: true,
 })
 
 const emit = defineEmits<{
@@ -29,6 +31,7 @@ const emit = defineEmits<{
       :entries="entries"
       :is-vertical="isVertical && rotate"
       :selected="selected"
+      :dim-inactive="dimInactive"
       @select="(e) => emit('select', e)"
     />
   </template>

--- a/packages/core/src/client/webcomponents/components/dock/DockGroupButton.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockGroupButton.vue
@@ -9,12 +9,15 @@ import { setDocksGroupPanel, useDocksGroupPanel } from '../../state/floating-too
 import DockEntry from './DockEntry.vue'
 import DockGroupPopover from './DockGroupPopover.vue'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   context: DocksContext
   group: DevToolsViewGroup
   isVertical: boolean
   selected: DevToolsDockEntry | null
-}>()
+  dimInactive?: boolean
+}>(), {
+  dimInactive: true,
+})
 
 const emit = defineEmits<{
   (e: 'select', entry: DevToolsDockEntry): void
@@ -122,7 +125,7 @@ function onClick() {
       :dock="group"
       :is-vertical="isVertical"
       :is-selected="isActive || isPanelVisible"
-      :is-dimmed="selected ? !isActive : false"
+      :is-dimmed="dimInactive && selected ? !isActive : false"
       :badge="group.badge"
       @click="onClick"
     />

--- a/packages/core/src/client/webcomponents/components/dock/DockStandalone.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockStandalone.vue
@@ -61,6 +61,7 @@ function switchEntry(id: string | undefined) {
           :groups="groupedEntries"
           :is-vertical="false"
           :selected="context.docks.selected"
+          :dim-inactive="false"
           @select="(e) => switchEntry(e?.id)"
         >
           <template #separator>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed an issue where dock sidebar icons became greyed out in `popup` mode (especially noticeable with brand icons like `Vite+` and `Nuxt`).

before:
<img width="320" height="659" alt="屏幕截图_25-7-2026_124753_" src="https://github.com/user-attachments/assets/ae87b832-e530-4a10-9877-fb4f18d71414" />

now:
<img width="485" height="688" alt="屏幕截图_25-7-2026_12485_" src="https://github.com/user-attachments/assets/369e0908-6979-4db4-ad1a-ab84f847dbb5" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
