### PR TITLE
feat(core): mirror the dock panel's localStorage state into shared state

### DIFF
--- a/packages/core/src/client/inject/runtime.test.ts
+++ b/packages/core/src/client/inject/runtime.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { startDevTools } from './runtime'
+import { nextTick, ref } from 'vue'
+import { startDevTools, useLocalStorageSharedState } from './runtime'
 
 const mocks = vi.hoisted(() => ({
   getDevToolsRpcClient: vi.fn(
     (_options: { baseURL: string[] }) => new Promise(() => {}),
   ),
+  useLocalStorage: vi.fn(),
 }))
 
 vi.mock('@vitejs/devtools-kit/client', () => ({
@@ -13,7 +15,7 @@ vi.mock('@vitejs/devtools-kit/client', () => ({
 }))
 
 vi.mock('@vueuse/core', () => ({
-  useLocalStorage: vi.fn(),
+  useLocalStorage: mocks.useLocalStorage,
 }))
 
 vi.mock('../webcomponents/state/context', () => ({
@@ -49,5 +51,51 @@ describe('injected DevTools runtime', () => {
     expect(options.baseURL[1]).toBe(
       new URL('/__devtools/', import.meta.url).href,
     )
+  })
+})
+
+describe('useLocalStorageSharedState', () => {
+  afterEach(() => {
+    mocks.useLocalStorage.mockReset()
+  })
+
+  it('returns the exact ref useLocalStorage produces, untouched', () => {
+    const state = ref({ open: false })
+    mocks.useLocalStorage.mockReturnValue(state)
+    const rpc = { sharedState: { get: vi.fn(() => new Promise(() => {})) } } as any
+
+    expect(useLocalStorageSharedState(rpc, 'k', { open: false })).toBe(state)
+  })
+
+  it('creates the shared-state slot under the same key, seeded from the current local value', () => {
+    const state = ref({ open: true, mode: 'float' })
+    mocks.useLocalStorage.mockReturnValue(state)
+    const get = vi.fn(() => new Promise(() => {}))
+    const rpc = { sharedState: { get } } as any
+
+    useLocalStorageSharedState(rpc, 'vite-devtools-dock-state', { open: false, mode: 'float' })
+
+    expect(get).toHaveBeenCalledWith('vite-devtools-dock-state', { initialValue: state.value })
+  })
+
+  it('mirrors every local change into the shared state once the slot resolves', async () => {
+    const state = ref<{ open: boolean }>({ open: false })
+    mocks.useLocalStorage.mockReturnValue(state)
+    const mutate = vi.fn()
+    const sharedStatePromise = Promise.resolve({ mutate })
+    const rpc = { sharedState: { get: vi.fn(() => sharedStatePromise) } } as any
+
+    useLocalStorageSharedState(rpc, 'k', { open: false })
+    await sharedStatePromise // by then, the watchEffect this attaches has already run once, synchronously
+
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(mutate.mock.calls[0]![0]()).toStrictEqual({ open: false })
+
+    mutate.mockClear()
+    state.value = { open: true }
+    await nextTick() // let the watchEffect's reactive dependency flush
+
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(mutate.mock.calls[0]![0]()).toStrictEqual({ open: true })
   })
 })

--- a/packages/core/src/client/inject/runtime.ts
+++ b/packages/core/src/client/inject/runtime.ts
@@ -1,12 +1,43 @@
 /// <reference types="vite/client" />
 /// <reference lib="dom" />
 
-import type { DockPanelStorage } from '@vitejs/devtools-kit/client'
+import type { DevToolsRpcClient, DockPanelStorage } from '@vitejs/devtools-kit/client'
+import type { UseStorageOptions } from '@vueuse/core'
 import { CLIENT_CONTEXT_KEY, getDevToolsRpcClient } from '@vitejs/devtools-kit/client'
 import { DEVTOOLS_MOUNT_PATH } from '@vitejs/devtools-kit/constants'
 import { useLocalStorage } from '@vueuse/core'
+import { watchEffect } from 'vue'
 import { DEVTOOLS_HIDE_EVENT, DEVTOOLS_MODE_FILENAME } from '../../constants'
 import { createDocksContext } from '../webcomponents/state/context'
+
+/**
+ * `useLocalStorage`, plus mirroring the whole value into shared state under
+ * the same key — so a node-side plugin (e.g. one gating a deferred reload on
+ * "the panel closed") can observe it. A plain `useLocalStorage` ref never
+ * reaches the server on its own; shared state already round-trips a client
+ * mutation through the server before it reappears locally, so this is the
+ * whole mirror. Fire-and-forget: nothing here needs the shared handle back,
+ * and the local ref (returned unchanged) stays the source of truth for every
+ * existing reader/writer.
+ */
+export function useLocalStorageSharedState<T extends object>(
+  rpc: DevToolsRpcClient,
+  key: string,
+  initialValue: T,
+  options?: UseStorageOptions<T>,
+) {
+  const state = useLocalStorage<T>(key, initialValue, options)
+  void rpc.sharedState.get<T>(key, { initialValue: state.value }).then((shared) => {
+    watchEffect(() => {
+      // Reading `state.value` here, synchronously, is what registers it as
+      // this effect's reactive dependency — capturing it inside `mutate`'s
+      // own (lazily-invoked) recipe instead would never re-run on a change.
+      const snapshot = { ...state.value }
+      shared.mutate(() => snapshot)
+    })
+  })
+  return state
+}
 
 export type InjectMode = 'passive' | 'normal' | 'hidden'
 
@@ -60,7 +91,8 @@ async function mountDock(): Promise<void> {
     ],
   })
 
-  const state = useLocalStorage<DockPanelStorage>(
+  const state = useLocalStorageSharedState<DockPanelStorage>(
+    rpc,
     'vite-devtools-dock-state',
     {
       mode: 'float',

--- a/packages/core/src/client/inject/runtime.ts
+++ b/packages/core/src/client/inject/runtime.ts
@@ -12,12 +12,9 @@ import { createDocksContext } from '../webcomponents/state/context'
 
 /**
  * `useLocalStorage`, plus mirroring the whole value into shared state under
- * the same key — so a node-side plugin (e.g. one gating a deferred reload on
- * "the panel closed") can observe it. A plain `useLocalStorage` ref never
- * reaches the server on its own; shared state already round-trips a client
- * mutation through the server before it reappears locally, so this is the
- * whole mirror. Fire-and-forget: nothing here needs the shared handle back,
- * and the local ref (returned unchanged) stays the source of truth for every
+ * the same key so a Node-side plugin can observe it too — a plain
+ * `useLocalStorage` ref never reaches the server on its own. Fire-and-forget:
+ * the local ref (returned unchanged) stays the source of truth for every
  * existing reader/writer.
  */
 export function useLocalStorageSharedState<T extends object>(
@@ -29,9 +26,7 @@ export function useLocalStorageSharedState<T extends object>(
   const state = useLocalStorage<T>(key, initialValue, options)
   void rpc.sharedState.get<T>(key, { initialValue: state.value }).then((shared) => {
     watchEffect(() => {
-      // Reading `state.value` here, synchronously, is what registers it as
-      // this effect's reactive dependency — capturing it inside `mutate`'s
-      // own (lazily-invoked) recipe instead would never re-run on a change.
+      /** Read synchronously so this effect tracks `state.value` as its dependency — capturing it inside `mutate`'s lazy recipe wouldn't. */
       const snapshot = { ...state.value }
       shared.mutate(() => snapshot)
     })


### PR DESCRIPTION
### Why

`panelStore` (the `vite-devtools-dock-state` key) is purely browser-local today — nothing on the Node/server side can see it, including whether the panel is even open. Any Node-side plugin that wants to react to dock UI state — gate some behavior on visibility, log usage, sync it elsewhere — has nothing to observe.

### What changed

- Wraps the existing `useLocalStorage` call with a small generic helper, `useLocalStorageSharedState`, that mirrors the whole value into `rpc.sharedState` under the same key. Shared-state mutations already round-trip through the server before reappearing locally, so that's the entire mechanism — no new dock-entry field, no client-script gating, no RPC command, no trust handshake.
- Mirrors the whole object rather than cherry-picking `open`: it's already one `useLocalStorage`-backed, fully serializable, browser-local singleton (not per-tab), so a second, narrower key for just one field would just be a redundant place for that field to live.

**Known limitation, flagging it rather than hiding it:** shared state is one authoritative value, last-mutation-wins — with two tabs open, a Node-side consumer watching e.g. `open` sees whichever tab mutated most recently. Per-connection keying would need a way to garbage-collect a disconnected tab's entry, and nothing in the public API exposes that today, so I went with the simpler singleton.

### Linked Issues

### Additional context

Verified with `pnpm build`, `pnpm test` (5 new tests for the helper, 384 passing total), `pnpm typecheck`, `pnpm lint` — all green.
