### PR TITLE
fix(core): keep transient-context commands listed in shortcut settings

### DIFF
--- a/packages/core/src/client/webcomponents/components/views-builtin/SettingsShortcuts.vue
+++ b/packages/core/src/client/webcomponents/components/views-builtin/SettingsShortcuts.vue
@@ -22,10 +22,17 @@ interface ShortcutRow {
   indent: boolean
 }
 
-// Only offer to bind commands that are actually reachable right now — binding a
-// key to something the current context rules out (e.g. the dock-mode commands
-// while the dock is detached into a popup) would silently do nothing.
-const availableCommands = computed(() => filterCommandsByWhen(commandsCtx.commands, props.context.when.context))
+// This page is only reachable with the dock open and the palette closed, so `when`
+// is evaluated against that context rather than the live one. `dockOpen`/`paletteOpen`
+// are transient dispatch state — `close-panel`'s `!paletteOpen` exists to hand Escape
+// to the palette, not to say the command is unbindable — so filtering by them would
+// drop permanently bindable rows the moment Ctrl+K is pressed. `popupOpen` and
+// `clientType` stay live: those describe whether a command can exist at all, which is
+// why the dock-mode commands still vanish while the dock is detached into a popup.
+const availableCommands = computed(() => filterCommandsByWhen(
+  commandsCtx.commands,
+  { ...props.context.when.context, dockOpen: true, paletteOpen: false },
+))
 
 const shortcutRows = computed<ShortcutRow[]>(() => {
   const rows: ShortcutRow[] = []


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed an issue where the Close Panel shortcut entry would incorrectly disappear while opening and closing the Command Palette.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
