### PR TITLE
fix(docs): prebundle fastdom for Mermaid

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -227,6 +227,12 @@ export default extendConfig(withMermaid(defineConfig({
     plugins: [
       groupIconVitePlugin(),
     ],
+    optimizeDeps: {
+      include: [
+        'fastdom',
+        'fastdom/extensions/fastdom-promised.js',
+      ],
+    },
   },
   mermaid: {
     theme: 'base',


### PR DESCRIPTION
### Description

Running `pnpm docs` currently and open browser fails with:

<img width="1786" height="323" alt="image" src="https://github.com/user-attachments/assets/254b1e08-1b02-49ec-b580-6203878566d5" />


```
Uncaught SyntaxError: The requested module '/node_modules/.pnpm/fastdom@1.0.12/node_modules/fastdom/fastdom.js?v=5c4dc56b' does not provide an export named 'default' (at bisector.js:56:1)
```
This PR adds fastdom and fastdom/extensions/fastdom-promised.js to Vite’s dependency optimization list.

upstream issue: https://github.com/emersonbottero/vitepress-plugin-mermaid/issues/98
