### PR TITLE
feat(core): render message actions as buttons on toast notifications

### DIFF
--- a/packages/core/src/client/webcomponents/components/display/ToastOverlay.stories.ts
+++ b/packages/core/src/client/webcomponents/components/display/ToastOverlay.stories.ts
@@ -36,3 +36,23 @@ export const Stack: Story = {
     },
   }),
 }
+
+/** A toast whose message carries an `activate` action, rendered alongside the dismiss control. */
+export const WithAction: Story = {
+  render: () => ({
+    setup() {
+      onMounted(() => {
+        addToast(message({
+          level: 'info',
+          message: 'New a11y violation detected',
+          notify: true,
+          autoDismiss: 10 ** 7,
+          actions: [
+            { id: 'view', label: 'View', kind: 'activate', activate: { dockId: 'devframes-plugin-messages' } },
+          ],
+        }))
+      })
+      return () => h(ToastOverlay)
+    },
+  }),
+}

--- a/packages/core/src/client/webcomponents/components/display/ToastOverlay.stories.ts
+++ b/packages/core/src/client/webcomponents/components/display/ToastOverlay.stories.ts
@@ -48,7 +48,7 @@ export const WithAction: Story = {
           notify: true,
           autoDismiss: 10 ** 7,
           actions: [
-            { id: 'view', label: 'View', kind: 'activate', activate: { dockId: 'devframes-plugin-messages' } },
+            { id: 'view', label: 'View', kind: 'activate', activate: { dockId: 'devframes_plugin_messages' } },
           ],
         }))
       })

--- a/packages/core/src/client/webcomponents/components/display/ToastOverlay.vue
+++ b/packages/core/src/client/webcomponents/components/display/ToastOverlay.vue
@@ -19,16 +19,11 @@ const toasts = useToasts()
 function openMessages(toastId: string) {
   dismissToast(toastId)
   selectMessage(toastId)
-  // Open the messages panel provided by `@devframes/plugin-messages`
-  // (its dock id is the plugin's devframe id, `PLUGIN_ID` in its `constants.ts`).
+  /** Opens the messages panel from `@devframes/plugin-messages` (dock id: its `PLUGIN_ID`, from its `constants.ts`). */
   props.context?.docks.switchEntry('devframes_plugin_messages')
 }
 
-// Mirrors the messages panel's own action dispatch (`onActivate` in
-// `@devframes/plugin-messages`'s `App.vue`): the only action kind today is
-// `activate`, which focuses a dock. Our shell handles the equivalent
-// `devframe:docks:activate` broadcast the same way (see `context.ts`), so
-// `switchEntry` is the local counterpart to that RPC call.
+/** Mirrors the messages panel's own dispatch; an unhandled kind is a silent no-op. */
 function dispatchAction(action: NonNullable<DevToolsMessageEntry['actions']>[number]) {
   if (action.kind === 'activate')
     props.context?.docks.switchEntry(action.activate.dockId)

--- a/packages/core/src/client/webcomponents/components/display/ToastOverlay.vue
+++ b/packages/core/src/client/webcomponents/components/display/ToastOverlay.vue
@@ -20,8 +20,8 @@ function openMessages(toastId: string) {
   dismissToast(toastId)
   selectMessage(toastId)
   // Open the messages panel provided by `@devframes/plugin-messages`
-  // (its dock id is the plugin's devframe id).
-  props.context?.docks.switchEntry('devframes-plugin-messages')
+  // (its dock id is the plugin's devframe id, `PLUGIN_ID` in its `constants.ts`).
+  props.context?.docks.switchEntry('devframes_plugin_messages')
 }
 
 // Mirrors the messages panel's own action dispatch (`onActivate` in

--- a/packages/core/src/client/webcomponents/components/display/ToastOverlay.vue
+++ b/packages/core/src/client/webcomponents/components/display/ToastOverlay.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DevToolsMessageEntry } from '@vitejs/devtools-kit'
 import type { DocksContext } from '@vitejs/devtools-kit/client'
 import { selectMessage, useMessages } from '../../state/messages'
 import { dismissToast, useToasts } from '../../state/toasts'
@@ -22,6 +23,16 @@ function openMessages(toastId: string) {
   // (its dock id is the plugin's devframe id).
   props.context?.docks.switchEntry('devframes-plugin-messages')
 }
+
+// Mirrors the messages panel's own action dispatch (`onActivate` in
+// `@devframes/plugin-messages`'s `App.vue`): the only action kind today is
+// `activate`, which focuses a dock. Our shell handles the equivalent
+// `devframe:docks:activate` broadcast the same way (see `context.ts`), so
+// `switchEntry` is the local counterpart to that RPC call.
+function dispatchAction(action: NonNullable<DevToolsMessageEntry['actions']>[number]) {
+  if (action.kind === 'activate')
+    props.context?.docks.switchEntry(action.activate.dockId)
+}
 </script>
 
 <template>
@@ -43,6 +54,14 @@ function openMessages(toastId: string) {
       >
         <MessageItem :entry="toast.entry" compact class="px-3 py-2.5">
           <template #actions>
+            <button
+              v-for="action of toast.entry.actions"
+              :key="action.id"
+              class="flex-none text-xs px-1.5 py-0.5 rounded border border-base op70 hover:op100 hover:bg-active transition"
+              @click.stop="dispatchAction(action)"
+            >
+              {{ action.label }}
+            </button>
             <button
               class="flex-none op30 hover:op100 p-0.5 rounded hover:bg-active transition"
               @click.stop="dismissToast(toast.id)"

--- a/playgrounds/core/src/pages/devtools.vue
+++ b/playgrounds/core/src/pages/devtools.vue
@@ -139,6 +139,21 @@ async function addNotification(msg: string, level: DevToolsMessageLevel) {
   })
 }
 
+/** Exercises the toast `#actions` slot (`dvcol/toast-message-actions`): a `view` button that focuses the messages dock, alongside the usual dismiss ✕. */
+async function addNotificationWithAction() {
+  if (!client.value)
+    return
+  await client.value.call('devtoolskit:internal:messages:add', {
+    message: 'New a11y violation detected',
+    level: 'warn',
+    notify: true,
+    autoDismiss: 10000,
+    actions: [
+      { id: 'view', label: 'View', kind: 'activate', activate: { dockId: 'devframes_plugin_messages' } },
+    ],
+  })
+}
+
 function incrementCounter() {
   if (!client.value)
     return
@@ -187,6 +202,10 @@ function incrementCounter() {
         <button class="btn-action-sm" @click="addLoadingThenResolve()">
           <div class="i-ph-spinner-gap-duotone" />
           Loading -> Resolve
+        </button>
+        <button class="btn-action-sm" @click="addNotificationWithAction()">
+          <div class="i-ph-cursor-click-duotone" />
+          Toast: With Action
         </button>
         <button class="btn-action-sm" @click="addBatchMessages()">
           <div class="i-ph-list-plus-duotone" />


### PR DESCRIPTION
### Why

Toasts only ever showed the dismiss ✕ — an entry's own `actions` (e.g. the `activate` kind, which focuses a dock) only rendered in the messages panel's detail view, not on the toast that actually announced it.

### What changed

- Renders `entry.actions` as buttons in the toast's own `#actions` slot, dispatching the same way the messages panel does: `switchEntry(action.activate.dockId)`.
- Fixes a pre-existing bug found while manually testing this: `switchEntry('devframes-plugin-messages')` (hyphens) never matched the dock's real mounted id, `devframes_plugin_messages` (underscores, `PLUGIN_ID` in `@devframes/plugin-messages`'s `constants.ts`) — a typo from the devframe 0.6 migration (#396) that's been silently breaking "click a toast to open messages" ever since.
- Adds a "Toast: With Action" button next to the existing Quick Actions in the playground's debug dashboard, so this (and the id fix) is easy to re-verify by hand later.

### Linked Issues

### Additional context

Verified by hand against the playground: firing the new demo toast and clicking its action button focuses the messages dock. Full gate (`pnpm build`/`test`/`typecheck`/`lint`) green — 381 tests passing.