### PR TITLE
feat(core): color a dock-bar entry's badge via a new badgeVariant field

### DIFF
--- a/packages/core/src/client/webcomponents/components/dock/DockEntries.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntries.vue
@@ -77,6 +77,7 @@ function toggleDockEntry(dock: DevToolsDockEntry) {
         :is-dimmed="dimInactive && selected ? (selected.id !== dock.id) : false"
         :is-vertical="isVertical"
         :badge="dock.badge"
+        :badge-variant="dock.badgeVariant"
         @click="toggleDockEntry(dock)"
       />
     </template>

--- a/packages/core/src/client/webcomponents/components/dock/DockEntry.stories.ts
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntry.stories.ts
@@ -69,7 +69,7 @@ export const Action: Story = { args: { isAction: true } }
 /** A count badge in the corner (e.g. pending items). */
 export const WithBadge: Story = { args: { badge: '3' } }
 
-/** A colored badge — e.g. a staged-but-unapplied override count, warning-orange until it reloads. */
+/** A colored badge, e.g. flagging a state that needs attention. */
 export const WithBadgeVariant: Story = { args: { badge: '3', badgeVariant: 'warning' } }
 
 /** Rotated for a left/right edge dock. */

--- a/packages/core/src/client/webcomponents/components/dock/DockEntry.stories.ts
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntry.stories.ts
@@ -12,6 +12,7 @@ interface EntryArgs {
   isVertical?: boolean
   isAction?: boolean
   badge?: string
+  badgeVariant?: 'default' | 'info' | 'success' | 'warning' | 'danger'
   tooltip?: boolean
 }
 
@@ -43,6 +44,7 @@ const meta = {
         isVertical: args.isVertical,
         isAction: args.isAction,
         badge: args.badge || undefined,
+        badgeVariant: args.badgeVariant,
         tooltip: args.tooltip,
       }))),
     ),
@@ -67,6 +69,9 @@ export const Action: Story = { args: { isAction: true } }
 /** A count badge in the corner (e.g. pending items). */
 export const WithBadge: Story = { args: { badge: '3' } }
 
+/** A colored badge — e.g. a staged-but-unapplied override count, warning-orange until it reloads. */
+export const WithBadgeVariant: Story = { args: { badge: '3', badgeVariant: 'warning' } }
+
 /** Rotated for a left/right edge dock. */
 export const Vertical: Story = { args: { isVertical: true } }
 
@@ -81,6 +86,8 @@ export const States: Story = {
         h(DockEntry, { context: ctx, dock: sample, isDimmed: true }),
         h(DockEntry, { context: ctx, dock: sample, isAction: true }),
         h(DockEntry, { context: ctx, dock: sample, badge: '9+' }),
+        h(DockEntry, { context: ctx, dock: sample, badge: '2', badgeVariant: 'warning' }),
+        h(DockEntry, { context: ctx, dock: sample, badge: '5', badgeVariant: 'success' }),
       ])),
     ),
   }),

--- a/packages/core/src/client/webcomponents/components/dock/DockEntry.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntry.vue
@@ -31,12 +31,12 @@ const props = withDefaults(
 // Only kicks in while selected — an idle group button keeps its default look.
 const accentStyle = computed(() => (props.isSelected ? accentTextStyle(props.accentColor) : undefined))
 
-/** `undefined` (the existing `bg-gray-6 text-white` utility classes below) at `'default'`/unset — every pre-existing badge consumer keeps its current look, unchanged. */
+/** `undefined` at `'default'`/unset keeps the existing `bg-gray-6 text-white` classes below. `colors[variant].bg`'s alpha is tuned for a tab badge, so it's boosted here for better contrast on the dock bar. */
 const badgeStyle = computed(() => {
   if (!props.badgeVariant || props.badgeVariant === 'default')
     return undefined
   const { bg, fg } = colors[props.badgeVariant]
-  return { backgroundColor: bg, color: fg }
+  return { backgroundColor: `rgba(from ${bg} r g b / 0.35)`, color: fg }
 })
 
 const button = useTemplateRef<HTMLButtonElement>('button')

--- a/packages/core/src/client/webcomponents/components/dock/DockEntry.vue
+++ b/packages/core/src/client/webcomponents/components/dock/DockEntry.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import type { DevToolsDockEntryBase } from '@vitejs/devtools-kit'
+import type { DevToolsDockBadgeVariant, DevToolsDockEntryBase } from '@vitejs/devtools-kit'
 import type { DocksContext } from '@vitejs/devtools-kit/client'
 import { useEventListener } from '@vueuse/core'
 import { computed, useTemplateRef } from 'vue'
+import { colors } from '../../json-render/components/tokens'
 import { setFloatingTooltip } from '../../state/floating-tooltip'
 import { accentTextStyle } from '../../utils/accent-color'
 import { openDockContextMenu } from './DockContextMenu'
@@ -17,6 +18,7 @@ const props = withDefaults(
     isDimmed?: boolean
     isVertical?: boolean
     badge?: string
+    badgeVariant?: DevToolsDockBadgeVariant
     tooltip?: boolean
     /** A `group` entry's optional `accentColor`, applied while selected/active. */
     accentColor?: string
@@ -28,6 +30,14 @@ const props = withDefaults(
 
 // Only kicks in while selected — an idle group button keeps its default look.
 const accentStyle = computed(() => (props.isSelected ? accentTextStyle(props.accentColor) : undefined))
+
+/** `undefined` (the existing `bg-gray-6 text-white` utility classes below) at `'default'`/unset — every pre-existing badge consumer keeps its current look, unchanged. */
+const badgeStyle = computed(() => {
+  if (!props.badgeVariant || props.badgeVariant === 'default')
+    return undefined
+  const { bg, fg } = colors[props.badgeVariant]
+  return { backgroundColor: bg, color: fg }
+})
 
 const button = useTemplateRef<HTMLButtonElement>('button')
 
@@ -94,7 +104,12 @@ useEventListener('pointerdown', () => {
       class="flex items-center justify-center p1.5 hover:bg-[#8881] hover:scale-110 transition-all duration-300 relative outline-none"
     >
       <DockIcon :icon="dock.icon" class="w-5 h-5 select-none" />
-      <div v-if="badge" class="absolute top-0.5 right-0 bg-gray-6 text-white text-0.6em px-1 rounded-full shadow">
+      <div
+        v-if="badge"
+        class="absolute top-0.5 right-0 text-0.6em px-1 rounded-full shadow"
+        :class="badgeStyle ? '' : 'bg-gray-6 text-white'"
+        :style="badgeStyle"
+      >
         {{ badge }}
       </div>
     </button>

--- a/packages/kit/src/types/docks.ts
+++ b/packages/kit/src/types/docks.ts
@@ -43,7 +43,21 @@ declare module '@devframes/hub/types' {
   interface DevframeDockEntryRegistry {
     'json-render': DevToolsViewJsonRender
   }
+  interface DevframeDockEntryBase {
+    /**
+     * Colors {@link DevframeDockEntryBase.badge} on the dock bar itself — the same variant set
+     * json-render's own `Tabs` badge already uses ({@link DevToolsDockBadgeVariant}), applied one
+     * level up. Omitted (or `'default'`) leaves the badge at its existing neutral fill.
+     */
+    badgeVariant?: DevToolsDockBadgeVariant
+  }
 }
+
+/**
+ * Color for a dock-bar entry's badge — mirrors json-render's `TabDescriptor.badgeVariant`
+ * (`components/Tabs.ts`), so a dock can reuse the exact same variant→color mapping one level up.
+ */
+export type DevToolsDockBadgeVariant = 'default' | 'info' | 'success' | 'warning' | 'danger'
 
 /**
  * A selectable launch root offered by a launcher dock entry.

--- a/packages/kit/src/types/docks.ts
+++ b/packages/kit/src/types/docks.ts
@@ -44,19 +44,12 @@ declare module '@devframes/hub/types' {
     'json-render': DevToolsViewJsonRender
   }
   interface DevframeDockEntryBase {
-    /**
-     * Colors {@link DevframeDockEntryBase.badge} on the dock bar itself — the same variant set
-     * json-render's own `Tabs` badge already uses ({@link DevToolsDockBadgeVariant}), applied one
-     * level up. Omitted (or `'default'`) leaves the badge at its existing neutral fill.
-     */
+    /** Colors {@link DevframeDockEntryBase.badge}. Omitted (or `'default'`) keeps the existing neutral fill. */
     badgeVariant?: DevToolsDockBadgeVariant
   }
 }
 
-/**
- * Color for a dock-bar entry's badge — mirrors json-render's `TabDescriptor.badgeVariant`
- * (`components/Tabs.ts`), so a dock can reuse the exact same variant→color mapping one level up.
- */
+/** Color for a dock-bar entry's badge — mirrors json-render's `TabDescriptor.badgeVariant`. */
 export type DevToolsDockBadgeVariant = 'default' | 'info' | 'success' | 'warning' | 'danger'
 
 /**

--- a/test/__snapshots__/tsnapi/@vitejs/devtools-kit/index.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@vitejs/devtools-kit/index.snapshot.d.ts
@@ -52,6 +52,7 @@ export interface ViteDevToolsNodeContext extends KitNodeContext {
 // #endregion
 
 // #region Types
+export type DevToolsDockBadgeVariant = 'default' | 'info' | 'success' | 'warning' | 'danger';
 export type DevToolsDockEntryCategory = DevframeDockEntryCategory;
 export type JsonRenderElement = UIElement;
 export type JsonRenderSpec = DevframeJsonRenderSpec;


### PR DESCRIPTION
### Why

`DockEntry`'s badge is a plain string label with a fixed gray fill — no way to color it. json-render's own `Tabs` component already supports this one level down (`TabDescriptor.badgeVariant`, with a real variant→color map, used today by tab strips inside a dock's own content); the dock-bar entry itself has no equivalent, even though it's the same kind of label.

### What changed

- `badgeVariant?: 'default' | 'info' | 'success' | 'warning' | 'danger'` on `DevframeDockEntryBase`, declared via the same `declare module '@devframes/hub/types'` merge this package already uses for `DevframeDockEntryRegistry` — no new field on the hub package itself.
- `DockEntry.vue`/`DockEntries.vue` thread it through, reusing `Tabs.ts`'s own `colors` token map rather than inventing a second one.
- Backward-compatible by construction: `DockEntry.vue` falls back to its pre-existing `bg-gray-6`/`text-white` classes at `'default'`/unset, and only switches to an inline-styled fill for an explicit non-default variant — every existing badge consumer keeps its current look, unchanged.

### Linked Issues

### Additional context

Verified with `pnpm build`, `pnpm test` (updated the public-API `.d.ts` snapshot for the new export, 381 passing total), `pnpm typecheck`, `pnpm lint` — all green.