### PR TITLE
fix(core): observe dock sidebar size in the popup's own realm

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockGroupSidebar.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockGroupSidebar.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { DevToolsDockEntry, DevToolsViewGroup } from '@vitejs/devtools-kit'
 import type { DocksContext } from '@vitejs/devtools-kit/client'
-import { useElementBounding, watchDebounced } from '@vueuse/core'
-import { computed, h, ref, useTemplateRef } from 'vue'
+import { watchDebounced } from '@vueuse/core'
+import { computed, h, ref, useTemplateRef, watch } from 'vue'
 import { deriveSidebarCapacity, docksSplitGroupsWithCapacity, getGroupMembersGrouped } from '../../state/dock-settings'
 import { sharedStateToRef } from '../../state/docks'
 import { setDocksSidebarOverflowPanel, setFloatingTooltip, useDocksSidebarOverflowPanel } from '../../state/floating-tooltip'
@@ -36,7 +36,24 @@ const memberGroups = computed(() => getGroupMembersGrouped(
 ))
 
 const sidebar = useTemplateRef<HTMLDivElement>('sidebar')
-const { height: frameHeight } = useElementBounding(sidebar)
+
+const frameHeight = ref(0)
+watch(sidebar, (el, _prev, onCleanup) => {
+  if (!el) {
+    frameHeight.value = 0
+    return
+  }
+  const ResizeObserverCtor = el.ownerDocument?.defaultView?.ResizeObserver ?? globalThis.ResizeObserver
+  if (!ResizeObserverCtor)
+    return
+  const observer = new ResizeObserverCtor(([entry]) => {
+    if (!entry)
+      return
+    frameHeight.value = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height
+  })
+  observer.observe(el)
+  onCleanup(() => observer.disconnect())
+}, { immediate: true, flush: 'post' })
 
 const totalItems = computed(() => memberGroups.value.reduce((acc, [, items]) => acc + items.length, 0))
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In popup dock mode, resizing the popup window does not update the dock sidebar group rail immediately.

When shrinking the popup window, the group rail does not collapse into the overflow ("more") icon as expected. when enlarging the popup window, the hidden icons do not restore immediately. the state is only updated after moving the mouse into the host page.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
