### PR TITLE
fix(core): forward loading to json-render Button's underlying BaseButton

### DIFF
--- a/packages/core/src/client/webcomponents/json-render/JsonRender.stories.ts
+++ b/packages/core/src/client/webcomponents/json-render/JsonRender.stories.ts
@@ -55,10 +55,12 @@ export const Gallery: Story = {
       b2: { type: 'Badge', props: { text: '3 warnings', variant: 'warning' } },
       b3: { type: 'Badge', props: { text: '1 error', variant: 'danger' } },
       b4: { type: 'Badge', props: { text: 'v0.3.4', variant: 'default' } },
-      buttons: { type: 'Stack', props: { direction: 'row', gap: 8 }, children: ['btn1', 'btn2', 'btn3'] },
+      buttons: { type: 'Stack', props: { direction: 'row', gap: 8 }, children: ['btn1', 'btn2', 'btn3', 'btn4'] },
       btn1: { type: 'Button', props: { label: 'Rebuild', variant: 'primary', icon: 'ph:arrows-clockwise' } },
       btn2: { type: 'Button', props: { label: 'Open', variant: 'secondary', icon: 'ph:arrow-square-out' } },
       btn3: { type: 'Button', props: { label: 'Delete', variant: 'danger', icon: 'ph:trash' } },
+      /* `icon` is intentionally still set here — `loading` takes priority and replaces it with the spinner, so this also demonstrates that precedence. */
+      btn4: { type: 'Button', props: { label: 'Deploying…', variant: 'primary', icon: 'ph:rocket-launch', loading: true } },
       progress: { type: 'Progress', props: { value: 68, max: 100, label: 'Bundling' } },
       toggle: { type: 'Switch', props: { label: 'Notifications', value: '{{notifications}}' } },
       divider: { type: 'Divider', props: { label: 'Details' } },

--- a/packages/core/src/client/webcomponents/json-render/components/Button.ts
+++ b/packages/core/src/client/webcomponents/json-render/components/Button.ts
@@ -11,6 +11,8 @@ export interface ButtonProps {
   variant?: BaseVariant
   icon?: string
   disabled?: boolean
+  /** Shows `BaseButton`'s spinner in place of `icon` and implies `disabled`. */
+  loading?: boolean
 }
 
 export const Button = defineComponent({
@@ -18,7 +20,7 @@ export const Button = defineComponent({
   props: registryProps<'Button', ButtonProps>(),
   setup(ctx) {
     return () => {
-      const { label, icon, variant = 'secondary', disabled } = ctx.element.props
+      const { label, icon, variant = 'secondary', disabled, loading } = ctx.element.props
       const press = ctx.on('press')
       const resolved: BaseVariant = VARIANTS.has(variant) ? variant : 'secondary'
 
@@ -26,6 +28,7 @@ export const Button = defineComponent({
         variant: resolved,
         size: 'sm',
         disabled,
+        loading,
         onClick: () => press.emit(),
       }, {
         icon: icon

--- a/test/__snapshots__/tsnapi/@vitejs/devtools/client/webcomponents.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vitejs/devtools/client/webcomponents.snapshot.d.ts
@@ -13,6 +13,7 @@ export interface ButtonProps {
   variant?: BaseVariant;
   icon?: string;
   disabled?: boolean;
+  loading?: boolean;
 }
 export interface CodeBlockProps {
   code?: string;


### PR DESCRIPTION
## Summary
- `JrButton` (json-render's `Button` catalog element) never read `element.props.loading`, so a spec-driven Button with `loading: true` silently dropped it — only `disabled`/`icon` actually reached the rendered button.
- `BaseButton` (`display/Button.vue`) already fully supports `loading` (renders its spinner in place of the icon slot), it just wasn't wired through.
- Adds `loading?: boolean` to `ButtonProps`, destructures it, and forwards it to `BaseButton`.
- Adds a `loading` example to the `JsonRender.stories.ts` Gallery story (button stays `icon`-set to demonstrate that `loading` takes precedence and swaps in the spinner).

## Test plan
- [x] `pnpm run typecheck` (vue-tsc -b)
- [x] `pnpm eslint` on the two changed files
- [x] `pnpm run build:js` + client build in `packages/core`
- [ ] Visual check in Storybook (`JsonRender/Gallery`) — the added `Deploying…` button shows the spinner instead of its icon