### PR TITLE
fix: keep plugin flow timeline visible when the calls table overflows

### DIFF
--- a/packages/rolldown/src/app/components/flowmap/PluginFlow.vue
+++ b/packages/rolldown/src/app/components/flowmap/PluginFlow.vue
@@ -100,7 +100,7 @@ function toggleShowType() {
 <template>
   <div class="p2 h-full w-full">
     <div class="flex border border-base rounded-2 h-full relative of-hidden">
-      <div v-if="expanded" class="of-hidden border-r border-base">
+      <div v-if="expanded" class="of-hidden border-r border-base shrink-0">
         <FlowmapPluginFlowTimeline
           :session="session"
           :build-metrics="buildMetrics"
@@ -114,7 +114,7 @@ function toggleShowType() {
           </template>
         </FlowmapPluginFlowTimeline>
       </div>
-      <div class="flex-1 h-full min-h-0 flex flex-col">
+      <div class="flex-1 h-full min-w-0 min-h-0 flex flex-col">
         <div class="flex items-center justify-between border-b border-base px2 h10 bg-base rounded-t-2 of-x-auto ws-nowrap">
           <div class="flex items-center h-full">
             <button v-if="!expanded" class="w8 h8 rounded-full cursor-pointer mr1 hover:bg-active flex items-center justify-center" @click="toggleExpanded(true)">
@@ -137,7 +137,7 @@ function toggleShowType() {
             </button>
           </div>
         </div>
-        <div class="flex-1 min-h-0 overscroll-contain">
+        <div class="flex-1 min-h-0 of-x-auto overscroll-contain">
           <DataPluginDetailsTable
             :session="session"
             :build-metrics="buildMetrics"

--- a/packages/vite/src/app/components/flowmap/PluginFlow.vue
+++ b/packages/vite/src/app/components/flowmap/PluginFlow.vue
@@ -102,7 +102,7 @@ function toggleShowType() {
 <template>
   <div class="p2 h-full w-full">
     <div class="flex border border-base rounded-2 h-full relative of-hidden">
-      <div v-if="expanded" class="of-hidden border-r border-base">
+      <div v-if="expanded" class="of-hidden border-r border-base shrink-0">
         <FlowmapPluginFlowTimeline
           :build-metrics="buildMetrics"
         >
@@ -115,7 +115,7 @@ function toggleShowType() {
           </template>
         </FlowmapPluginFlowTimeline>
       </div>
-      <div class="flex-1 h-full min-h-0 flex flex-col">
+      <div class="flex-1 h-full min-w-0 min-h-0 flex flex-col">
         <div class="flex items-center justify-between border-b border-base px2 h10 bg-base rounded-t-2 of-x-auto ws-nowrap">
           <div class="flex items-center h-full">
             <button v-if="!expanded" class="w8 h8 rounded-full cursor-pointer mr1 hover:bg-active flex items-center justify-center" @click="toggleExpanded(true)">
@@ -138,7 +138,7 @@ function toggleShowType() {
             </button>
           </div>
         </div>
-        <div class="flex-1 min-h-0 overscroll-contain">
+        <div class="flex-1 min-h-0 of-x-auto overscroll-contain">
           <DataPluginDetailsTable
             :modules="modules"
             :build-metrics="buildMetrics"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed an issue where the left timeline was almost invisible when the window width was small.

before:
<img width="2383" height="1062" alt="屏幕截图_1-8-2026_16947_localhost" src="https://github.com/user-attachments/assets/b251aa00-d94c-436d-aac9-7177a8e67b45" />

now:
<img width="2475" height="1130" alt="屏幕截图_1-8-2026_16722_localhost" src="https://github.com/user-attachments/assets/9213a8dc-1bab-4eed-b8ed-c25ba21b51ce" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
