### PR TITLE
fix(core): add vite server fallback for embedded connections

### DIFF
--- a/packages/core/src/client/inject/runtime.test.ts
+++ b/packages/core/src/client/inject/runtime.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startDevTools } from './runtime'
+
+const mocks = vi.hoisted(() => ({
+  getDevToolsRpcClient: vi.fn(
+    (_options: { baseURL: string[] }) => new Promise(() => {}),
+  ),
+}))
+
+vi.mock('@vitejs/devtools-kit/client', () => ({
+  CLIENT_CONTEXT_KEY: '__VITE_DEVTOOLS_CLIENT_CONTEXT__',
+  getDevToolsRpcClient: mocks.getDevToolsRpcClient,
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useLocalStorage: vi.fn(),
+}))
+
+vi.mock('../webcomponents/state/context', () => ({
+  createDocksContext: vi.fn(),
+}))
+
+describe('injected DevTools runtime', () => {
+  beforeEach(() => {
+    const hostWindow = {
+      addEventListener: vi.fn(),
+    } as unknown as Window
+    Object.defineProperty(hostWindow, 'parent', { value: hostWindow })
+    vi.stubGlobal('window', hostWindow)
+
+    startDevTools('normal')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    mocks.getDevToolsRpcClient.mockClear()
+  })
+
+  it('preserves the host-relative mount path as the primary base', () => {
+    const options = mocks.getDevToolsRpcClient.mock.calls[0]![0]
+
+    expect(options.baseURL).toHaveLength(2)
+    expect(options.baseURL[0]).toBe('/__devtools/')
+  })
+
+  it('adds the Vite module origin as the fallback base', () => {
+    const options = mocks.getDevToolsRpcClient.mock.calls[0]![0]
+
+    expect(options.baseURL[1]).toBe(
+      new URL('/__devtools/', import.meta.url).href,
+    )
+  })
+})

--- a/packages/core/src/client/inject/runtime.ts
+++ b/packages/core/src/client/inject/runtime.ts
@@ -50,10 +50,15 @@ async function mountDock(): Promise<void> {
   if (dockEl)
     return
 
-  // Inject runs in the user's host page, so `document.baseURI` points at
-  // the user's app — not at the Vite DevTools mount. Pass the mount path
-  // explicitly so the connection meta lookup hits `/__devtools/__connection.json`.
-  const rpc = await getDevToolsRpcClient({ baseURL: DEVTOOLS_MOUNT_PATH })
+  // Prefer the host page's origin for backwards compatibility. When the page
+  // is served by another backend, fall back to the Vite origin that loaded
+  // this module.
+  const rpc = await getDevToolsRpcClient({
+    baseURL: [
+      DEVTOOLS_MOUNT_PATH,
+      new URL(DEVTOOLS_MOUNT_PATH, import.meta.url).href,
+    ],
+  })
 
   const state = useLocalStorage<DockPanelStorage>(
     'vite-devtools-dock-state',


### PR DESCRIPTION
The embedded client currently loads connection metadata from the page origin. When the page is served by a separate backend, this can point to the wrong server.

This PR:

keeps the existing `/__devtools/` base as the first candidate

falls back to the vite server URL inferred from import.meta.url

preserves existing same-origin and proxied setups

adds unit tests for both candidate URLs and their priority

Related devframe change

This relies on [devframes/devframe#146](https://github.com/devframes/devframe/pull/146).

fetch() resolves normally for HTTP errors such as 404. If the response body is valid JSON, the previous implementation could treat it as connection metadata and never try the fallback URL.

devframes/devframe#146 checks response.ok before parsing the response, allowing connection discovery to continue with the next candidate after an HTTP error.

Fixes [#489](https://github.com/vitejs/devtools/issues/489).