### PR TITLE
chore(core): disable composite mode in tsconfig

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
+    "composite": false,
     "lib": ["esnext", "dom"]
   }
 }


### PR DESCRIPTION
The core project resolves workspace aliases directly to source files in sibling packages. Composite mode requires those files to belong to the project or be provided through project references, causing TS6307 errors in editors and standalone type checks.

The core tsconfig is not referenced by another TypeScript project, and the package build uses the root tsconfig directly, so composite mode is unnecessary here.