### PR TITLE
fix: keep plugin flow timeline vertically scrollable

### DIFF
--- a/packages/rolldown/src/app/components/flowmap/PluginFlow.vue
+++ b/packages/rolldown/src/app/components/flowmap/PluginFlow.vue
@@ -100,7 +100,7 @@ function toggleShowType() {
 <template>
   <div class="p2 h-full w-full">
     <div class="flex border border-base rounded-2 h-full relative of-hidden">
-      <div v-if="expanded" class="of-hidden border-r border-base shrink-0">
+      <div v-if="expanded" class="of-hidden border-r border-base shrink-0 h-full min-h-0 flex flex-col">
         <FlowmapPluginFlowTimeline
           :session="session"
           :build-metrics="buildMetrics"

--- a/packages/rolldown/src/app/components/flowmap/PluginFlowTimeline.vue
+++ b/packages/rolldown/src/app/components/flowmap/PluginFlowTimeline.vue
@@ -51,9 +51,9 @@ const endTime = computed(() => {
 </script>
 
 <template>
-  <div class="flex flex-col">
+  <div class="flex flex-col h-full min-h-0">
     <slot name="header" />
-    <div class="select-none h-full of-auto ws-nowrap w-auto of-visible p4 flex flex-col">
+    <div class="select-none flex-1 min-h-0 of-x-hidden of-y-auto ws-nowrap w-auto p4 flex flex-col" style="scrollbar-gutter: stable">
       <div class="flex">
         <FlowmapNode
           :active="false"

--- a/packages/vite/src/app/components/flowmap/PluginFlow.vue
+++ b/packages/vite/src/app/components/flowmap/PluginFlow.vue
@@ -102,7 +102,7 @@ function toggleShowType() {
 <template>
   <div class="p2 h-full w-full">
     <div class="flex border border-base rounded-2 h-full relative of-hidden">
-      <div v-if="expanded" class="of-hidden border-r border-base shrink-0">
+      <div v-if="expanded" class="of-hidden border-r border-base shrink-0 h-full min-h-0 flex flex-col">
         <FlowmapPluginFlowTimeline
           :build-metrics="buildMetrics"
         >

--- a/packages/vite/src/app/components/flowmap/PluginFlowTimeline.vue
+++ b/packages/vite/src/app/components/flowmap/PluginFlowTimeline.vue
@@ -49,9 +49,9 @@ const endTime = computed(() => {
 </script>
 
 <template>
-  <div class="flex flex-col">
+  <div class="flex flex-col h-full min-h-0">
     <slot name="header" />
-    <div class="select-none h-full of-auto ws-nowrap w-auto of-visible p4 flex flex-col">
+    <div class="select-none flex-1 min-h-0 of-x-hidden of-y-auto ws-nowrap w-auto p4 flex flex-col" style="scrollbar-gutter: stable">
       <div class="flex">
         <FlowmapNode
           :active="false"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed the issue where the left timeline could not scroll when the window height was limited.

<img width="2300" height="810" alt="屏幕截图_3-8-2026_111229_localhost" src="https://github.com/user-attachments/assets/892696d4-16e5-4939-8d36-1e5723740497" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
